### PR TITLE
fix(wasm): restore the player lantern helmet, the ingame HUD and the inventory overlays

### DIFF
--- a/src/game/ingamemenu/ingamemenuarchives.cpp
+++ b/src/game/ingamemenu/ingamemenuarchives.cpp
@@ -133,6 +133,7 @@ InGameMenuArchives::InGameMenuArchives()
 void InGameMenuArchives::draw(sf::RenderTarget& window, sf::RenderStates states)
 {
    InGameMenuPage::draw(window, states);
+   applyPageView(states);
 
    if (_selected_index == 2)
    {

--- a/src/game/ingamemenu/ingamemenuinventory.cpp
+++ b/src/game/ingamemenu/ingamemenuinventory.cpp
@@ -304,6 +304,7 @@ Inventory& InGameMenuInventory::getInventory()
 void InGameMenuInventory::draw(sf::RenderTarget& window, sf::RenderStates states)
 {
    InGameMenuPage::draw(window, states);
+   applyPageView(states);
    drawInventoryItems(window, states);
    drawInventoryTexts(window, states);
 }
@@ -501,6 +502,11 @@ void InGameMenuInventory::updateButtons()
 void InGameMenuInventory::drawInventoryItems(sf::RenderTarget& window, sf::RenderStates states)
 {
    const auto& inventory = getInventory();
+
+#ifdef __EMSCRIPTEN__
+   // vrsfml sprites carry no texture, it has to come from the render states
+   states.texture = _inventory_texture.get();
+#endif
 
    const auto move_offset = getMoveOffset();
    const auto offset_x_px = item_grid_offset_x_px + move_offset.value_or(0.0f);

--- a/src/game/ingamemenu/ingamemenupage.cpp
+++ b/src/game/ingamemenu/ingamemenupage.cpp
@@ -47,15 +47,22 @@ std::ostream& operator<<(std::ostream& os, InGameMenuPage::Animation animation)
    return os;
 }
 
-void InGameMenuPage::draw(sf::RenderTarget& window, sf::RenderStates states)
+void InGameMenuPage::applyPageView(sf::RenderStates& states) const
 {
+#ifdef __EMSCRIPTEN__
    const auto w = GameConfiguration::getInstance()._view_width;
    const auto h = GameConfiguration::getInstance()._view_height;
+   states.view = sf::View::fromRect(sf::FloatRect{{0.0f, 0.0f}, {static_cast<float>(w), static_cast<float>(h)}});
+#endif
+}
 
+void InGameMenuPage::draw(sf::RenderTarget& window, sf::RenderStates states)
+{
 #ifdef __EMSCRIPTEN__
-   const auto view = sf::View::fromRect(sf::FloatRect{{0.0f, 0.0f}, {static_cast<float>(w), static_cast<float>(h)}});
-   states.view = view;
+   applyPageView(states);
 #else
+   const auto w = GameConfiguration::getInstance()._view_width;
+   const auto h = GameConfiguration::getInstance()._view_height;
    sf::View view(sf::FloatRect({0.0f, 0.0f}, {static_cast<float>(w), static_cast<float>(h)}));
    window.setView(view);
 #endif

--- a/src/game/ingamemenu/ingamemenupage.h
+++ b/src/game/ingamemenu/ingamemenupage.h
@@ -89,6 +89,12 @@ public:
    std::optional<Animation> getAnimation() const;
 
 protected:
+   /// \brief applies the page's screen-space view to the given render states.
+   ///        needed because 'draw' takes its states by value, so subclasses drawing after the base
+   ///        implementation would otherwise lose the view (which travels in the states on wasm).
+   /// \param states render states to update; no-op on desktop, where the view lives on the target.
+   void applyPageView(sf::RenderStates& states) const;
+
    /// \brief loads layers from the configured PSD file into drawable page structures.
    void load();
 

--- a/src/game/items/item.cpp
+++ b/src/game/items/item.cpp
@@ -1,6 +1,6 @@
 #include "item.h"
 
-void Item::draw(sf::RenderTarget& /*target*/)
+void Item::draw(sf::RenderTarget& /*target*/, const sf::RenderStates& /*states*/)
 {
 }
 

--- a/src/game/items/item.h
+++ b/src/game/items/item.h
@@ -15,7 +15,8 @@ public:
 
    /// \brief draws item-specific visuals.
    /// \param target SFML render target that receives the item graphics.
-   virtual void draw(sf::RenderTarget& target);
+   /// \param states render states applied to the item graphics (carries .view for WASM camera transform).
+   virtual void draw(sf::RenderTarget& target, const sf::RenderStates& states);
 
    /// \brief updates item state for the current frame.
    /// \param dt elapsed frame time since the previous update.

--- a/src/game/items/itemlantern.cpp
+++ b/src/game/items/itemlantern.cpp
@@ -28,7 +28,7 @@ ItemLantern::ItemLantern()
    sfcompat::setTextureRect(*_helmet_sprite_l, sf::IntRect({24, 1776}, {24, 24}));
 }
 
-void ItemLantern::draw(sf::RenderTarget& target)
+void ItemLantern::draw(sf::RenderTarget& target, const sf::RenderStates& states)
 {
    if (!_enabled)
    {
@@ -46,9 +46,13 @@ void ItemLantern::draw(sf::RenderTarget& target)
    }
 
 #ifdef __EMSCRIPTEN__
-   target.draw(player->isPointingRight() ? *_helmet_sprite_r : *_helmet_sprite_l, sf::RenderStates{.texture = _player_texture.get()});
+   // the incoming states carry the level view; without it the helmet would be drawn with the
+   // render target's default view and end up outside the visible camera rect
+   auto helmet_states = states;
+   helmet_states.texture = _player_texture.get();
+   target.draw(player->isPointingRight() ? *_helmet_sprite_r : *_helmet_sprite_l, helmet_states);
 #else
-   target.draw(player->isPointingRight() ? *_helmet_sprite_r : *_helmet_sprite_l);
+   target.draw(player->isPointingRight() ? *_helmet_sprite_r : *_helmet_sprite_l, states);
 #endif
 }
 

--- a/src/game/items/itemlantern.h
+++ b/src/game/items/itemlantern.h
@@ -15,7 +15,8 @@ public:
 
    /// \brief draws the lantern light circle when the item is enabled.
    /// \param target SFML render target that receives the light sprite.
-   void draw(sf::RenderTarget& target) override;
+   /// \param states render states applied to the helmet sprite (carries .view for WASM camera transform).
+   void draw(sf::RenderTarget& target, const sf::RenderStates& states) override;
 
    /// \brief updates the light position to follow the current player.
    /// \param dt elapsed frame time since the previous update.

--- a/src/game/layers/infolayer.cpp
+++ b/src/game/layers/infolayer.cpp
@@ -335,16 +335,24 @@ void InfoLayer::updateHealthLayerOffsets()
    // -> move out health bar
    // if game state 'not running' detected
    // -> reset
-   if (GameState::getInstance().getMode() == ExecutionMode::NotRunning)
-   {
-      _hide_time_health.reset();
-      _show_time_health.reset();
-      _player_health_x_offset = x_offset_hidden;
-   }
-
    const auto now = GlobalClock::getInstance().getElapsedTime();
    constexpr auto duration_show_s = 1.0f;
    constexpr auto duration_hide_s = 1.0f;
+
+   if (GameState::getInstance().getMode() == ExecutionMode::NotRunning)
+   {
+      _hide_time_health.reset();
+      _player_health_x_offset = x_offset_hidden;
+
+      // a pending slide-in must be deferred here, not dropped: wasm loads levels synchronously
+      // inside the update loop, so setLoading(false) can land in a frame where the queued
+      // 'running' mode has not been synced yet. re-stamping keeps the effect at its first frame
+      // (fully hidden) until the game actually runs.
+      if (_show_time_health.has_value())
+      {
+         _show_time_health = now;
+      }
+   }
 
    auto effect_elapsed = false;
 
@@ -918,7 +926,14 @@ void InfoLayer::drawInventoryItem(sf::RenderTarget& window, sf::RenderStates sta
          continue;
       }
 
+#ifdef __EMSCRIPTEN__
+      // vrsfml sprites carry no texture and the view travels in the render states
+      auto item_states = states;
+      item_states.texture = _inventory_texture.get();
+      window.draw(*_inventory_sprites[i], item_states);
+#else
       window.draw(*_inventory_sprites[i]);
+#endif
       _slot_item_layers[i]->draw(window, states);
    }
 }

