### PR TITLE
console: add Tab completion for developer commands

### DIFF
--- a/src/game/debug/console.cpp
+++ b/src/game/debug/console.cpp
@@ -750,6 +750,63 @@ void Console::nextCommand()
    _command = _history[static_cast<size_t>(_history_index)];
 }
 
+void Console::complete()
+{
+   if (_command.empty())
+   {
+      return;
+   }
+
+   std::vector<std::string> matches;
+   for (const auto& [command_name, callback] : _registered_commands)
+   {
+      if (command_name.size() >= _command.size() && command_name.compare(0, _command.size(), _command) == 0)
+      {
+         matches.push_back(command_name);
+      }
+   }
+
+   if (matches.empty())
+   {
+      return;
+   }
+
+   std::ranges::sort(matches);
+
+   if (matches.size() == 1)
+   {
+      _command = matches.front() + ' ';
+      return;
+   }
+
+   // reduce all matches to their longest common prefix so the input can be extended as far as it is unambiguous
+   std::string common_prefix = matches.front();
+   for (const auto& match : matches)
+   {
+      const auto comparable_length = std::min(common_prefix.size(), match.size());
+      size_t prefix_length = 0;
+      while (prefix_length < comparable_length && common_prefix[prefix_length] == match[prefix_length])
+      {
+         ++prefix_length;
+      }
+      common_prefix.resize(prefix_length);
+   }
+
+   _command = common_prefix;
+
+   // print the remaining candidates so the user can decide how to continue typing
+   std::string candidate_line = "  ";
+   for (size_t index = 0; index < matches.size(); ++index)
+   {
+      if (index > 0)
+      {
+         candidate_line += "  ";
+      }
+      candidate_line += matches[index];
+   }
+   _log.push_back(candidate_line);
+}
+
 void Console::addCommand(const std::string& command, CommandFunction callback)
 {
    _registered_commands[command] = callback;
@@ -842,6 +899,10 @@ void Console::processEvent(sf::Keyboard::Key key)
    else if (key == sf::Keyboard::Key::Down)
    {
       nextCommand();
+   }
+   else if (key == sf::Keyboard::Key::Tab)
+   {
+      complete();
    }
    else if (key == sf::Keyboard::Key::F12)
    {

--- a/src/game/debug/console.h
+++ b/src/game/debug/console.h
@@ -55,6 +55,12 @@ public:
    /// \brief recalls the next command from history into the input line.
    void nextCommand();
 
+   /// \brief completes the current command line against the registered commands.
+   /// on a unique prefix match the command is filled in and a trailing space is appended;
+   /// on multiple matches the input is extended to the longest common prefix and the
+   /// remaining candidates are printed to the console log.
+   void complete();
+
    /// \brief registers an external command callback and exposes it in the help system.
    /// \param command command keyword used to trigger the callback.
    /// \param callback function invoked when the command is entered.


### PR DESCRIPTION
## Summary

Adds **Tab completion** to the in-game developer console (`F12`, `DEVELOPMENT_MODE`). The console already supported command history via the Up/Down arrows but had no completion for its ~40 registered commands (weapons, extras, items, teleportation, playback, cheats), which made the multi-token commands tedious to type.

## Behavior

Pressing `Tab` matches the current input against the registered command keys:

- **Unique prefix match** → fills in the full command and appends a trailing space (shell-style), e.g. `tps` → `tps `.
- **Multiple matches** → extends the input to the longest common prefix and prints the remaining candidates to the console log for discoverability, e.g. `wea` → `weapon ` + lists `weapon add bow  weapon add gun  weapon add sword  weapon clear`.
- **No match** → no-op.

## Implementation notes

- Matching uses the authoritative `_registered_commands` map (the executable commands, including multi-token keys like `weapon add gun`).
- `Tab` (`0x09`) is already filtered out by `append()`'s printable-range guard (`> 0x1F`), so it never leaks into the input line as a stray character.
- Reuses idioms already present in `console.cpp` (`std::ranges::sort`, `std::min`); no new includes required.
- Change is self-contained to `console.h` / `console.cpp`; formatted with clang-format.

## Testing

- Incremental MSVC Release build compiles and links cleanly (`deceptus.exe` produced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
