### PR TITLE
WASM: pixel-perfect integer scaling for the web/itch build

### DIFF
--- a/emscripten/itch_index.html
+++ b/emscripten/itch_index.html
@@ -1,0 +1,207 @@
+<!doctype html>
+<html lang="en-us">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    <title>Deceptus</title>
+
+    <!--
+        Player-facing shell tailored for itch.io. Unlike deceptus.html (the dev
+        shell with the on-page console, output log and emscripten chrome), this
+        page shows only the game canvas and a loading screen. Runtime messages
+        still go to the browser console so problems remain debuggable.
+
+        coi-serviceworker.js must load first: this build uses pthreads, which
+        require SharedArrayBuffer, which the browser only exposes on a
+        cross-origin-isolated page. itch.io does not send the COOP/COEP headers,
+        so the service worker reloads the page once with them applied.
+    -->
+    <script src="coi-serviceworker.js"></script>
+
+    <style>
+        html, body {
+            margin: 0;
+            padding: 0;
+            width: 100%;
+            height: 100%;
+            background: #000;
+            overflow: hidden;
+        }
+
+        /* center the canvas; the engine sizes it to an integer multiple of the
+           640x360 base view (see GameConfiguration), so the browser never has to
+           resample it. the surrounding area is the letterbox. */
+        body {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        #canvas {
+            background: #000;
+            display: block;
+            outline: none;
+            /* crisp pixels: the display size is an exact integer multiple, so
+               every source pixel becomes a clean NxN block */
+            image-rendering: pixelated;
+            image-rendering: crisp-edges;
+        }
+
+        #loading {
+            position: absolute;
+            inset: 0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 22px;
+            background: #0a0a0c;
+            color: #cfd6c0;
+            font-family: 'Trebuchet MS', 'Segoe UI', system-ui, sans-serif;
+            letter-spacing: 0.35em;
+            transition: opacity 0.6s ease;
+            z-index: 10;
+        }
+
+        #loading.hidden {
+            opacity: 0;
+            pointer-events: none;
+        }
+
+        #title {
+            font-size: 30px;
+            font-weight: 700;
+            text-transform: uppercase;
+            color: #e7ecdc;
+            text-shadow: 0 0 18px rgba(189, 215, 46, 0.25);
+        }
+
+        #track {
+            width: min(320px, 60vw);
+            height: 4px;
+            border-radius: 4px;
+            background: rgba(255, 255, 255, 0.08);
+            overflow: hidden;
+        }
+
+        #bar {
+            width: 0%;
+            height: 100%;
+            background: #bdd72e;
+            border-radius: 4px;
+            transition: width 0.2s ease;
+        }
+
+        #label {
+            font-size: 11px;
+            letter-spacing: 0.25em;
+            text-transform: uppercase;
+            color: #7f866f;
+            min-height: 14px;
+        }
+    </style>
+</head>
+<body>
+    <canvas id="canvas" oncontextmenu="event.preventDefault()" tabindex="-1"></canvas>
+
+    <div id="loading">
+        <div id="title">Deceptus</div>
+        <div id="track"><div id="bar"></div></div>
+        <div id="label">Loading&hellip;</div>
+    </div>
+
+    <script>
+        var canvasElement = document.getElementById("canvas");
+        var loadingElement = document.getElementById("loading");
+        var barElement = document.getElementById("bar");
+        var labelElement = document.getElementById("label");
+
+        function hideLoadingScreen() {
+            loadingElement.classList.add("hidden");
+        }
+
+        // the engine sizes the canvas drawing buffer to an integer multiple of 640x360 in *device*
+        // pixels. to display it 1:1 on screen (no fractional upscaling on os-scaled displays where
+        // devicePixelRatio != 1, e.g. windows at 125%), the css size must be buffer / dpr. sdl sets the
+        // css size equal to the buffer, so we correct it here whenever the buffer changes.
+        function syncCanvasCssSize() {
+            var devicePixelRatio = window.devicePixelRatio || 1;
+            var cssWidth = (canvasElement.width / devicePixelRatio) + "px";
+            var cssHeight = (canvasElement.height / devicePixelRatio) + "px";
+            if (canvasElement.style.width !== cssWidth) {
+                canvasElement.style.width = cssWidth;
+            }
+            if (canvasElement.style.height !== cssHeight) {
+                canvasElement.style.height = cssHeight;
+            }
+        }
+
+        var canvasSizeObserver = new MutationObserver(syncCanvasCssSize);
+        canvasSizeObserver.observe(canvasElement, {attributes: true, attributeFilter: ["width", "height", "style"]});
+        window.addEventListener("resize", syncCanvasCssSize);
+        syncCanvasCssSize();
+
+        canvasElement.addEventListener(
+            "webglcontextlost",
+            function (event) {
+                event.preventDefault();
+                loadingElement.classList.remove("hidden");
+                labelElement.textContent = "Graphics context lost — please reload";
+            },
+            false
+        );
+
+        var Module = {
+            canvas: canvasElement,
+            // keep diagnostics in the browser console, not on the page
+            print: function () {
+                console.log.apply(console, arguments);
+            },
+            printErr: function () {
+                console.error.apply(console, arguments);
+            },
+            setStatus: function (text) {
+                if (!Module.setStatus.last) {
+                    Module.setStatus.last = { time: Date.now(), text: "" };
+                }
+                if (text === Module.setStatus.last.text) {
+                    return;
+                }
+
+                var progressMatch = text.match(/([^(]+)\((\d+(\.\d+)?)\/(\d+)\)/);
+                var now = Date.now();
+                if (progressMatch && now - Module.setStatus.last.time < 30) {
+                    return;
+                }
+                Module.setStatus.last.time = now;
+                Module.setStatus.last.text = text;
+
+                if (progressMatch) {
+                    var value = parseInt(progressMatch[2], 10);
+                    var maximum = parseInt(progressMatch[4], 10);
+                    barElement.style.width = (maximum ? (100 * value / maximum) : 0) + "%";
+                    labelElement.textContent = (progressMatch[1].trim() || "Loading") + "…";
+                } else if (text) {
+                    labelElement.textContent = text;
+                } else {
+                    // empty status = all downloads complete, runtime about to start
+                    barElement.style.width = "100%";
+                    hideLoadingScreen();
+                }
+            },
+            monitorRunDependencies: function () {},
+            // fires once the game has started its main loop
+            postRun: [hideLoadingScreen]
+        };
+
+        Module.setStatus("Downloading…");
+
+        window.onerror = function () {
+            loadingElement.classList.remove("hidden");
+            labelElement.textContent = "Something went wrong — see the browser console";
+        };
+    </script>
+    <script async src="deceptus.js"></script>
+</body>
+</html>

--- a/src/game/config/gameconfiguration.cpp
+++ b/src/game/config/gameconfiguration.cpp
@@ -1,5 +1,6 @@
 #include "gameconfiguration.h"
 
+#include <algorithm>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -9,6 +10,11 @@
 #include "SFML/Graphics.hpp"
 #include "framework/tools/log.h"
 #include "json/json.hpp"
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#include <emscripten/html5.h>
+#endif
 
 using json = nlohmann::json;
 
@@ -166,6 +172,17 @@ GameConfiguration& GameConfiguration::getInstance()
          __instance._windowed_height = __instance._video_mode_height;
       }
 
