### PR TITLE
Fix player silhouette not rendering on SFML3 desktop

### DIFF
--- a/data/shaders/player_silhouette.frag
+++ b/data/shaders/player_silhouette.frag
@@ -1,0 +1,23 @@
+#ifdef GL_ES
+uniform sampler2D u_texture;
+uniform float u_alpha;
+
+in vec2 sf_v_texCoord;
+
+layout(location = 0) out vec4 sf_fragColor;
+
+void main()
+{
+   vec4 texture_color = texture(u_texture, sf_v_texCoord);
+   sf_fragColor = vec4(1.0, 1.0, 1.0, texture_color.a * u_alpha);
+}
+#else
+uniform sampler2D u_texture;
+uniform float u_alpha;
+
+void main()
+{
+   vec4 texture_color = texture2D(u_texture, gl_TexCoord[0].xy);
+   gl_FragColor = vec4(1.0, 1.0, 1.0, texture_color.a * u_alpha);
+}
+#endif

--- a/src/game/debug/console.cpp
+++ b/src/game/debug/console.cpp
@@ -224,7 +224,7 @@ Console::Console()
       "item clear",
       [this](const auto&)
       {
-         SaveState::getPlayerInfo()._inventory._items.clear();
+         SaveState::getPlayerInfo()._inventory.clear();
          _log.emplace_back("removed all items");
       }
    );

