### PR TITLE
feat: persist save games and settings to a writable location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1128,6 +1128,8 @@ if(EMSCRIPTEN)
         -sASSERTIONS=1
         -sAUDIO_WORKLET=1
         -sWASM_WORKERS=1
+        # link the IDBFS backend so settings/saves can be persisted to IndexedDB (see src/main.cpp)
+        -lidbfs.js
         "-sEXPORTED_RUNTIME_METHODS=['HEAPU32','HEAPU8','HEAP32','HEAPF32','HEAPU16']"
         --preload-file ${CMAKE_SOURCE_DIR}/data@data
     )

--- a/src/framework/tools/gamepaths.cpp
+++ b/src/framework/tools/gamepaths.cpp
@@ -2,12 +2,20 @@
 #include <cstdlib>
 #include <stdexcept>
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
 namespace GamePaths
 {
 
 std::filesystem::path getGameDataDir()
 {
-#ifdef _WIN32
+#ifdef __EMSCRIPTEN__
+   // on the web the writable tree lives inside the IDBFS mount created in main(), which is
+   // synchronized to IndexedDB so it survives page reloads
+   return std::filesystem::path("/deceptus");
+#elif defined(_WIN32)
    // on windows, use %APPDATA%\deceptus
    const char* appdata_folder = std::getenv("APPDATA");
    if (appdata_folder)
@@ -41,6 +49,41 @@ std::filesystem::path getSettingsDir()
    auto settings_dir = getGameDataDir() / "settings";
    std::filesystem::create_directories(settings_dir);
    return settings_dir;
+}
+
+std::filesystem::path getPreferencesFile(const std::string& filename)
+{
+   const auto target = getSettingsDir() / filename;
+
+   // seed the writable copy from the bundled default on first access; on desktop this also migrates
+   // progress written by earlier versions that still lived in the read-only data/config tree
+   if (!std::filesystem::exists(target))
+   {
+      const auto bundled_default = std::filesystem::path("data/config") / filename;
+      if (std::filesystem::exists(bundled_default))
+      {
+         std::error_code error_code;
+         std::filesystem::copy_file(bundled_default, target, error_code);
+      }
+   }
+
+   return target;
+}
+
+void flushToPersistentStorage()
+{
+#ifdef __EMSCRIPTEN__
+   // persist the IDBFS mount back to IndexedDB so the write survives a page reload
+   EM_ASM(FS.syncfs(
+      false,
+      function(error) {
+         if (error)
+         {
+            console.error("FS.syncfs failed:", error);
+         }
+      }
+   ););
+#endif
 }
 
 std::filesystem::path getLogDir()

--- a/src/framework/tools/gamepaths.h
+++ b/src/framework/tools/gamepaths.h
@@ -21,6 +21,25 @@ std::filesystem::path getGameDataDir();
 std::filesystem::path getSettingsDir();
 
 ///
+/// \brief Resolves a writable preferences file inside the settings directory.
+///
+/// On first access the file is seeded from the bundled default in data/config when it does not
+/// exist yet, which also migrates existing progress written by earlier versions. Reads and writes
+/// should both use the returned path so data/config stays a read-only default source.
+///
+/// \param filename bare file name, e.g. "savestate.json".
+/// \return Absolute path to the writable preferences file.
+///
+std::filesystem::path getPreferencesFile(const std::string& filename);
+
+///
+/// \brief Flushes pending writes to persistent storage.
+///
+/// No-op on desktop. On the web build this triggers an IDBFS sync so saves survive a page reload.
+///
+void flushToPersistentStorage();
+
+///
 /// \brief Returns the log directory and creates it when missing.
 /// \return Log directory path.
 ///

--- a/src/game/config/gameconfiguration.cpp
+++ b/src/game/config/gameconfiguration.cpp
@@ -137,6 +137,9 @@ void GameConfiguration::serializeToFile(const std::string& filename)
    std::string data = serialize();
    std::ofstream file(filename);
    file << data;
+   file.close();
+
+   GamePaths::flushToPersistentStorage();
 }
 
 GameConfiguration& GameConfiguration::getDefaults()

--- a/src/game/config/gameconfiguration.h
+++ b/src/game/config/gameconfiguration.h
@@ -4,6 +4,8 @@
 #include <string>
 #include <utility>
 