+#ifdef __EMSCRIPTEN__
+      // on the web the canvas fills the browser/itch viewport, whose size is arbitrary. render at the
+      // largest integer multiple of the 640x360 base view that fits so pixel-art fonts stay crisp.
+      // this overrides the config file's video mode.
+      {
+         const auto [viewport_video_mode_width, viewport_video_mode_height] = __instance.computeViewportVideoMode();
+         __instance._video_mode_width = viewport_video_mode_width;
+         __instance._video_mode_height = viewport_video_mode_height;
+      }
+#endif
+
       __initialized = true;
    }
 
@@ -213,3 +230,19 @@ void GameConfiguration::clampResolutionToDesktop()
    }
 #endif
 }
+
+#ifdef __EMSCRIPTEN__
+std::pair<int32_t, int32_t> GameConfiguration::computeViewportVideoMode() const
+{
+   // work in device pixels (css pixels * device pixel ratio), so the render resolution is an integer
+   // multiple of the base view in *physical* pixels. on displays with os scaling (dpr != 1, e.g. windows
+   // at 125%) the browser upscales the canvas by dpr, so a buffer that is only an integer multiple in css
+   // pixels still gets fractionally resampled to physical pixels, turning the pixel-art fonts into mush.
+   // the shell then sets the canvas css size to buffer/dpr so this device-pixel buffer maps 1:1 on screen.
+   const double device_pixel_ratio = emscripten_get_device_pixel_ratio();
+   const auto available_width = static_cast<int32_t>(EM_ASM_DOUBLE({ return window.innerWidth; }) * device_pixel_ratio);
+   const auto available_height = static_cast<int32_t>(EM_ASM_DOUBLE({ return window.innerHeight; }) * device_pixel_ratio);
+   const auto integer_scale = std::max(1, std::min(available_width / _view_width, available_height / _view_height));
+   return {_view_width * integer_scale, _view_height * integer_scale};
+}
+#endif

--- a/src/game/config/gameconfiguration.h
+++ b/src/game/config/gameconfiguration.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <string>
+#include <utility>
 
 /// \brief stores global game settings and handles json persistence.
 struct GameConfiguration
@@ -62,6 +63,14 @@ struct GameConfiguration
    /// clamps _video_mode_width and _video_mode_height to the desktop resolution if needed.
    /// persists changes to disk if the resolution was adjusted.
    void clampResolutionToDesktop();