--- a/src/game/player/itemsystem.cpp
+++ b/src/game/player/itemsystem.cpp
@@ -20,13 +20,13 @@ void ItemSystem::update(const sf::Time& dt)
    }
 }
 
-void ItemSystem::draw(sf::RenderTarget& target)
+void ItemSystem::draw(sf::RenderTarget& target, const sf::RenderStates& states)
 {
    for (auto& item : _slots)
    {
       if (item)
       {
-         item->draw(target);
+         item->draw(target, states);
       }
    }
 }

--- a/src/game/player/itemsystem.h
+++ b/src/game/player/itemsystem.h
@@ -20,7 +20,8 @@ public:
 
    /// \brief draws all currently equipped item instances.
    /// \param target render target passed to each equipped item.
-   void draw(sf::RenderTarget& target);
+   /// \param states render states passed to each equipped item (carries .view for WASM camera transform).
+   void draw(sf::RenderTarget& target, const sf::RenderStates& states);
 
    /// \brief ensures a runtime item instance exists for an inventory item key.
    /// \param item_name inventory item key to instantiate.

--- a/src/game/player/player.cpp
+++ b/src/game/player/player.cpp
@@ -365,7 +365,7 @@ void Player::draw(sf::RenderTarget& color, sf::RenderTarget& normal, const sf::R
    );
 
    // draw equipped items
