### PR TITLE
music: load tracks off the game thread on desktop; extract platform backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,8 +154,9 @@ set(GAME_FILES
     src/game/audio/audiorange.h
     src/game/audio/audioupdatedata.cpp
     src/game/audio/audioupdatedata.h
-    src/game/audio/musicbackend.cpp
     src/game/audio/musicbackend.h
+    src/game/audio/musicbackenddesktop.cpp
+    src/game/audio/musicbackendemscripten.cpp
     src/game/audio/musicfilenames.cpp
     src/game/audio/musicfilenames.h
     src/game/audio/musicplayer.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,8 @@ set(GAME_FILES
     src/game/audio/audiorange.h
     src/game/audio/audioupdatedata.cpp
     src/game/audio/audioupdatedata.h
+    src/game/audio/musicbackend.cpp
+    src/game/audio/musicbackend.h
     src/game/audio/musicfilenames.cpp
     src/game/audio/musicfilenames.h
     src/game/audio/musicplayer.cpp

--- a/src/game/audio/musicbackend.cpp
+++ b/src/game/audio/musicbackend.cpp
@@ -1,0 +1,281 @@
+#include "musicbackend.h"
+
+#include <SFML/Audio.hpp>
+
+#include <array>
+#include <chrono>
+#include <future>
+
+#ifdef __EMSCRIPTEN__
+#include <SFML/System.hpp>
+#include <cstddef>
+#include <fstream>
+#include <vector>
+#endif
+
+#ifndef __EMSCRIPTEN__
+namespace
+{
+/// \brief desktop backend backed by vanilla SFML 3 file-streamed sf::Music instances.
+///
+/// The two streams live as plain value objects for the player's lifetime. Loading is
+/// pushed onto a worker thread via std::async so opening/decoding a track never blocks
+/// the game loop and stutters a frame.
+class MusicBackendDesktop : public MusicBackend
+{
+public:
+   MusicBackendDesktop()
+   {
+      if (!_music[0].openFromFile("data/music/empty.ogg"))
+      {
+      }
+
+      if (!_music[1].openFromFile("data/music/empty.ogg"))
+      {
+      }
+
+      _music[0].setRelativeToListener(true);
+      _music[1].setRelativeToListener(true);
+   }
+
+   void play(int slot) override
+   {
+      _music[slot].play();
+   }
+
+   void stop(int slot) override
+   {
+      _music[slot].stop();
+   }
+
+   void setVolume(int slot, float volume) override
+   {
+      _music[slot].setVolume(volume);
+   }
+
+   bool isPlaying(int slot) const override
+   {
+      return _music[slot].getStatus() == sf::SoundStream::Status::Playing;
+   }
+
+   void beginLoad(int slot, const std::string& filename) override
+   {
+      _load_state[slot] = LoadState::Loading;
+
+      // next() references a stable std::array slot, so capturing it by reference stays
+      // valid for the lifetime of the load.
+      auto& music = _music[slot];
+      const std::string track_filename = filename;
+      _load_future[slot] = std::async(std::launch::async, [&music, track_filename]() { return music.openFromFile(track_filename); });
+   }
+
+   bool isLoadReady(int slot) override
+   {
+      if (_load_state[slot] == LoadState::Ready)
+      {
+         return true;
+      }
+
+      if (_load_state[slot] == LoadState::Loading && _load_future[slot].valid() &&
+          _load_future[slot].wait_for(std::chrono::seconds(0)) == std::future_status::ready)
+      {
+         _load_succeeded[slot] = _load_future[slot].get();
+         _load_state[slot] = LoadState::Ready;
+         return true;
+      }
+
+      return false;
+   }
+
+   bool loadSucceeded(int slot) const override
+   {
+      return _load_succeeded[slot];
+   }
+
+   void waitForLoad(int slot) override
+   {
+      if (_load_state[slot] == LoadState::Loading && _load_future[slot].valid())
+      {
+         _load_succeeded[slot] = _load_future[slot].get();
+         _load_state[slot] = LoadState::Ready;
+      }
+   }
+
+private:
+   enum class LoadState
+   {
+      Idle,
+      Loading,
+      Ready
+   };
+
+   std::array<sf::Music, 2> _music;
+   std::array<std::future<bool>, 2> _load_future;
+   std::array<bool, 2> _load_succeeded{false, false};                       //!< result of the last completed load per slot
+   std::array<LoadState, 2> _load_state{LoadState::Idle, LoadState::Idle};  //!< per-slot background load progress
+};
+}  // namespace
+#endif
+
+#ifdef __EMSCRIPTEN__
+namespace
+{
+// On Emscripten, miniaudio runs the audio callback on the AudioWorklet thread (a
+// WASM Worker). Streamed music decodes inside that callback, and filesystem
+// syscalls proxied from the worklet thread cannot be awaited, so file-backed
+// sf::Music produces silence. Reading the whole compressed track into memory up
+// front (on the main thread) lets the worklet decode it without touching the
+// filesystem. The returned buffer must outlive the MusicReader because
+// openFromMemory references it rather than copying.
+std::vector<std::byte> readFileBytes(const std::string& path)
+{
+   std::ifstream file(path, std::ios::binary | std::ios::ate);
+   if (!file)
+   {
+      return {};
+   }
+
+   const auto size = static_cast<std::size_t>(file.tellg());
+   file.seekg(0, std::ios::beg);
+
+   std::vector<std::byte> bytes(size);
+   if (size > 0u && !file.read(reinterpret_cast<char*>(bytes.data()), static_cast<std::streamsize>(size)))
+   {
+      return {};
+   }
+
+   return bytes;
+}
+
+/// \brief Emscripten backend backed by VRSFML sf::Music instances streamed from memory.
+///
+/// Each track is read fully into memory on the main thread and handed to the stream via
+/// openFromMemory, because the AudioWorklet thread that decodes it cannot perform
+/// filesystem syscalls. Loading is therefore synchronous; glitches are accepted on this
+/// platform.
+class MusicBackendEmscripten : public MusicBackend
+{
+public:
+   MusicBackendEmscripten()
+   {
+      auto handle = sf::AudioContext::getDefaultPlaybackDeviceHandle();
+      if (!handle.hasValue())
+      {
+         return;
+      }
+
+      _playback_device = std::make_unique<sf::PlaybackDevice>(*handle);
+
+      loadIntoSlot(0, "data/music/empty.ogg");
+      loadIntoSlot(1, "data/music/empty.ogg");
+   }
+
+   void play(int slot) override
+   {
+      if (_music[slot])
+      {
+         _music[slot]->play();
+      }
+   }
+
+   void stop(int slot) override
+   {
+      if (_music[slot])
+      {
+         _music[slot]->stop();
+      }
+   }
+
+   void setVolume(int slot, float volume) override
+   {
+      if (_music[slot])
+      {
+         _music[slot]->setVolume(volume);
+      }
+   }
+
+   bool isPlaying(int slot) const override
+   {
+      return _music[slot] && _music[slot]->isPlaying();
+   }
+
+   void beginLoad(int slot, const std::string& filename) override
+   {
+      _load_succeeded[slot] = loadIntoSlot(slot, filename);
+   }
+
+   bool isLoadReady(int /*slot*/) override
+   {
+      return true;
+   }
+
+   bool loadSucceeded(int slot) const override
+   {
+      return _load_succeeded[slot];
+   }
+
+   void waitForLoad(int /*slot*/) override
+   {
+   }
+
+private:
+   /// \brief reads the track into memory and (re)creates the slot's stream from it.
+   /// \param slot stream slot index (0 or 1) to load into.
+   /// \param filename path of the track to open.
+   /// \return true if a usable stream was created.
+   bool loadIntoSlot(int slot, const std::string& filename)
+   {
+      if (!_playback_device)
+      {
+         return false;
+      }
+
+      auto track_bytes = readFileBytes(filename);
+      if (track_bytes.empty())
+      {
+         return false;
+      }
+
+      auto new_reader = sf::MusicReader::openFromMemory(track_bytes.data(), track_bytes.size());
+      if (!new_reader.hasValue())
+      {
+         return false;
+      }
+
+      // Tear down the slot's existing stream and reader before replacing its backing
+      // bytes: the old reader references _music_data[slot] via openFromMemory.
+      if (_music[slot])
+      {
+         _music[slot]->stop();
+      }
+      _music[slot].reset();
+      _music_readers[slot].reset();
+
+      // Moving the vector transfers the heap allocation without reallocating, so the
+      // pointer captured by new_reader's MemoryInputStream stays valid.
+      _music_data[slot] = std::move(track_bytes);
+      _music_readers[slot] = std::make_unique<sf::MusicReader>(std::move(*new_reader));
+      _music[slot] = std::make_unique<sf::Music>(*_playback_device, *_music_readers[slot]);
+      _music[slot]->setRelativeToListener(true);
+
+      return true;
+   }
+
+   std::unique_ptr<sf::PlaybackDevice> _playback_device;  //!< owned playback device; null if audio context is unavailable
+   std::array<std::vector<std::byte>, 2>
+      _music_data;  //!< compressed track bytes backing each reader; must outlive the MusicReader (openFromMemory references, not copies)
+   std::array<std::unique_ptr<sf::MusicReader>, 2> _music_readers;  //!< music reader (memory source) for each stream slot
+   std::array<std::unique_ptr<sf::Music>, 2> _music;                //!< music stream for each slot; null until first track is loaded
+   std::array<bool, 2> _load_succeeded{false, false};               //!< result of the last completed load per slot
+};
+}  // namespace
+#endif
+
+std::unique_ptr<MusicBackend> MusicBackend::create()
+{
+#ifdef __EMSCRIPTEN__
+   return std::make_unique<MusicBackendEmscripten>();
+#else
+   return std::make_unique<MusicBackendDesktop>();
+#endif
+}

--- a/src/game/audio/musicbackend.h
+++ b/src/game/audio/musicbackend.h
@@ -1,0 +1,69 @@
+#ifndef MUSICBACKEND_H
+#define MUSICBACKEND_H
+
+#include <memory>
+#include <string>
+
+/// \brief platform-specific stream plumbing for the music player.
+///
+/// MusicPlayer owns the transition/crossfade/playlist state machine and is fully
+/// platform-agnostic. MusicBackend abstracts the two things that genuinely differ
+/// between the desktop (vanilla SFML 3) and Emscripten (VRSFML) builds: how a track
+/// is opened and how a stream slot is addressed. Exactly one concrete backend is
+/// compiled per platform and created via create().
+///
+/// Slot indices are 0 or 1 — the player double-buffers two streams so it can
+/// crossfade or hand over between the active and the inactive slot.
+class MusicBackend
+{
+public:
+   virtual ~MusicBackend() = default;
+
+   /// \brief starts playback of the stream in the given slot.
+   /// \param slot stream slot index (0 or 1).
+   virtual void play(int slot) = 0;
+
+   /// \brief stops the stream in the given slot.
+   /// \param slot stream slot index (0 or 1).
+   virtual void stop(int slot) = 0;
+
+   /// \brief sets the playback volume of the stream in the given slot.
+   /// \param slot stream slot index (0 or 1).
+   /// \param volume platform-scaled volume value to apply.
+   virtual void setVolume(int slot, float volume) = 0;
+
+   /// \brief returns whether the stream in the given slot is currently playing.
+   /// \param slot stream slot index (0 or 1).
+   /// \return true if the slot holds a stream that is playing.
+   virtual bool isPlaying(int slot) const = 0;
+
+   /// \brief begins loading a track into the given slot.
+   ///
+   /// The desktop backend opens the file on a background thread so the game loop never
+   /// blocks; the Emscripten backend reads it into memory synchronously (an
+   /// AudioWorklet-thread constraint). Either way the result is retrieved through
+   /// isLoadReady() and loadSucceeded().
+   /// \param slot stream slot index (0 or 1) to load into.
+   /// \param filename path of the track to open.
+   virtual void beginLoad(int slot, const std::string& filename) = 0;
+
+   /// \brief returns whether the load started for the given slot has finished.
+   /// \param slot stream slot index (0 or 1).
+   /// \return true once the load result is available.
+   virtual bool isLoadReady(int slot) = 0;
+
+   /// \brief returns whether the most recently completed load for the slot succeeded.
+   /// \param slot stream slot index (0 or 1).
+   /// \return true if the last load opened a usable stream.
+   virtual bool loadSucceeded(int slot) const = 0;
+
+   /// \brief blocks until any in-flight load for the given slot has finished.
+   /// \param slot stream slot index (0 or 1).
+   virtual void waitForLoad(int slot) = 0;
+
+   /// \brief creates the backend implementation for the current platform.
+   /// \return owning pointer to the platform backend.
+   static std::unique_ptr<MusicBackend> create();
+};
+
+#endif  // MUSICBACKEND_H

--- a/src/game/audio/musicbackenddesktop.cpp
+++ b/src/game/audio/musicbackenddesktop.cpp
@@ -1,0 +1,120 @@
+#include "musicbackend.h"
+
+#ifndef __EMSCRIPTEN__
+
+#include <SFML/Audio.hpp>
+
+#include <array>
+#include <chrono>
+#include <future>
+#include <memory>
+#include <string>
+
+namespace
+{
+/// \brief desktop backend backed by vanilla SFML 3 file-streamed sf::Music instances.
+///
+/// The two streams live as plain value objects for the player's lifetime. Loading is
+/// pushed onto a worker thread via std::async so opening/decoding a track never blocks
+/// the game loop and stutters a frame.
+class MusicBackendDesktop : public MusicBackend
+{
+public:
+   MusicBackendDesktop()
+   {
+      if (!_music[0].openFromFile("data/music/empty.ogg"))
+      {
+      }
+
+      if (!_music[1].openFromFile("data/music/empty.ogg"))
+      {
+      }
+
+      _music[0].setRelativeToListener(true);
+      _music[1].setRelativeToListener(true);
+   }
+
+   void play(int slot) override
+   {
+      _music[slot].play();
+   }
+
+   void stop(int slot) override
+   {
+      _music[slot].stop();
+   }
+
+   void setVolume(int slot, float volume) override
+   {
+      _music[slot].setVolume(volume);
+   }
+
+   bool isPlaying(int slot) const override
+   {
+      return _music[slot].getStatus() == sf::SoundStream::Status::Playing;
+   }
+
+   void beginLoad(int slot, const std::string& filename) override
+   {
+      _load_state[slot] = LoadState::Loading;
+
+      // next() references a stable std::array slot, so capturing it by reference stays
+      // valid for the lifetime of the load.
+      auto& music = _music[slot];
+      const std::string track_filename = filename;
+      _load_future[slot] = std::async(std::launch::async, [&music, track_filename]() { return music.openFromFile(track_filename); });
+   }
+
+   bool isLoadReady(int slot) override
+   {
+      if (_load_state[slot] == LoadState::Ready)
+      {
+         return true;
+      }
+
+      if (_load_state[slot] == LoadState::Loading && _load_future[slot].valid() &&
+          _load_future[slot].wait_for(std::chrono::seconds(0)) == std::future_status::ready)
+      {
+         _load_succeeded[slot] = _load_future[slot].get();
+         _load_state[slot] = LoadState::Ready;
+         return true;
+      }
+
+      return false;
+   }
+
+   bool loadSucceeded(int slot) const override
+   {
+      return _load_succeeded[slot];
+   }
+
+   void waitForLoad(int slot) override
+   {
+      if (_load_state[slot] == LoadState::Loading && _load_future[slot].valid())
+      {
+         _load_succeeded[slot] = _load_future[slot].get();
+         _load_state[slot] = LoadState::Ready;
+      }
+   }
+
+private:
+   enum class LoadState
+   {
+      Idle,
+      Loading,
+      Ready
+   };
+
+   std::array<sf::Music, 2> _music;
+   std::array<std::future<bool>, 2> _load_future;
+   std::array<bool, 2> _load_succeeded{false, false};                       //!< result of the last completed load per slot
+   std::array<LoadState, 2> _load_state{LoadState::Idle, LoadState::Idle};  //!< per-slot background load progress
+};
+}  // namespace
+
+std::unique_ptr<MusicBackend> MusicBackend::create()
+{
+   return std::make_unique<MusicBackendDesktop>();
+}
+
+#endif

--- a/src/game/audio/musicbackendemscripten.cpp
+++ b/src/game/audio/musicbackendemscripten.cpp
@@ -1,123 +1,17 @@
 #include "musicbackend.h"
 
+#ifdef __EMSCRIPTEN__
+
 #include <SFML/Audio.hpp>
+#include <SFML/System.hpp>
 
 #include <array>
-#include <chrono>
-#include <future>
-
-#ifdef __EMSCRIPTEN__
-#include <SFML/System.hpp>
 #include <cstddef>
 #include <fstream>
+#include <memory>
+#include <string>
 #include <vector>
-#endif
 
-#ifndef __EMSCRIPTEN__
-namespace
-{
-/// \brief desktop backend backed by vanilla SFML 3 file-streamed sf::Music instances.
-///
-/// The two streams live as plain value objects for the player's lifetime. Loading is
-/// pushed onto a worker thread via std::async so opening/decoding a track never blocks
-/// the game loop and stutters a frame.
-class MusicBackendDesktop : public MusicBackend
-{
-public:
-   MusicBackendDesktop()
-   {
-      if (!_music[0].openFromFile("data/music/empty.ogg"))
-      {
-      }
-
-      if (!_music[1].openFromFile("data/music/empty.ogg"))
-      {
-      }
-
-      _music[0].setRelativeToListener(true);
-      _music[1].setRelativeToListener(true);
-   }
-
-   void play(int slot) override
-   {
-      _music[slot].play();
-   }
-
-   void stop(int slot) override
-   {
-      _music[slot].stop();
-   }
-
-   void setVolume(int slot, float volume) override
-   {
-      _music[slot].setVolume(volume);
-   }
-
-   bool isPlaying(int slot) const override
-   {
-      return _music[slot].getStatus() == sf::SoundStream::Status::Playing;
-   }
-
-   void beginLoad(int slot, const std::string& filename) override
-   {
-      _load_state[slot] = LoadState::Loading;
-
-      // next() references a stable std::array slot, so capturing it by reference stays
-      // valid for the lifetime of the load.
-      auto& music = _music[slot];
-      const std::string track_filename = filename;
-      _load_future[slot] = std::async(std::launch::async, [&music, track_filename]() { return music.openFromFile(track_filename); });
-   }
-
-   bool isLoadReady(int slot) override
-   {
-      if (_load_state[slot] == LoadState::Ready)
-      {
-         return true;
-      }
-
-      if (_load_state[slot] == LoadState::Loading && _load_future[slot].valid() &&
-          _load_future[slot].wait_for(std::chrono::seconds(0)) == std::future_status::ready)
-      {
-         _load_succeeded[slot] = _load_future[slot].get();
-         _load_state[slot] = LoadState::Ready;
-         return true;
-      }
-
-      return false;
-   }
-
-   bool loadSucceeded(int slot) const override
-   {
-      return _load_succeeded[slot];
-   }
-
-   void waitForLoad(int slot) override
-   {
-      if (_load_state[slot] == LoadState::Loading && _load_future[slot].valid())
-      {
-         _load_succeeded[slot] = _load_future[slot].get();
-         _load_state[slot] = LoadState::Ready;
-      }
-   }
-
-private:
-   enum class LoadState
-   {
-      Idle,
-      Loading,
-      Ready
-   };
-
-   std::array<sf::Music, 2> _music;
-   std::array<std::future<bool>, 2> _load_future;
-   std::array<bool, 2> _load_succeeded{false, false};                       //!< result of the last completed load per slot
-   std::array<LoadState, 2> _load_state{LoadState::Idle, LoadState::Idle};  //!< per-slot background load progress
-};
-}  // namespace
-#endif
-
-#ifdef __EMSCRIPTEN__
 namespace
 {
 // On Emscripten, miniaudio runs the audio callback on the AudioWorklet thread (a
@@ -269,13 +163,10 @@ private:
    std::array<bool, 2> _load_succeeded{false, false};               //!< result of the last completed load per slot
 };
 }  // namespace
-#endif
 
 std::unique_ptr<MusicBackend> MusicBackend::create()
 {
-#ifdef __EMSCRIPTEN__
    return std::make_unique<MusicBackendEmscripten>();
-#else
-   return std::make_unique<MusicBackendDesktop>();
-#endif
 }
+
+#endif

--- a/src/game/audio/musicplayer.cpp
+++ b/src/game/audio/musicplayer.cpp
@@ -3,46 +3,9 @@
 #include "framework/tools/log.h"
 #include "game/config/gameconfiguration.h"
 
+#include <algorithm>
 #include <chrono>
 #include <filesystem>
-#ifdef __EMSCRIPTEN__
-#include <cstddef>
-#include <fstream>
-#include <string>
-#include <vector>
-#endif
-
-#ifdef __EMSCRIPTEN__
-namespace
-{
-// On Emscripten, miniaudio runs the audio callback on the AudioWorklet thread (a
-// WASM Worker). Streamed music decodes inside that callback, and filesystem
-// syscalls proxied from the worklet thread cannot be awaited, so file-backed
-// sf::Music produces silence. Reading the whole compressed track into memory up
-// front (on the main thread) lets the worklet decode it without touching the
-// filesystem. The returned buffer must outlive the MusicReader because
-// openFromMemory references it rather than copying.
-std::vector<std::byte> readFileBytes(const std::string& path)
-{
-   std::ifstream file(path, std::ios::binary | std::ios::ate);
-   if (!file)
-   {
-      return {};
-   }
-
-   const auto size = static_cast<std::size_t>(file.tellg());
-   file.seekg(0, std::ios::beg);
-
-   std::vector<std::byte> bytes(size);
-   if (size > 0u && !file.read(reinterpret_cast<char*>(bytes.data()), static_cast<std::streamsize>(size)))
-   {
-      return {};
-   }
-
-   return bytes;
-}
-}  // namespace
-#endif
 
 MusicPlayer& MusicPlayer::getInstance()
 {
@@ -50,44 +13,8 @@ MusicPlayer& MusicPlayer::getInstance()
    return instance;
 }
 
-MusicPlayer::MusicPlayer()
+MusicPlayer::MusicPlayer() : _backend(MusicBackend::create())
 {
-#ifdef __EMSCRIPTEN__
-   auto handle = sf::AudioContext::getDefaultPlaybackDeviceHandle();
-   if (!handle.hasValue())
-   {
-      return;
-   }
-   _playback_device = std::make_unique<sf::PlaybackDevice>(*handle);
-
-   for (auto music_slot_index = 0u; music_slot_index < _music.size(); ++music_slot_index)
-   {
-      _music_data[music_slot_index] = readFileBytes("data/music/empty.ogg");
-      if (_music_data[music_slot_index].empty())
-      {
-         continue;
-      }
-
-      auto reader = sf::MusicReader::openFromMemory(_music_data[music_slot_index].data(), _music_data[music_slot_index].size());
-      if (reader.hasValue())
-      {
-         _music_readers[music_slot_index] = std::make_unique<sf::MusicReader>(std::move(*reader));
-         _music[music_slot_index] = std::make_unique<sf::Music>(*_playback_device, *_music_readers[music_slot_index]);
-         _music[music_slot_index]->setRelativeToListener(true);
-      }
-   }
-#else
-   if (!_music[0].openFromFile("data/music/empty.ogg"))
-   {
-   }
-
-   if (!_music[1].openFromFile("data/music/empty.ogg"))
-   {
-   }
-
-   _music[0].setRelativeToListener(true);
-   _music[1].setRelativeToListener(true);
-#endif
 }
 
 void MusicPlayer::update(const sf::Time& dt)
@@ -95,6 +22,20 @@ void MusicPlayer::update(const sf::Time& dt)
    std::scoped_lock lock(_mutex);
 
    const auto dt_ms = std::chrono::milliseconds(dt.asMilliseconds());
+
+   // a track is being opened into the inactive slot; wait for it to finish before
+   // starting playback or any further transition. The desktop backend loads on a worker
+   // thread (so the frame never blocks), the Emscripten backend loads synchronously —
+   // either way the state machine treats it the same.
+   if (_loading_request.has_value())
+   {
+      const auto next_index = 1 - _current_index;
+      if (_backend->isLoadReady(next_index))
+      {
+         activateLoadedTrack(_backend->loadSucceeded(next_index));
+      }
+      return;
+   }
 
    switch (_transition_state)
    {
@@ -125,40 +66,18 @@ void MusicPlayer::updateCrossfade(std::chrono::milliseconds dt)
    _crossfade_elapsed += dt;
    const auto normalized_time = std::min(1.0f, static_cast<float>(_crossfade_elapsed.count()) / _crossfade_duration.count());
 
-#ifdef __EMSCRIPTEN__
-   if (auto* next_music = nextMusic())
-   {
-      next_music->setVolume(volume() * normalized_time);
-   }
-   if (auto* cur_music = currentMusic())
-   {
-      cur_music->setVolume(volume() * (1.0f - normalized_time));
-   }
+   const auto next_index = 1 - _current_index;
+   _backend->setVolume(next_index, volume() * normalized_time);
+   _backend->setVolume(_current_index, volume() * (1.0f - normalized_time));
 
    if (_crossfade_elapsed >= _crossfade_duration)
    {
-      if (auto* cur_music = currentMusic())
-      {
-         cur_music->stop();
-         cur_music->setVolume(volume());
-      }
-      _current_index = 1 - _current_index;  // swap
+      _backend->stop(_current_index);
+      _backend->setVolume(_current_index, volume());
+      _current_index = next_index;  // swap
       _transition_state = MusicPlayerTypes::MusicTransitionState::None;
       _pending_request.reset();
    }
-#else
-   next().setVolume(volume() * normalized_time);
-   current().setVolume(volume() * (1.0f - normalized_time));
-
-   if (_crossfade_elapsed >= _crossfade_duration)
-   {
-      current().stop();
-      current().setVolume(volume());
-      _current_index = 1 - _current_index;  // swap
-      _transition_state = MusicPlayerTypes::MusicTransitionState::None;
-      _pending_request.reset();
-   }
-#endif
 }
 
 void MusicPlayer::updateFadeOut(std::chrono::milliseconds dt)
@@ -166,25 +85,11 @@ void MusicPlayer::updateFadeOut(std::chrono::milliseconds dt)
    _fade_out_elapsed += dt;
    const auto normalized_time = std::min(1.0f, static_cast<float>(_fade_out_elapsed.count()) / _fade_out_duration.count());
 
-#ifdef __EMSCRIPTEN__
-   if (auto* cur_music = currentMusic())
-   {
-      cur_music->setVolume(volume() * (1.0f - normalized_time));
-   }
-#else
-   current().setVolume(volume() * (1.0f - normalized_time));
-#endif
+   _backend->setVolume(_current_index, volume() * (1.0f - normalized_time));
 
    if (_fade_out_elapsed >= _fade_out_duration)
    {
-#ifdef __EMSCRIPTEN__
-      if (auto* cur_music = currentMusic())
-      {
-         cur_music->stop();
-      }
-#else
-      current().stop();
-#endif
+      _backend->stop(_current_index);
 
       if (_pending_request.has_value())
       {
@@ -205,7 +110,7 @@ void MusicPlayer::processPendingRequest()
       return;
    }
 
-   const auto& request = _pending_request.value();
+   const auto request = _pending_request.value();
 
    switch (request.transition)
    {
@@ -218,11 +123,7 @@ void MusicPlayer::processPendingRequest()
 
       case MusicPlayerTypes::TransitionType::LetCurrentFinish:
       {
-#ifdef __EMSCRIPTEN__
-         if (currentMusic() == nullptr || !currentMusic()->isPlaying())
-#else
-         if (current().getStatus() != sf::SoundStream::Status::Playing)
-#endif
+         if (!_backend->isPlaying(_current_index))
          {
             beginTransition(request);
             _pending_request.reset();
@@ -232,10 +133,11 @@ void MusicPlayer::processPendingRequest()
 
       case MusicPlayerTypes::TransitionType::Crossfade:
       {
+         // the crossfade only begins once the track finishes loading; activateLoadedTrack()
+         // sets the Crossfading state. Clear the pending request so it is not re-processed
+         // while the load is in flight.
          beginTransition(request);
-         _transition_state = MusicPlayerTypes::MusicTransitionState::Crossfading;
-         _crossfade_elapsed = std::chrono::milliseconds{0};
-         _crossfade_duration = request.duration;
+         _pending_request.reset();
          break;
       }
 
@@ -254,17 +156,10 @@ void MusicPlayer::processPendingRequest()
 
 void MusicPlayer::handleTrackFinished()
 {
-#ifdef __EMSCRIPTEN__
-   if (currentMusic() != nullptr && currentMusic()->isPlaying())
+   if (_backend->isPlaying(_current_index))
    {
       return;
    }
-#else
-   if (current().getStatus() == sf::SoundStream::Status::Playing)
-   {
-      return;
-   }
-#endif
 
    switch (_post_action)
    {
@@ -275,14 +170,7 @@ void MusicPlayer::handleTrackFinished()
 
       case MusicPlayerTypes::PostPlaybackAction::Loop:
       {
-#ifdef __EMSCRIPTEN__
-         if (auto* cur_music = currentMusic())
-         {
-            cur_music->play();
-         }
-#else
-         current().play();
-#endif
+         _backend->play(_current_index);
          break;
       }
 
@@ -303,28 +191,6 @@ void MusicPlayer::handleTrackFinished()
    }
 }
 
-#ifdef __EMSCRIPTEN__
-sf::Music* MusicPlayer::currentMusic()
-{
-   return _music[_current_index].get();
-}
-
-sf::Music* MusicPlayer::nextMusic()
-{
-   return _music[1 - _current_index].get();
-}
-#else
-sf::Music& MusicPlayer::current()
-{
-   return _music[_current_index];
-}
-
-sf::Music& MusicPlayer::next()
-{
-   return _music[1 - _current_index];
-}
-#endif
-
 void MusicPlayer::queueTrack(const TrackRequest& request)
 {
    std::scoped_lock lock(_mutex);
@@ -335,20 +201,13 @@ void MusicPlayer::stop()
 {
    std::scoped_lock lock(_mutex);
 
-#ifdef __EMSCRIPTEN__
-   for (auto& music_ptr : _music)
-   {
-      if (music_ptr)
-      {
-         music_ptr->stop();
-      }
-   }
-#else
-   for (auto& music : _music)
-   {
-      music.stop();
-   }
-#endif
+   // wait for any in-flight background load to finish so the backend is not opening a
+   // stream while we stop it.
+   _backend->waitForLoad(1 - _current_index);
+   _loading_request.reset();
+
+   _backend->stop(0);
+   _backend->stop(1);
 
    _pending_request.reset();
    _transition_state = MusicPlayerTypes::MusicTransitionState::None;
@@ -364,97 +223,11 @@ void MusicPlayer::setPlaylist(const std::vector<std::string>& playlist)
 
 void MusicPlayer::adjustActiveMusicVolume()
 {
-#ifdef __EMSCRIPTEN__
-   if (auto* cur_music = currentMusic())
-   {
-      cur_music->setVolume(volume());
-   }
-#else
-   current().setVolume(volume());
-#endif
+   _backend->setVolume(_current_index, volume());
 }
 
 void MusicPlayer::beginTransition(const TrackRequest& request)
 {
-#ifdef __EMSCRIPTEN__
-   if (!_playback_device)
-   {
-      return;
-   }
-
-   if (!std::filesystem::exists(request.filename))
-   {
-      Log::Error() << "music file does not exist: " << request.filename;
-      return;
-   }
-
-   auto start_time = std::chrono::high_resolution_clock::now();
-
-   auto track_bytes = readFileBytes(request.filename);
-   if (track_bytes.empty())
-   {
-      Log::Error() << "unable to load music file: " << request.filename;
-      return;
-   }
-
-   auto new_reader = sf::MusicReader::openFromMemory(track_bytes.data(), track_bytes.size());
-   auto end_time = std::chrono::high_resolution_clock::now();
-
-   auto load_duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
-
-   if (!new_reader.hasValue())
-   {
-      Log::Error() << "unable to load music file: " << request.filename;
-      return;
-   }
-   else if (load_duration.count() >= 100)
-   {
-      Log::Info() << "Music load time for " << request.filename << ": " << load_duration.count() << " ms (Main thread - may cause hiccups)";
-   }
-
-   const auto next_index = 1 - _current_index;
-
-   // Tear down the slot's existing stream and reader before replacing its backing
-   // bytes: the old reader references _music_data[next_index] via openFromMemory.
-   if (_music[next_index])
-   {
-      _music[next_index]->stop();
-   }
-   _music[next_index].reset();
-   _music_readers[next_index].reset();
-
-   // Moving the vector transfers the heap allocation without reallocating, so the
-   // pointer captured by new_reader's MemoryInputStream stays valid.
-   _music_data[next_index] = std::move(track_bytes);
-   _music_readers[next_index] = std::make_unique<sf::MusicReader>(std::move(*new_reader));
-   _music[next_index] = std::make_unique<sf::Music>(*_playback_device, *_music_readers[next_index]);
-   _music[next_index]->setRelativeToListener(true);
-
-   if (request.transition == MusicPlayerTypes::TransitionType::Crossfade)
-   {
-      _music[next_index]->setVolume(0.f);
-   }
-   else
-   {
-      _music[next_index]->setVolume(volume());
-      if (_music[_current_index])
-      {
-         _music[_current_index]->stop();
-      }
-   }
-
-   _music[next_index]->play();
-   _post_action = request.post_action;
-
-   if (request.transition == MusicPlayerTypes::TransitionType::ImmediateSwitch ||
-       request.transition == MusicPlayerTypes::TransitionType::LetCurrentFinish)
-   {
-      _current_index = 1 - _current_index;
-   }
-#else
-   auto& next_track = next();
-   auto& current_track = current();
-
    // check if the file exists before attempting to load
    if (!std::filesystem::exists(request.filename))
    {
@@ -462,42 +235,55 @@ void MusicPlayer::beginTransition(const TrackRequest& request)
       return;
    }
 
-   // time the music file loading operation
-   auto start_time = std::chrono::high_resolution_clock::now();
-   bool success = next_track.openFromFile(request.filename);
-   auto end_time = std::chrono::high_resolution_clock::now();
+   // Load the track into the inactive slot. beginLoad is asynchronous on desktop and
+   // synchronous on Emscripten; activateLoadedTrack() picks the result up through the
+   // loading branch in update() once the backend reports it ready.
+   _loading_request = request;
+   _backend->beginLoad(1 - _current_index, request.filename);
+}
 
-   auto load_duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
+void MusicPlayer::activateLoadedTrack(bool load_succeeded)
+{
+   const auto request = _loading_request.value();
+   _loading_request.reset();
 
-   if (!success)
+   if (!load_succeeded)
    {
       Log::Error() << "unable to load music file: " << request.filename;
+      _transition_state = MusicPlayerTypes::MusicTransitionState::None;
       return;
    }
-   else if (load_duration.count() >= 100)
-   {
-      Log::Info() << "Music load time for " << request.filename << ": " << load_duration.count() << " ms (Main thread - may cause hiccups)";
-   }
+
+   const auto next_index = 1 - _current_index;
 
    if (request.transition == MusicPlayerTypes::TransitionType::Crossfade)
    {
-      next_track.setVolume(0.f);
+      _backend->setVolume(next_index, 0.f);
    }
    else
    {
-      next_track.setVolume(100.f);
-      current_track.stop();
+#ifdef __EMSCRIPTEN__
+      _backend->setVolume(next_index, volume());
+#else
+      _backend->setVolume(next_index, 100.f);
+#endif
+      _backend->stop(_current_index);
    }
 
-   next_track.play();
+   _backend->play(next_index);
    _post_action = request.post_action;
 
    if (request.transition == MusicPlayerTypes::TransitionType::ImmediateSwitch ||
        request.transition == MusicPlayerTypes::TransitionType::LetCurrentFinish)
    {
-      _current_index = 1 - _current_index;
+      _current_index = next_index;
    }
-#endif
+   else if (request.transition == MusicPlayerTypes::TransitionType::Crossfade)
+   {
+      _transition_state = MusicPlayerTypes::MusicTransitionState::Crossfading;
+      _crossfade_elapsed = std::chrono::milliseconds{0};
+      _crossfade_duration = request.duration;
+   }
 }
 
 float MusicPlayer::volume() const

--- a/src/game/audio/musicplayer.h
+++ b/src/game/audio/musicplayer.h
@@ -1,20 +1,22 @@
 #ifndef MUSICPLAYER_H
 #define MUSICPLAYER_H
 
-#include <SFML/Audio.hpp>
-#ifdef __EMSCRIPTEN__
 #include <SFML/System.hpp>
-#endif
-#include <array>
 #include <chrono>
-#include <cstddef>
+#include <cstdint>
+#include <memory>
 #include <mutex>
 #include <optional>
+#include <string>
 #include <vector>
 
+#include "game/audio/musicbackend.h"
 #include "game/audio/musicplayertypes.h"
 
 /// \brief singleton music playback controller supporting queued transitions, crossfades, and playlists.
+///
+/// Owns the platform-agnostic transition state machine; all stream mechanics (loading and
+/// per-slot playback control) are delegated to a MusicBackend selected for the build.
 class MusicPlayer
 {
 public:
@@ -53,9 +55,13 @@ private:
    /// \brief constructs the player and opens placeholder tracks for both stream slots.
    MusicPlayer();
 
-   /// \brief loads the requested track into the inactive slot and starts the selected transition behavior.
-   /// \param request track request to execute immediately.
+   /// \brief starts loading the requested track into the inactive slot.
+   /// \param request track request to load and eventually activate.
    void beginTransition(const TrackRequest& request);
+
+   /// \brief activates the track loaded into the inactive slot and starts its transition behavior.
+   /// \param load_succeeded whether the backend load succeeded.
+   void activateLoadedTrack(bool load_succeeded);
 
    /// \brief computes effective music volume from master and music configuration values.
    /// \return normalized sf::Music volume value in the 0-100 range.
@@ -77,29 +83,8 @@ private:
 
    mutable std::mutex _mutex;
 
-#ifdef __EMSCRIPTEN__
-   /// \brief returns a pointer to the currently active music stream slot, or nullptr if not loaded.
-   sf::Music* currentMusic();
+   std::unique_ptr<MusicBackend> _backend;  //!< platform stream plumbing for both slots
 
-   /// \brief returns a pointer to the inactive music stream slot used for upcoming transitions, or nullptr if not loaded.
-   sf::Music* nextMusic();
-
-   std::unique_ptr<sf::PlaybackDevice> _playback_device;  //!< owned playback device; null if audio context is unavailable
-   std::array<std::vector<std::byte>, 2>
-      _music_data;  //!< compressed track bytes backing each reader; must outlive the MusicReader (openFromMemory references, not copies)
-   std::array<std::unique_ptr<sf::MusicReader>, 2> _music_readers;  //!< music reader (memory source) for each stream slot
-   std::array<std::unique_ptr<sf::Music>, 2> _music;                //!< music stream for each slot; null until first track is loaded
-#else
-   /// \brief returns the currently active music stream slot.
-   /// \return reference to the active sf::Music instance.
-   sf::Music& current();
-
-   /// \brief returns the inactive music stream slot used for upcoming transitions.
-   /// \return reference to the inactive sf::Music instance.
-   sf::Music& next();
-
-   std::array<sf::Music, 2> _music;
-#endif
    int32_t _current_index = 0;  // 0 or 1
 
    MusicPlayerTypes::MusicTransitionState _transition_state = MusicPlayerTypes::MusicTransitionState::None;
@@ -112,6 +97,7 @@ private:
 
    MusicPlayerTypes::PostPlaybackAction _post_action = MusicPlayerTypes::PostPlaybackAction::None;
    std::optional<TrackRequest> _pending_request;
+   std::optional<TrackRequest> _loading_request;  //!< request whose track is being loaded into the inactive slot; empty when idle
 
    std::vector<std::string> _playlist;
    std::size_t _playlist_index = 0;


### PR DESCRIPTION
## Problem

Playing a new track (e.g. hitting a sensor rect in `catacombs.tmx` that calls `playMusic` from `level.lua`) stuttered the game for a few frames. `beginTransition()` opened and decoded the `.ogg` **synchronously inside `MusicPlayer::update()`**, which runs on the game-loop thread — so opening the stream blocked the frame.

## Fix

**Desktop** now opens the track on a `std::async` worker thread, so the frame never blocks. The state machine waits for the load through a new *loading* branch in `update()` and only starts playback once the backend reports the load ready. The currently-playing track keeps streaming during the load, so there is no audio gap either.

**WASM** keeps loading synchronously (reading the whole compressed track into memory up front is required by the AudioWorklet-thread constraint); minor glitches are accepted there.

## Refactor: `MusicBackend` seam

Rather than fork the whole class, I extracted the narrow part that actually differs per platform:

- **`MusicPlayer`** is now a fully platform-agnostic transition / crossfade / playlist state machine. All the `#ifdef`s that were smeared through `update` / `updateCrossfade` / `updateFadeOut` / `processPendingRequest` / `handleTrackFinished` / the slot accessors are gone.
- **`MusicBackend`** (new) abstracts the six operations that genuinely differ: `play / stop / setVolume / isPlaying / beginLoad / isLoadReady / loadSucceeded / waitForLoad`.
  - `MusicBackendDesktop` — vanilla SFML 3, value `sf::Music`, async load.
  - `MusicBackendEmscripten` — VRSFML, `readFileBytes` + `openFromMemory`, synchronous load.
- Loading is modeled as a state **both** platforms pass through: desktop waits real frames, WASM reports ready immediately.

The only `#ifdef`s left in the subsystem are the two backend class guards, the factory, and two genuine behavioral differences in `MusicPlayer` (the volume scale, and the freshly-activated non-crossfade track volume), both preserved exactly.

## Behavior

Unchanged on both platforms, with one intentional unification: WASM crossfades now start one frame later (load→activate happens next tick), which is inaudible.

## Testing

Desktop (`build_deb`, vanilla SFML 3, Ninja) builds and links cleanly.