+
+#ifdef __EMSCRIPTEN__
+   /// \brief computes the largest integer multiple of the base view that fits the browser viewport.
+   /// keeping the render resolution an exact multiple of _view_width x _view_height avoids fractional
+   /// scaling, which would turn the pixel-art fonts into uneven mush.
+   /// \return the video mode width and height as a {width, height} pair.
+   std::pair<int32_t, int32_t> computeViewportVideoMode() const;
+#endif
 
 private:
    /// \brief serializes the current settings into formatted json text.

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -42,6 +42,7 @@
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
+#include <emscripten/html5.h>
 #endif
 
 #include <ctime>
@@ -1037,6 +1038,19 @@ void Game::timedDraw()
 int32_t Game::loop()
 {
 #ifdef __EMSCRIPTEN__
+   // re-fit the render resolution whenever the browser/itch viewport changes size (window resize,
+   // fullscreen toggle) so the game keeps filling the window at an integer scale
+   emscripten_set_resize_callback(
+      EMSCRIPTEN_EVENT_TARGET_WINDOW,
+      this,
+      EM_FALSE,
+      [](int, const EmscriptenUiEvent*, void* user_data) -> EM_BOOL
+      {
+         static_cast<Game*>(user_data)->refitToViewport();
+         return EM_FALSE;
+      }
+   );
+
    emscripten_set_main_loop_arg(
       [](void* arg)
       {
@@ -1171,6 +1185,20 @@ void Game::changeResolution(int32_t w, int32_t h)
       _level->createViews();
    }
 }
+
+#ifdef __EMSCRIPTEN__
+void Game::refitToViewport()
+{
+   auto& config = GameConfiguration::getInstance();
+   const auto [new_width, new_height] = config.computeViewportVideoMode();
+   if (new_width == config._video_mode_width && new_height == config._video_mode_height)
+   {
+      return;
+   }
+
+   changeResolution(new_width, new_height);
+}
+#endif
 
 void Game::takeScreenshot()
 {

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -141,6 +141,13 @@ private:
    /// \param h target height in pixels.
    void changeResolution(int32_t w, int32_t h);
 
+#ifdef __EMSCRIPTEN__
+   /// \brief re-fits the render resolution to the current browser viewport (integer multiple of the base
+   /// view), recreating rendering resources only when the size actually changes. invoked on browser resize
+   /// and fullscreen transitions so the game fills the itch/browser window without fractional scaling.
+   void refitToViewport();
+#endif
+
    /// \brief reloads save-state data and loads level at last checkpoint.
    void goToLastCheckpoint();
 


### PR DESCRIPTION
## Problem

The web (Emscripten/VRSFML) build was pinned to a hardcoded **1920×1080** canvas and let the browser scale it down to the itch/browser viewport. That scaling is **fractional**, and it was compounded by OS display scaling (Windows 125%/150% → `devicePixelRatio` ≠ 1), so the 640×360 pixel-art was resampled into uneven, wobbly fonts.

| Before | After |
|---|---|
| fixed 1920×1080 buffer, browser resamples to a fractional size → uneven glyphs | render at the largest **integer** multiple of 640×360 that fits, displayed 1:1 → crisp |

## Change

Render at the largest integer multiple of the 640×360 base view that fits the viewport, measured in **physical** pixels:

- **`GameConfiguration::computeViewportVideoMode()`** — picks the integer scale from `window.innerWidth/Height × devicePixelRatio` and overrides the config file's video mode at startup.
- **`Game::refitToViewport()`** — wired to `emscripten_set_resize_callback`, re-fits on browser resize and fullscreen via the existing `changeResolution()`. (VRSFML's shared GL context survives the window recreation, so textures are not lost.)
- **`emscripten/itch_index.html`** — player-facing shell that centers the canvas and syncs its CSS size to `buffer / dpr` so the device-pixel buffer maps 1:1 on screen (no fractional resample). Includes a loading screen and the COI service worker required for SharedArrayBuffer on itch.io.

All engine changes are guarded by `__EMSCRIPTEN__`; **the desktop build is unaffected**.

## Verification

Booted in headless Chrome and confirmed crisp rendering with `canvas.clientWidth × dpr == canvas.width` and `canvas.width % 640 == 0`:

| devicePixelRatio | render buffer (physical px) | scale | fit |
|---|---|---|---|
| 1.0 | 1280×720 | 2× | 1:1 |
| 1.25 | 1280×720 | 2× | 1:1 |
| 1.5 | 1920×1080 | 3× | 1:1 |

Also verified live re-fit across window resize (1× / 2× / 3×) with no crash and no texture loss.

**Recommended itch.io embed settings:** viewport **1280×720** and enable the **fullscreen button** — that fills edge-to-edge and crisp at 100/150/200% scaling, and fullscreen re-fits to the monitor's largest integer scale.