-   SaveState::getPlayerInfo()._items.draw(color);
+   SaveState::getPlayerInfo()._items.draw(color, states);
 }
 
 void Player::drawStencil(sf::RenderTarget& color, const sf::RenderStates& states)


### PR DESCRIPTION
Three overlays were missing on the web build while working fine on desktop. Two distinct root causes, neither of them a rendering failure.

## 1. Draw paths that drop `sf::RenderStates`

Under VRSFML the active view travels in `sf::RenderStates::view` (`View view{}` means "computed from the render target's size if unset"), and sprites carry no texture. Desktop instead calls `target.setView()`, which persists on the target so later draws inherit it. Any draw that receives no states — or builds a fresh `sf::RenderStates` — therefore renders in screen space at world coordinates and lands outside the camera rect.

Three sites had this:

- **Lantern helmet.** `Player::draw` called `_items.draw(color)` with no states, and `ItemLantern::draw` built its own `sf::RenderStates{.texture = ...}`. The states are now threaded through `Item::draw`, `ItemSystem::draw` and `ItemLantern::draw`, so the helmet uses the same view as the player animation it sits on.
- **HUD item-slot icon.** `InfoLayer::drawInventoryItem` drew the icon sprite with no states at all.
- **Inventory / archives pages.** `InGameMenuPage::draw` takes its states **by value**, so the ortho view it sets never reached anything a subclass drew after calling the base. The inventory page's icons rendered as untextured quads at wrong positions, and `InGameMenuArchives::drawTreasures` had the identical defect. Fixed with a protected `InGameMenuPage::applyPageView()` helper (a no-op on desktop) called from both subclasses.

## 2. The HUD was parked off-screen

`InfoLayer` slides the health, stamina and item-slot group in from `x_offset_hidden = -220`. On wasm `Game::loadLevel` runs the loader inline rather than through `std::async`, so `setLoading(true)` and `setLoading(false)` both land inside one `Game::update()` call — and that frame still reports `ExecutionMode::NotRunning`, because `GameState::sync()` runs at the *end* of update while the load request is handled near the start.

The `NotRunning` branch of `updateHealthLayerOffsets` then reset `_show_time_health`, discarding the slide-in that had just been requested, so the offset never moved off `-220`. It now re-stamps the show time instead of resetting it, which defers a pending slide-in (pinned at its first frame, fully hidden) until the game actually runs.

Desktop is unaffected: its async load means `setLoading(false)` always arrives on a frame that is already running.

## Desktop impact

None intended. Every change is either inside an `#ifdef __EMSCRIPTEN__` branch or a no-op on desktop. At `ZDepth::Player` the states now passed to the items are empty on desktop, since stencil writing starts at `Player + 1`.

## Verification

- Desktop build (MSVC, vanilla SFML 3) and wasm build (VRSFML via Docker/Emscripten) both compile and link.
- `clang-format -i` run on every touched file.
- In-browser, driven through the Chrome DevTools Protocol: the helmet lamp renders on the player's head; the HUD slides in on the initial level load; the item icon appears in slot X; and the inventory page shows the grid icon, the equipped-slot icon, the title and the description in the right panel.
- The desktop inventory page was captured for side-by-side comparison.

A useful diagnostic for the second bug: triggering a death-driven reload (`damage 100` in the F12 console) made the HUD appear correctly, which ruled out rendering and pointed at state/timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