+#include "framework/tools/gamepaths.h"
+
 /// \brief stores global game settings and handles json persistence.
 struct GameConfiguration
 {
@@ -36,11 +38,11 @@ struct GameConfiguration
 
    /// \brief loads configuration values from a json file.
    /// \param filename source configuration file path.
-   void deserializeFromFile(const std::string& filename = "data/config/game.json");
+   void deserializeFromFile(const std::string& filename = GamePaths::getPreferencesFile("game.json").string());
 
    /// \brief writes current configuration values to a json file.
    /// \param filename destination configuration file path.
-   void serializeToFile(const std::string& filename = "data/config/game.json");
+   void serializeToFile(const std::string& filename = GamePaths::getPreferencesFile("game.json").string());
 
    /// \brief returns the built-in default configuration values.
    /// \return shared default configuration object.

--- a/src/game/config/inputconfiguration.cpp
+++ b/src/game/config/inputconfiguration.cpp
@@ -5,6 +5,7 @@
 #include <ostream>
 #include <sstream>
 
+#include "framework/tools/gamepaths.h"
 #include "framework/tools/localization.h"
 #include "framework/tools/log.h"
 #include "json/json.hpp"
@@ -465,6 +466,9 @@ void InputConfiguration::serializeToFile(const std::string& filename)
    std::string data = serialize();
    std::ofstream output_file(filename);
    output_file << data;
+   output_file.close();
+
+   GamePaths::flushToPersistentStorage();
 }
 
 void InputConfiguration::serializeToFile()
@@ -498,6 +502,9 @@ void InputConfiguration::saveControllerBindingsToFile(const std::string& filenam
    std::string data = serializeControllerSection();
    std::ofstream output_file(filename);
    output_file << data;
+   output_file.close();
+
+   GamePaths::flushToPersistentStorage();
 }
 
 void InputConfiguration::setCurrentFilename(const std::string& filename)
@@ -512,12 +519,12 @@ const std::string& InputConfiguration::getCurrentFilename() const
 
 std::string InputConfiguration::keyboardFilename()
 {
-   return "data/config/controls.json";
+   return GamePaths::getPreferencesFile("controls.json").string();
 }
 
 std::string InputConfiguration::controllerFilename(const std::string& guid)
 {
-   return "data/config/controls_controller_" + guid + ".json";
+   return GamePaths::getPreferencesFile("controls_controller_" + guid + ".json").string();
 }
 
 InputConfiguration& InputConfiguration::getDefaults()

--- a/src/game/state/savestate.cpp
+++ b/src/game/state/savestate.cpp
@@ -108,6 +108,9 @@ void SaveState::serializeToFile(const std::string& filename)
    std::string data = serialize();
    std::ofstream file(filename);
    file << data;
+   file.close();
+
+   GamePaths::flushToPersistentStorage();
 }
 
 std::string SaveState::serialize()
@@ -178,4 +181,6 @@ void SaveState::writePlayerStatsToFile(const std::string& filename) const
 
    output_file << save_states_json.dump(4);
    output_file.close();
+
+   GamePaths::flushToPersistentStorage();
 }

--- a/src/game/state/savestate.h
+++ b/src/game/state/savestate.h
@@ -5,6 +5,7 @@
 
 #include "json/json.hpp"
 
+#include "framework/tools/gamepaths.h"
 #include "game/player/playerinfo.h"
 
 /// \brief stores one save-slot snapshot, including player info and per-level state.
@@ -60,15 +61,15 @@ struct SaveState
 
    /// \brief loads save slots from a json file and deserializes into the static array.
    /// \param filename path to the save json file.
-   static void deserializeFromFile(const std::string& filename = "data/config/savestate.json");
+   static void deserializeFromFile(const std::string& filename = GamePaths::getPreferencesFile("savestate.json").string());
 
    /// \brief serializes all save slots and writes them to a json file.
    /// \param filename path to the destination save json file.
-   static void serializeToFile(const std::string& filename = "data/config/savestate.json");
+   static void serializeToFile(const std::string& filename = GamePaths::getPreferencesFile("savestate.json").string());
 
    /// \brief patches only the current slot's player stats in an existing save file.
    /// \param filename path to the save json file to update.
