### PR TITLE
WASM: fix invisible smoke effect

### DIFF
--- a/src/game/mechanisms/smokeeffect.cpp
+++ b/src/game/mechanisms/smokeeffect.cpp
@@ -58,6 +58,11 @@ void SmokeEffect::draw(sf::RenderTarget& color, sf::RenderTarget& /*normal*/, co
 
    const sf::Texture& smoke_render_texture = _render_texture->getTexture();
    sf::Sprite rt_sprite;
+   // a default-constructed sprite has an empty texture rect (0x0) and would draw nothing; the geometry
+   // must be sized to the render texture explicitly since the texture is supplied via the render states
+   rt_sprite.textureRect = sf::FloatRect{
+      {0.f, 0.f}, {static_cast<float>(smoke_render_texture.getSize().x), static_cast<float>(smoke_render_texture.getSize().y)}
+   };
    rt_sprite.position = _offset_px;
    rt_sprite.scale = {_pixel_ratio, _pixel_ratio};
    rt_sprite.color = _layer_color;


### PR DESCRIPTION
## Problem

The smoke effect is invisible in the web (Emscripten/VRSFML) build.

## Root cause

The Emscripten `SmokeEffect::draw` path composites its intermediate render texture through a **default-constructed** sprite and supplies the texture only via `sf::RenderStates`:

```cpp
sf::Sprite rt_sprite;              // texture rect defaults to 0x0
...
draw_states.texture = &smoke_render_texture;
color.draw(rt_sprite, draw_states);
```

In VRSFML a sprite's geometry comes from its `textureRect`. Supplying the texture through the render states binds the sampler but never sizes the quad, so it stays 0×0 and nothing is drawn. (The desktop path constructs the sprite *from* the texture, so its rect is set implicitly.)

## Fix

Size the sprite's texture rect to the render texture explicitly — the same pattern already used for the main window composite in `Game::draw()` (`game.cpp:692`):

```cpp
rt_sprite.textureRect = sf::FloatRect{
   {0.f, 0.f},
   {static_cast<float>(smoke_render_texture.getSize().x), static_cast<float>(smoke_render_texture.getSize().y)}
};
```

Change is inside the `#ifdef __EMSCRIPTEN__` branch only; the desktop build is unaffected.

## Verification

Root-caused against the working `Game::draw()` sprite and confirmed the WASM build compiles clean. Smoke only renders in-level, so this has **not** yet been eyeballed in a running level — worth a quick visual confirmation before merge.