### PR TITLE
fix: snap the hud slide to its target when the effect runs out

### DIFF
--- a/src/game/layers/infolayer.cpp
+++ b/src/game/layers/infolayer.cpp
@@ -354,15 +354,16 @@ void InfoLayer::updateHealthLayerOffsets()
       }
    }
 
-   auto effect_elapsed = false;
-
+   // when an effect runs out its offset is snapped to the final value rather than left wherever the
+   // last evaluated frame happened to put it. a single long frame (a fullscreen transition, a level
+   // load) can step the normalized time straight past 1.0, which used to leave the hud parked a few
+   // pixels short of its target for good, since nothing touches the offset afterwards.
    if (_hide_time_health.has_value())
    {
       // evaluate hide time
       const auto time_diff_s = (now - _hide_time_health.value()).asSeconds();
       const auto time_diff_norm = time_diff_s / duration_hide_s;
-      effect_elapsed = time_diff_norm > 1.0f;
-      if (!effect_elapsed)
+      if (time_diff_norm <= 1.0f)
       {
          const auto time_diff_norm_clamped = std::clamp(time_diff_norm, 0.0f, 1.0f);
          const auto time_diff_eased = Easings::easeInQuad<float>(time_diff_norm_clamped);
@@ -370,6 +371,7 @@ void InfoLayer::updateHealthLayerOffsets()
       }
       else
       {
+         _player_health_x_offset = x_offset_hidden;
          _hide_time_health.reset();
       }
    }
@@ -377,9 +379,8 @@ void InfoLayer::updateHealthLayerOffsets()
    {
       // evaluate show time
       const auto time_diff_s = (now - _show_time_health.value()).asSeconds();
-      const auto time_diff_norm = time_diff_s / duration_hide_s;
-      effect_elapsed = time_diff_norm > 1.0f;
-      if (!effect_elapsed)
+      const auto time_diff_norm = time_diff_s / duration_show_s;
+      if (time_diff_norm <= 1.0f)
       {
          const auto time_diff_norm_clamped = std::clamp(time_diff_norm, 0.0f, 1.0f);
          const auto time_diff_eased = Easings::easeOutCubic<float>(time_diff_norm_clamped);
@@ -387,13 +388,9 @@ void InfoLayer::updateHealthLayerOffsets()
       }
       else
       {
+         _player_health_x_offset = 0.0f;
          _show_time_health.reset();
       }
-   }
-
-   if (effect_elapsed)
-   {
-      return;
    }
 
    std::ranges::for_each(


### PR DESCRIPTION
The HUD could end up parked a few pixels short of its target position permanently — most visibly when going fullscreen shortly after a level load.

## Root cause

`InfoLayer::updateHealthLayerOffsets()` evaluated the slide, and once the normalized time passed 1.0 it reset the timestamp and returned early — *before* applying the positions:

```cpp
effect_elapsed = time_diff_norm > 1.0f;
...
else { _show_time_health.reset(); }

if (effect_elapsed) { return; }   // returns before the positions are written
```

So the last offset actually written to the sprites is the **previous** frame's. Normally that frame sits at t≈0.99 and the error is a fraction of a pixel — invisible. But a single long frame steps the normalized time straight past 1.0: from t=0.6, `easeOutCubic(0.6)` = 0.936, so the offset freezes at −14px, and nothing touches it again once the timestamp is gone. A fullscreen transition is exactly such a long frame, since it rebuilds the render targets.

## Fix

Snap the offset to its final value when an effect runs out — `x_offset_hidden` for the hide, `0` for the show — and fall through to apply the positions instead of returning. `effect_elapsed` is no longer needed.

Also divide by `duration_show_s` rather than `duration_hide_s` in the show branch. Both are `1.0f`, so this is behaviour-neutral, but it is clearly the intent and `duration_show_s` was otherwise unused.

## Platform

Platform-neutral. The same latent bug exists on desktop; it was simply invisible on the web before #382, because the slide-in never ran there at all.

## Verification — please read

Honest about what is and is not confirmed:

- **Confirmed:** desktop (MSVC) and wasm (VRSFML) builds both compile. `clang-format` run.
- **Confirmed:** the failing scenario is reachable and easy to hit — driving the web build to click Fullscreen the instant the game logs `level loading finished` lands inside the 1s slide-in window.
- **Not confirmed by measurement:** I could not verify the exact pixel offset before/after with my screenshot tooling. A shifted HUD gets *clipped* at the screen edge, so the naive "leftmost bright column" metric reads the same either way, and my follow-up attempt to measure an interior feature (the health bar's left tip) failed to locate it in the fullscreen capture. The reasoning above is from the code path, plus a field report of exactly this symptom.

So: the mechanism is solid and the fix is small and safe, but it has not been visually A/B'd. Worth a quick manual check that the HUD still slides in cleanly on desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