-   void writePlayerStatsToFile(const std::string& filename = "data/config/savestate.json") const;
+   void writePlayerStatsToFile(const std::string& filename = GamePaths::getPreferencesFile("savestate.json").string()) const;
 
 private:
    /// \brief serializes all slots into formatted json text.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,10 @@
 #include <memory>
 #include <sstream>
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
 #include "framework/tools/gamepaths.h"
 #include "framework/tools/localization.h"
 #include "framework/tools/logthread.h"
@@ -48,6 +52,26 @@ int WINAPI WinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPSTR /
 int main(int /*argc*/, char** /*argv*/)
 #endif
 {
+#ifdef __EMSCRIPTEN__
+   // mount a persistent IDBFS-backed filesystem and load its contents from IndexedDB before any
+   // settings or save files are resolved. ASYNCIFY lets us block until the initial load completes,
+   // so GamePaths sees the persisted data on startup.
+   EM_ASM(FS.mkdir('/deceptus'); FS.mount(IDBFS, {}, '/deceptus'); Module.__persistent_fs_synced = 0; FS.syncfs(
+      true,
+      function(error) {
+         if (error)
+         {
+            console.error("initial FS.syncfs failed:", error);
+         }
+         Module.__persistent_fs_synced = 1;
+      }
+   ););
+   while (emscripten_run_script_int("Module.__persistent_fs_synced") == 0)
+   {
+      emscripten_sleep(50);
+   }
+#endif
+
    GamePaths::createGameDirectories();
 
    // setup logging to file


### PR DESCRIPTION
## Summary

Save games and settings were written to hardcoded `data/config/*.json` paths. On WASM that tree is the **read-only, non-persistent** Emscripten preload bundle, so progress could never be saved and was lost on every reload; on desktop it wrote into the game's install tree rather than a proper user-data location.

This routes the read/write configs through the existing `GamePaths` abstraction (previously used only for logs/recordings), seeds them from the bundled defaults on first run, and adds real IndexedDB-backed persistence on WASM.

## What changed

**Central mechanism** — two new helpers in `GamePaths` (`src/framework/tools/gamepaths.{h,cpp}`):
- `getPreferencesFile(name)` → returns the writable path under `getSettingsDir()`, seeding it once from `data/config/<name>` when absent. This both **migrates existing desktop progress** and provides first-run defaults.
- `flushToPersistentStorage()` → no-op on desktop; `FS.syncfs(false)` on WASM.

**Routed through it** (reads + writes): `savestate.json`, `game.json`, `controls.json`, and per-controller bindings — via each class's single path source (`SaveState`, `GameConfiguration`, `InputConfiguration`). A `flushToPersistentStorage()` call was added after every write.

**Left untouched:** read-only configs (`levels`, `tweaks`, `menus`, `achievements`, `treasures`, …) keep reading directly from `data/config`, so shipped-data updates still reach players and aren't shadowed by a stale user copy. Debug-only `camera.json`/`physics.json` are also left as-is so hand-tuned dev values aren't shadowed.

**WASM persistence:**
- `main.cpp` mounts IDBFS at `/deceptus` and blocks on an initial `FS.syncfs(true)` (via the already-enabled ASYNCIFY) **before** any config is resolved.
- `GamePaths::getGameDataDir()` returns `/deceptus` on Emscripten, so the seed-copy from the read-only `/data/config` MEMFS into the persistent mount works identically to desktop.
- `-lidbfs.js` added to the WASM link options.

Resulting locations: `%APPDATA%\deceptus\settings` (Windows), `~/.local/share/deceptus/settings` (Linux/macOS), IDBFS `/deceptus/settings` → IndexedDB (WASM).

## Testing

- **Desktop (MSVC):** compiles and links `deceptus.exe`.
- **WASM (emscripten):** compiles and links `deceptus.html`; `-lidbfs.js` accepted (no IDBFS-undefined link error).
- **Runtime — still to confirm in a browser:** that a save/setting survives a page reload (IDBFS load-on-start + flush-on-save) and that a fresh profile seeds from the preloaded defaults. Desktop migration and re-seed-after-delete should also be spot-checked per the plan checklist.

## Notes

`main()` assumes a fresh MEMFS on page load (`FS.mkdir('/deceptus')`), which holds for normal loads.