### PR TITLE
WASM: fix invisible fog and waterfall ShaderLayers

### DIFF
--- a/data/shaders/fog.vert
+++ b/data/shaders/fog.vert
@@ -15,7 +15,10 @@ void main()
    vec3 pos = vec3(sf_a_position, 1.0);
    gl_Position = vec4(dot(sf_u_mvpRow0, pos), dot(sf_u_mvpRow1, pos), 0.0, 1.0);
    sf_v_color = sf_a_color;
-   sf_v_texCoord = sf_a_texCoord * sf_u_invTextureSize;
+   // the ShaderLayer quad supplies normalized 0..1 texcoords (uv_width/uv_height default to 1.0),
+   // matching the desktop gl_TexCoord[0] path, so they must NOT be scaled by sf_u_invTextureSize:
+   // that would shrink the sampled region to a ~1-texel sliver and collapse the fog. see ring.vert.
+   sf_v_texCoord = sf_a_texCoord;
 }
 #else
 void main()

--- a/data/shaders/waterfall.vert
+++ b/data/shaders/waterfall.vert
@@ -15,7 +15,10 @@ void main()
    vec3 pos = vec3(sf_a_position, 1.0);
    gl_Position = vec4(dot(sf_u_mvpRow0, pos), dot(sf_u_mvpRow1, pos), 0.0, 1.0);
    sf_v_color = sf_a_color;
-   sf_v_texCoord = sf_a_texCoord * sf_u_invTextureSize;
+   // the ShaderLayer quad supplies normalized 0..1 texcoords (uv_width/uv_height default to 1.0),
+   // matching the desktop gl_TexCoord[0] path, so they must NOT be scaled by sf_u_invTextureSize:
+   // that would shrink the sampled region to a ~1-texel sliver and collapse the effect. see ring.vert.
+   sf_v_texCoord = sf_a_texCoord;
 }
 #else
 void main()


### PR DESCRIPTION
## Problem

The fog ShaderLayer (`fog.frag`/`fog.vert`) is invisible in the web build — the atmospheric haze present on desktop is missing, leaving the scene flat.

## Root cause

`fog.vert`'s `GL_ES` path scaled the vertex texcoord by `sf_u_invTextureSize`:

```glsl
sf_v_texCoord = sf_a_texCoord * sf_u_invTextureSize;
```

But the `ShaderLayer` quad supplies **normalized 0..1** texcoords (`uv_width`/`uv_height` default to 1.0, and no fog TMX object overrides them), matching the desktop `gl_TexCoord[0] = gl_MultiTexCoord0` path. Multiplying 0..1 by `1/textureSize` shrank the sampled region to a ~1-texel sliver, so the fog collapsed to a flat tint and effectively vanished.

This is the same class of bug already documented and fixed in `ring.vert`.

## Fix

Pass the texcoord through unscaled, so the ES path matches desktop:

```glsl
sf_v_texCoord = sf_a_texCoord;
```

Data-only change (one shader), desktop path untouched.

## Note — waterfall has the same latent bug

`waterfall.vert` has the identical `sf_a_texCoord * sf_u_invTextureSize` and its frag also treats the uv as normalized 0..1 (`uv.y / u_uv_height`, `uv * u_resolution`). It is very likely broken on web the same way. Left out of this PR since only fog was reported — happy to fix it in a follow-up.

## Verification

Root-caused against the working desktop path and the `ring.vert` precedent. Shader renders in-level, so a visual confirmation in a running level is the final check.