--- a/src/game/level/level.cpp
+++ b/src/game/level/level.cpp
@@ -1051,9 +1051,74 @@ void Level::drawLayers(sf::RenderTarget& target, sf::RenderTarget& normal, int32
    const sf::RenderStates level_view_states{.view = *_level_view};
 #endif
 
+   // player silhouette stencil setup: the foreground layers replace the stencil buffer with 1
+   // wherever they render, and the faint transparent-white player silhouette is then drawn only
+   // where the stencil equals 1 - i.e. exactly where the player is hidden behind foreground
+   // geometry. this must go through sf::StencilMode (not raw gl) so the state survives sfml's
+   // per-render-target cache invalidation when tilemaps alternate between the color and normal
+   // targets.
+#ifdef __EMSCRIPTEN__
+   const sf::StencilMode stencil_write_mode{
+      .stencilComparison = sf::StencilComparison::Always,
+      .stencilUpdateOperation = sf::StencilUpdateOperation::Replace,
+      .stencilOnly = false,
+      .stencilReference = sf::StencilValue{1u},
+      .stencilMask = sf::StencilValue{0xffu}
+   };
+   const sf::StencilMode stencil_test_mode{
+      .stencilComparison = sf::StencilComparison::Equal,
+      .stencilUpdateOperation = sf::StencilUpdateOperation::Keep,
+      .stencilOnly = false,
+      .stencilReference = sf::StencilValue{1u},
+      .stencilMask = sf::StencilValue{0xffu}
+   };
+#else
+   const sf::StencilMode stencil_write_mode{
+      sf::StencilComparison::Always,
+      sf::StencilUpdateOperation::Replace,
+      1,     // reference: mark foreground pixels with 1
+      0xff,  // mask
+      false  // stencilOnly: draw the foreground color too
+   };
+   const sf::StencilMode stencil_test_mode{
+      sf::StencilComparison::Equal,
+      sf::StencilUpdateOperation::Keep,
+      1,     // reference: keep only where stencil equals 1
+      0xff,  // mask
+      false
+   };
+#endif
+
+   const auto stencil_start_layer = PlayerStencil::getStartLayer();
+   const auto stencil_stop_layer = PlayerStencil::getStopLayer();
+
    for (auto z_index = from; z_index <= to; z_index++)
    {
-      PlayerStencil::draw(target, z_index);
+      // reset the stencil mask before the foreground layers start writing into it
+      if (z_index == stencil_start_layer)
+      {
+#ifdef __EMSCRIPTEN__
+         target.clearStencil(sf::StencilValue{0u});
+#else
+         target.clearStencil(0);
+#endif
+      }
+
+      // draw the transparent-white player silhouette wherever the accumulated foreground mask is set
+      if (z_index == stencil_stop_layer)
+      {
+         auto silhouette_states = level_view_states;
+         silhouette_states.stencilMode = stencil_test_mode;
+         std::static_pointer_cast<Player>(PlayerRegistry::getFirst())->drawStencil(target, silhouette_states);
+      }
+
+      // within the foreground range, every drawn layer replaces the stencil buffer with 1
+      auto layer_states = level_view_states;
+      if (z_index >= stencil_start_layer && z_index < stencil_stop_layer)
+      {
+         layer_states.stencilMode = stencil_write_mode;
+      }
+
       drawParallaxMaps(target, z_index);
 
       // draw all tile maps
@@ -1061,7 +1126,7 @@ void Level::drawLayers(sf::RenderTarget& target, sf::RenderTarget& normal, int32
       {
          if (tile_map->getZ() == z_index && !tile_map->isPostLighting())
          {
-            tile_map->draw(target, normal, level_view_states);
+            tile_map->draw(target, normal, layer_states);
          }
       }
 
@@ -1072,13 +1137,13 @@ void Level::drawLayers(sf::RenderTarget& target, sf::RenderTarget& normal, int32
          z_index,
          [&player_chunk](const auto& mechanism)
          { return !mechanism->isPostLighting() && !mechanism->isOverlay() && checkUpdateMechanism(player_chunk, mechanism); },
-         level_view_states
+         layer_states
       );
 
       // ambient occlusion
       if (z_index == _ambient_occlusion->getZ())
       {
-         _ambient_occlusion->draw(target, level_view_states);
+         _ambient_occlusion->draw(target, layer_states);
       }
 
       // draw enemies
@@ -1088,7 +1153,7 @@ void Level::drawLayers(sf::RenderTarget& target, sf::RenderTarget& normal, int32
          {
             if (checkUpdateMechanism(player_chunk, enemy))
             {
-               enemy->draw(target, normal, level_view_states);
+               enemy->draw(target, normal, layer_states);
             }
          }
       }
@@ -1096,7 +1161,7 @@ void Level::drawLayers(sf::RenderTarget& target, sf::RenderTarget& normal, int32
       // draw player
       if (z_index == static_cast<int32_t>(ZDepth::Player))
       {
-         drawPlayer(target, normal, level_view_states);
+         drawPlayer(target, normal, layer_states);
       }
 
       // draw image layers; post-lighting layers are drawn after the lighting pass
@@ -1108,7 +1173,7 @@ void Level::drawLayers(sf::RenderTarget& target, sf::RenderTarget& normal, int32
             {
                continue;
             }
-            layer->draw(target, normal, level_view_states);
+            layer->draw(target, normal, layer_states);
          }
       }
    }

--- a/src/game/player/player.cpp
+++ b/src/game/player/player.cpp
@@ -131,6 +131,11 @@ void Player::initialize()
 {
    _damage_clock.restart();
 
+   if (!_silhouette_shader.loadFromFragment("data/shaders/player_silhouette.frag"))
+   {
+      Log::Error() << "failed to load player silhouette shader";
+   }
+
    _jump._jump_dust_animation_callback = [this](PlayerJump::DustAnimationType animation_type)
    {
       switch (animation_type)
@@ -363,10 +368,20 @@ void Player::draw(sf::RenderTarget& color, sf::RenderTarget& normal, const sf::R
    SaveState::getPlayerInfo()._items.draw(color);
 }
 
-void Player::drawStencil(sf::RenderTarget& color)
+void Player::drawStencil(sf::RenderTarget& color, const sf::RenderStates& states)
 {
-   const auto stencil_color = sf::Color{255, 255, 255, 40};
+   const auto stencil_color = sf::Color{255, 255, 255, 25};
    const auto draw_position_px = _pixel_position_f + sf::Vector2f(0, 8);
+
+   // the silhouette shader forces the occluded player to transparent white (its rgb comes from the
+   // shader, its alpha from the sprite shape scaled by u_alpha) instead of the dimmed sprite colors
+   auto stencil_states = states;
+   if (_silhouette_shader.isLoaded())
+   {
+      _silhouette_shader.setUniform("u_texture", sf::Shader::CurrentTexture);
+      _silhouette_shader.setUniform("u_alpha", stencil_color.a / 255.f);
+      stencil_states.shader = &_silhouette_shader.native();
+   }
 
    auto current_cycle = _player_animation->getCurrentCycle();
    if (current_cycle)
@@ -377,7 +392,7 @@ void Player::drawStencil(sf::RenderTarget& color)
 #else
       current_cycle->setPosition(draw_position_px);
 #endif
-      current_cycle->draw(color);
+      current_cycle->draw(color, stencil_states);
    }
 
    auto auxiliary_cycle = _player_animation->getAuxiliaryCycle();
@@ -389,7 +404,7 @@ void Player::drawStencil(sf::RenderTarget& color)
 #else
       auxiliary_cycle->setPosition(draw_position_px);
 #endif
-      auxiliary_cycle->draw(color);
+      auxiliary_cycle->draw(color, stencil_states);
    }
 }
 

--- a/src/game/player/player.h
+++ b/src/game/player/player.h
@@ -2,6 +2,7 @@
 
 #include "game/player/playerinterface.h"
 
+#include "framework/tools/sfmlshader.h"
 #include "game/animation/animationpool.h"
 #include "game/constants.h"
 #include "game/effects/waterbubbles.h"
@@ -77,7 +78,7 @@ public:
 
    /// \brief draws a translucent stencil version of current player animations.
    /// \param color color render target.
-   void drawStencil(sf::RenderTarget& color);
+   void drawStencil(sf::RenderTarget& color, const sf::RenderStates& states);
 
    /// \brief runs one full frame of player simulation, including physics interaction, audio, and animations.
    /// \param dt elapsed frame time.
@@ -502,6 +503,8 @@ private:
 
    std::shared_ptr<PlayerAnimation> _player_animation;
    std::deque<PositionedAnimation> _last_animations;
+
+   sfcompat::Shader _silhouette_shader;  //!< tints the occluded-player silhouette to transparent white
 
    Chunk _chunk{0, 0};
    AnimationPool _animation_pool{"data/sprites/animations.json"};

--- a/src/game/player/playerstencil.cpp
+++ b/src/game/player/playerstencil.cpp
@@ -6,35 +6,6 @@
 #include "SFML/OpenGL.hpp"
 
 #include "game/constants.h"
-#include "game/player/player.h"
-#include "game/player/playerregistry.h"
-
-void PlayerStencil::replaceAllWithOne()
-{
-   glStencilFunc(GL_ALWAYS, 1, 0xFF);
-   glStencilOp(GL_REPLACE, GL_REPLACE, GL_REPLACE);
-}
-
-void PlayerStencil::keepIfOne()
-{
-   glStencilFunc(GL_EQUAL, 1, 0xFF);
-   glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
-}
-
-void PlayerStencil::enableTest()
-{
-   glEnable(GL_STENCIL_TEST);
-}
-
-void PlayerStencil::disableTest()
-{
-   glDisable(GL_STENCIL_TEST);
-}
-
-void PlayerStencil::clearStencilBuffer()
-{
-   glClear(GL_STENCIL_BUFFER_BIT);
-}
 
 namespace
 {
@@ -95,22 +66,4 @@ int32_t PlayerStencil::getStartLayer()
 int32_t PlayerStencil::getStopLayer()
 {
    return static_cast<int32_t>(ZDepth::ForegroundMax) - 1;
-}
-
-void PlayerStencil::draw(sf::RenderTarget& target, int32_t z_index)
-{
-   if (z_index == PlayerStencil::getStartLayer())
-   {
-      PlayerStencil::clearStencilBuffer();
-      PlayerStencil::replaceAllWithOne();
-   }
-
-   if (z_index == PlayerStencil::getStopLayer())
-   {
-      PlayerStencil::enableTest();
-      PlayerStencil::keepIfOne();
-      std::static_pointer_cast<Player>(PlayerRegistry::getFirst())->drawStencil(target);
-      PlayerStencil::disableTest();
-      PlayerStencil::clearStencilBuffer();
-   }
 }

--- a/src/game/player/playerstencil.h
+++ b/src/game/player/playerstencil.h
@@ -1,6 +1,7 @@
 #ifndef PLAYERSTENCIL_H
 #define PLAYERSTENCIL_H
 
+#include <cstdint>
 #include <memory>
 
 namespace sf
@@ -11,11 +12,6 @@ class RenderTexture;
 
 namespace PlayerStencil
 {
-/// \brief runs stencil setup and player stencil rendering at dedicated z-layers.
-/// \param target render target used for player stencil drawing at the stop layer.
-/// \param z_index current render layer index in the world draw pass.
-void draw(sf::RenderTarget& target, int32_t z_index);
-
 /// \brief returns the layer where stencil capture starts.
 /// \return z-layer directly above the player layer.
 int32_t getStartLayer();
@@ -24,25 +20,10 @@ int32_t getStartLayer();
 /// \return z-layer directly below the maximum foreground layer.
 int32_t getStopLayer();
 
-/// \brief clears the current opengl stencil buffer.
-void clearStencilBuffer();
-
-/// \brief configures stencil writes to replace all fragments with value 1.
-void replaceAllWithOne();
-
-/// \brief configures stencil testing to keep fragments only where stencil equals 1.
-void keepIfOne();
-
 /// \brief reports whether a layer should bypass stencil handling.
 /// \param z_index render layer being queried.
 /// \return false for all layers in the current implementation.
 bool isIgnored(int32_t z_index);
-
-/// \brief enables opengl stencil testing.
-void enableTest();
-
-/// \brief disables opengl stencil testing.
-void disableTest();
 
 /// \brief dumps the stencil buffer to a debug image every 60 calls.
 /// \param texture render texture that provides output dimensions for the dump.


### PR DESCRIPTION
## Problem

The occluded-player silhouette — the faint transparent-white player shown when he's hidden behind foreground geometry (walls, doors) — stopped rendering after the desktop build switched to vanilla SFML 3.

**Root cause:** `PlayerStencil` drove the stencil buffer with raw GL calls (`glEnable(GL_STENCIL_TEST)`, `glStencilFunc/Op`). SFML 3's `RenderTarget` caches stencil state, and switching the active render target invalidates that cache (`m_cache.enable = false`). Because the foreground tilemaps draw to **both** the color (`level`) and `normal` render targets, the target switch forces SFML to re-apply its default (disabled) stencil mode on the next `level` draw — wiping the manual `glEnable` *before* the foreground geometry rasterizes. So nothing was ever written into the stencil buffer, and the silhouette was masked to nothing.

Raw-GL stencil state fundamentally cannot coexist with SFML 3's per-draw state cache when alternating render targets.

## Fix

- Drive the stencil through `sf::RenderStates::stencilMode` so SFML re-applies it on every draw. In `Level::drawLayers`: clear the stencil at the start layer, foreground layers draw with `Always/Replace` (write 1), and the silhouette draws with `Equal/Keep` (visible only where occluded). Uses the same desktop/WASM `#ifdef` `StencilMode` idiom as `drawLightOccluders`.
- Removed the now-dead raw-GL helpers from `playerstencil.{h,cpp}` (kept the layer-range accessors and the debug `dump`).
- `Player::drawStencil` now takes `const sf::RenderStates&` and forwards it to the animation cycle draws.

## White silhouette

`setColor(white)` alone only multiplies the sprite texture, so the silhouette showed the player's own colors dimmed rather than white. Added a small `data/shaders/player_silhouette.frag` (fragment-only, GL ES + desktop paths, mirroring `flash.frag`) that outputs `vec4(1, 1, 1, textureAlpha * u_alpha)` — white RGB with the sprite's shape as alpha. Owned by `Player`, loaded in `initialize()`, applied in `drawStencil` with `u_alpha` controlling the faintness. `setColor` is kept as a fallback if the shader fails to load.

## Testing

Desktop build (`build_rel`, MSVC / vanilla SFML 3) compiles and links cleanly. Verified in-game: the transparent-white silhouette now appears when the player stands behind foreground geometry. Since the shader and stencil paths both have GL ES branches, the WASM build should be covered too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)