### PR TITLE
fix(wasm): render tmx image layers

### DIFF
--- a/src/game/mechanisms/imagelayer.cpp
+++ b/src/game/mechanisms/imagelayer.cpp
@@ -71,14 +71,18 @@ void ImageLayer::draw(sf::RenderTarget& target, sf::RenderTarget& normal, const 
       return;
    }
 
+   // the texture has to travel in the render states, vrsfml sprites do not own one
+   const auto* texture = _texture->getTexture().get();
+
    if (_parallax_settings.has_value())
    {
-      target.draw(*_sprite, sf::RenderStates{.blendMode = _blend_mode, .view = _parallax_view});
+      target.draw(*_sprite, sf::RenderStates{.blendMode = _blend_mode, .view = _parallax_view, .texture = texture});
    }
    else
    {
       sf::RenderStates draw_states = states;
       draw_states.blendMode = _blend_mode;
+      draw_states.texture = texture;
       target.draw(*_sprite, draw_states);
    }
 #else
@@ -100,6 +104,11 @@ void ImageLayer::update(const sf::Time& dt)
          _sprite = std::make_unique<sf::Sprite>();
          _sprite->position = _position;
          _sprite->color = _color;
+
+         // vrsfml sprites are not constructed from a texture, so the texture rect stays empty
+         // (and nothing is drawn) unless it is set to cover the texture explicitly
+         const auto texture_size = _texture->getTexture()->getSize();
+         _sprite->textureRect = sf::FloatRect{{0.0f, 0.0f}, {static_cast<float>(texture_size.x), static_cast<float>(texture_size.y)}};
 #else
          _sprite = std::make_unique<sf::Sprite>(*_texture->getTexture());
          _sprite->setPosition(_position);


### PR DESCRIPTION
TMX image layers were invisible in the web build — the black foreground silhouettes (hanging cage, vines, chains, the shapes along the bottom) never showed up, while desktop rendered them fine.

## Root cause

Two things were missing, both consequences of VRSFML sprites not owning a texture:

1. **Empty texture rect.** On emscripten the sprite is default-constructed (`std::make_unique<sf::Sprite>()`), so `textureRect` stays `{0,0,0,0}` and nothing is rasterized. Desktop passes the texture to the `sf::Sprite` constructor, which sizes the rect to the whole texture automatically.
2. **No texture in the render states.** Neither emscripten draw path set `states.texture`, so even a correctly sized sprite would have sampled nothing. The parallax branch built a fresh `sf::RenderStates{.blendMode, .view}`; the non-parallax branch copied the incoming states (which do carry the level view) but never added the texture.

## Fix

- Set `textureRect` from the texture size when the sprite is created.
- Put the texture into the render states in both emscripten draw paths.

The texture is fetched at draw time rather than cached on the sprite, because `LazyTexture` streams chunks in and out and may replace the texture object between frames.

## Desktop impact

None — both changes sit inside existing `#ifdef __EMSCRIPTEN__` branches. Desktop build compiles unchanged.

## Verification

- WASM (VRSFML via Docker/Emscripten) and desktop MSVC builds both compile; `clang-format` run.
- Verified in the browser: the hanging cage, the vines at the top right, the chain and the dark foreground shapes all render in the starting room, matching the desktop build.

Note this is the same underlying bug class as #382 — a draw path that does not supply what VRSFML expects in `sf::RenderStates`. Worth grepping for other `sf::Sprite` instances created without a texture on emscripten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
