### PR TITLE
fix(wasm): render gateway frame and in-air projectiles

### DIFF
--- a/src/game/level/luanode.cpp
+++ b/src/game/level/luanode.cpp
@@ -1385,7 +1385,7 @@ void LuaNode::draw(sf::RenderTarget& target, sf::RenderTarget& /*normal*/, const
    // draw sprite on top of projectiles
    for (auto& weapon : _weapons)
    {
-      weapon->draw(target);
+      weapon->draw(target, states);
    }
 
    for (auto i = 0u; i < _sprites.size(); i++)

--- a/src/game/mechanisms/gateway.cpp
+++ b/src/game/mechanisms/gateway.cpp
@@ -143,6 +143,7 @@ std::shared_ptr<sf::Texture> createRotatedTexture(const sf::Texture& original, c
    render_texture.clear(sf::Color::Transparent);
 
    sf::Sprite sprite;
+   sprite.textureRect = sf::FloatRect{{0.0f, 0.0f}, {width_px, height_px}};
    sprite.origin = {width_px / 2.0f, height_px / 2.0f};
    sprite.rotation = angle;
    sprite.position = {width_px / 2.0f, height_px / 2.0f};


### PR DESCRIPTION
## Summary

Fixes two WASM/VRSFML-only rendering regressions (both confirmed working on the web build; desktop unaffected).

### 1. Gateway portal frame invisible
`Gateway::createRotatedTexture` built the rotated `pa_`/`pi_` frame pieces by drawing a **default-constructed** `sf::Sprite` into a render texture. In VRSFML a default sprite has an empty `textureRect` and draws nothing, so every rotated frame piece became a fully transparent texture and the whole metallic diamond frame disappeared (only the un-rotated background diamond and socket rendered). Desktop SFML avoids this because `sf::Sprite sprite(original)` auto-sizes the rect to the full texture.

Fix: set `sprite.textureRect` before drawing, matching the rest of the file's VRSFML sprite handling.

### 2. Arrows / projectiles invisible in-air
`LuaNode::draw` drew its weapons with `weapon->draw(target)`, dropping the `states` argument. `Weapon::draw`'s own comment notes `states` is "used in WASM to carry the level view." On VRSFML the view transform lives in `states.transform`, so arrows rendered in the wrong coordinate space (off-screen). On desktop `states.transform` is identity (the RenderTarget's view does the mapping) and carries no shader at that point, so passing it is a no-op there.

Fix: `weapon->draw(target, states)`.

## Testing
- Web build: gateway frame renders correctly (jump to tile 223,110); arrow-trap arrows now visible in flight.
- Both changes are dual-platform-safe; desktop rendering unchanged.