### PR TITLE
add WASM/Emscripten GitHub Actions build

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,40 @@
+name: WASM
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    container: emscripten/emsdk
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Cache FetchContent
+        uses: actions/cache@v5
+        with:
+          path: build_wasm/_deps
+          key: fetchcontent-wasm-${{ hashFiles('CMakeLists.txt') }}
+
+      - name: Configure
+        run: emcmake cmake -B build_wasm -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build_wasm --parallel
+
+      - name: Package
+        run: |
+          mkdir -p artifacts
+          cp build_wasm/deceptus.html build_wasm/deceptus.js \
+             build_wasm/deceptus.wasm build_wasm/deceptus.data artifacts/
+          cp build_wasm/index.html artifacts/ 2>/dev/null || true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: deceptus-wasm
+          path: artifacts/

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -9,10 +9,25 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
-    container: emscripten/emsdk
 
     steps:
       - uses: actions/checkout@v5
+
+      # The final emcc link runs Binaryen wasm-opt (at Release -O3), which needs more RAM than the
+      # ~16 GB runner has and gets OOM-killed (exit 137). Add swap on /mnt (the large scratch disk)
+      # as headroom so the link completes.
+      - name: Add swap space
+        run: |
+          sudo fallocate -l 12G /mnt/swapfile
+          sudo chmod 600 /mnt/swapfile
+          sudo mkswap /mnt/swapfile
+          sudo swapon /mnt/swapfile
+
+      - name: Set up Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: latest
+          actions-cache-folder: emsdk-cache
 
       - name: Cache FetchContent
         uses: actions/cache@v5


### PR DESCRIPTION
builds the WASM target inside the emscripten/emsdk container (same image as build_wasm.bat), caches FetchContent, and uploads the deceptus.html/js/wasm/data bundle as an artifact.