### PR TITLE
fix(wasm): keep the browser in fullscreen when the viewport re-fits

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -254,6 +254,13 @@ void Game::initializeWindow()
 
    showGpu();
 
+   initializeRenderTargets();
+}
+
+void Game::initializeRenderTargets()
+{
+   const auto& game_config = GameConfiguration::getInstance();
+
    // reset render textures if needed
    if (_window_render_texture)
    {
@@ -1174,9 +1181,16 @@ void Game::changeResolution(int32_t w, int32_t h)
    // clamp to desktop limits to prevent SFML errors
    config.clampResolutionToDesktop();
 
+#ifdef __EMSCRIPTEN__
+   // recreating the render window would drop the browser out of fullscreen, since the new window is
+   // created with fullscreen=false. entering fullscreen resizes the viewport, which invokes this via
+   // refitToViewport(), so a recreation here makes the game kick itself straight back to windowed.
+   // resizing the existing canvas keeps the fullscreen state and the gl context intact.
+   _window->setSize({static_cast<uint32_t>(config._video_mode_width), static_cast<uint32_t>(config._video_mode_height)});
+   initializeRenderTargets();
+#else
    initializeWindow();
 
-#ifndef __EMSCRIPTEN__
    _menu_background = std::make_unique<MenuBackgroundScene>();
 #endif
 
@@ -1228,6 +1242,11 @@ void Game::processEvent(const sf::Event& event)
    else if (auto* resized_event = event.getIf<sf::Event::Resized>())
    {
 #ifdef __linux__
+      return;
+#endif
+#ifdef __EMSCRIPTEN__
+      // on the web the canvas is resized by the game itself (refitToViewport), so acting on the
+      // resulting event would feed arbitrary, non-integer-multiple sizes back into changeResolution
       return;
 #endif
       // only handle intentional user resizes, not OS-generated DPI adjustments

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -70,6 +70,10 @@ private:
    /// \brief creates or recreates window and render textures from configuration.
    void initializeWindow();
 
+   /// \brief creates or recreates the render textures and deferred render targets for the
+   ///        configured video mode, without touching the window itself.
+   void initializeRenderTargets();
+
    /// \brief initializes game controller integration and pause bindings.
    void initializeController();
 


### PR DESCRIPTION
Clicking the Fullscreen button on the regular `deceptus.html` flickered for a moment and dropped straight back to windowed. The game was kicking itself out.

## Root cause

Entering fullscreen resizes the viewport, which fires the emscripten resize callback registered in `Game::loop()`. That calls `refitToViewport()` → `changeResolution()`, which recreated the `sf::RenderWindow`. On emscripten the new window is created with `fullscreen = false`, so SDL exits the document's fullscreen state.

An event trace confirms it — the canvas *does* become the fullscreen element, and a second `fullscreenchange` fires ~100ms later, right after the recreation:

```
t+  228ms window-resize      fs=canvas inner=800x544 canvas=640x360
t+  228ms fullscreenchange   fs=canvas inner=800x544 canvas=640x360
t+  331ms window-resize      fs=None   inner=1382x748 canvas=1280x720
t+  331ms fullscreenchange   fs=None   inner=1382x748 canvas=1280x720
```

A bare `canvas.requestFullscreen()` behaves identically, so emscripten's `requestFullscreen` helper is not involved.

There was a second contributor: `sf::Event::Resized` fed the raw canvas size straight back into `changeResolution`, and each recreation produced another resize event. A single fullscreen click caused **four** window recreations in 230ms — 800x600, 640x360, 800x600, 1280x720 — none of the intermediate sizes being an integer multiple of the 640x360 base view.

## Fix

- Extract the render-target half of `initializeWindow()` into `initializeRenderTargets()`.
- On emscripten, `changeResolution()` resizes the existing window (`setSize`) and rebuilds only the render textures and deferred targets. The canvas element, the GL context and the fullscreen state all survive.
- Ignore `sf::Event::Resized` on emscripten, next to the existing `__linux__` guard. On the web the canvas is resized by the game itself, so `refitToViewport()` is the authoritative path.

Side benefit: a resize no longer re-shows the splash screen or re-queries the GPU.

## Desktop impact

None. Desktop still calls `initializeWindow()`, whose behaviour is unchanged — only its tail moved into a helper it calls itself. The desktop-only `toggleFullScreen()` is untouched; it has always managed its own window and render targets separately.

## Verification

Headless Chrome misreports fullscreen metrics (it claims an 800x600 screen while the window is 1400x900), so this was verified in a real browser window:

- Fullscreen holds, with a single `fullscreenchange` and a single resolution change.
- The buffer becomes 1920x1080 — a 3x integer scale that maps 1:1 to device pixels at dpr 1.25, so fullscreen stays pixel-perfect.
- Ordinary browser resizing still re-fits (640x360 ↔ 1280x720), both rendering correctly.
- WASM (VRSFML via Docker/Emscripten) and desktop MSVC builds both compile; desktop smoke-tested by launching and loading a level.

Untested: the itch shell (`emscripten/itch_index.html`), which has its own canvas CSS handling. It goes through the same `refitToViewport()` path, so it should benefit equally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
