### PR TITLE
feat(lua): allow sprites and projectiles to use their own z index

### DIFF
--- a/data/scripts/enemies/frog_blue.lua
+++ b/data/scripts/enemies/frog_blue.lua
@@ -36,6 +36,8 @@ v2d = require "data/scripts/enemies/vectorial2"
 -- orb_path=straight               -- straight or sine
 -- orb_speed=160.0                 -- fireball travel speed
 -- orb_lifetime=3000               -- lifetime in milliseconds before disappearing
+-- orb_z=40                        -- z index the travelling orb is drawn at
+-- orb_collision_size=16           -- edge length of the square hit area centered on the visible orb
 -- wave_strength=24.0              -- vertical size for sine movement
 -- wave_speed=8.0                  -- sine frequency/speed
 -- idle_anim_speed=10.0
@@ -65,6 +67,16 @@ FIREBALL_HEIGHT = 120
 FIREBALL_ROW_Y = 312
 FIREBALL_FRAME_SPACING = 120
 FIREBALL_FRAME_COUNT = 8
+-- The orb graphic does not fill its 120x120 frame; the visible dot sits at (36, 60) inside the frame
+-- while the engine draws the sprite centered on the node position plus the sprite offset.
+-- Both values are needed to place the hit rect on the dot instead of on the frame center.
+FIREBALL_VISUAL_CENTER_X = 36
+FIREBALL_VISUAL_CENTER_Y = 60
+-- Size of the bright core of the orb. The surrounding glow is intentionally not part of the hit area.
+DEFAULT_ORB_COLLISION_SIZE = 16
+-- z index the orb is drawn at. The frog itself stays on its own z index, so the orb can travel
+-- in front of foreground tiles without dragging the frog along.
+DEFAULT_ORB_Z = 40
 -- Shooting animation timing. The blue frog frames are 48x48.
 -- The blue frog starts at grid column 17 on the shared frog sprite sheet.
 -- For the attack row, this maps to these grid cells:
@@ -139,6 +151,8 @@ _orb_speed = DEFAULT_FIREBALL_SPEED
 _orb_lifetime = DEFAULT_ORB_LIFETIME
 _wave_strength = DEFAULT_WAVE_STRENGTH
 _wave_speed = DEFAULT_WAVE_SPEED
+_orb_z = DEFAULT_ORB_Z
+_orb_collision_size = DEFAULT_ORB_COLLISION_SIZE
 
 -- health and death variables
 _energy = 30  -- frog's health points
@@ -175,6 +189,8 @@ properties = {
    orb_path = DEFAULT_ORB_PATH,
    orb_speed = DEFAULT_FIREBALL_SPEED,
    orb_lifetime = DEFAULT_ORB_LIFETIME,
+   orb_z = DEFAULT_ORB_Z,
+   orb_collision_size = DEFAULT_ORB_COLLISION_SIZE,
 
    -- sine path tuning
    wave_strength = DEFAULT_WAVE_STRENGTH,
@@ -195,6 +211,7 @@ function initialize()
    setSpriteOffset(1, 36, -12)
    setSpriteScale(1, 1.0, 1.0)
    setSpriteVisible(1, false)
+   setSpriteZ(1, _orb_z)
 
    updateSprite(0.0)
 end
@@ -380,10 +397,13 @@ function updateFireball(dt)
    setSpriteScale(1, 1.0, 1.0)
    setSpriteVisible(1, true)
 
-   -- Use a smaller hit area inside the orb so the visual feels fair.
-   local hitbox_x = _position:getX() + fireball_offset_x + 18
-   local hitbox_y = _position:getY() + fireball_offset_y + 18
-   if not _fireball_hit_player and intersectsWithPlayer(hitbox_x, hitbox_y, 36, 36) then
+   -- Use a smaller hit area inside the orb so the visual feels fair. The rect is centered on the
+   -- visible dot, which is offset from the center of the 120x120 sprite frame.
+   local orb_center_x = _position:getX() + fireball_offset_x + FIREBALL_VISUAL_CENTER_X - FIREBALL_WIDTH / 2
+   local orb_center_y = _position:getY() + fireball_offset_y + FIREBALL_VISUAL_CENTER_Y - FIREBALL_HEIGHT / 2
+   local hitbox_x = orb_center_x - _orb_collision_size / 2
+   local hitbox_y = orb_center_y - _orb_collision_size / 2
+   if not _fireball_hit_player and intersectsWithPlayer(hitbox_x, hitbox_y, _orb_collision_size, _orb_collision_size) then
       damage(properties.damage, 0, 0)
       _fireball_hit_player = true
    end
@@ -582,6 +602,21 @@ function writeProperty(key, value)
       if (v ~= nil and v > 0) then
          _orb_lifetime = v
          properties.orb_lifetime = v
+      end
+
+   elseif (key == "orb_collision_size") then
+      local collision_size = tonumber(value)
+      if (collision_size ~= nil and collision_size > 0) then
+         _orb_collision_size = collision_size
+         properties.orb_collision_size = collision_size
+      end
+
+   elseif (key == "orb_z") then
+      local z_index = tonumber(value)
+      if (z_index ~= nil) then
+         _orb_z = z_index
+         properties.orb_z = z_index
+         setSpriteZ(1, _orb_z)
       end
 
    elseif (key == "wave_strength") then

--- a/doc/lua_interface/readme.md
+++ b/doc/lua_interface/readme.md
@@ -539,6 +539,27 @@ Sets the for linear velocity of this node
 |2|float|Velocity y (in meters)|
 
 
+## `setProjectileZ`
+
+Set the z layer the projectiles of a given weapon are drawn at. By default projectiles are drawn at the z layer of
+the node that fired them (see `setZ`). Assigning an explicit z layer to a weapon lets its projectiles travel in
+front of or behind level layers without moving the enemy itself.
+
+Valid z layers range from 0 to 50. The player is drawn at z layer 20.
+
+```lua
+function initialize()
+   addWeapon(WeaponType["Gun"], 100, 1, 0.0, 0.08)
+   setProjectileZ(0, 40)
+end
+```
+
+|Parameter Position|Type|Description|
+|-|-|-|
+|1|int32_t|Weapon index|
+|2|int32_t|z layer|
+
+
 ## `setSpriteOffset`
 
 Sets the offset for a given sprite
@@ -580,6 +601,28 @@ Set the visibility of a given sprite
 |-|-|-|
 |1|int32_t|Sprite id|
 |2|bool|Visibility flag (true for visible, false for invisible)|
+
+
+## `setSpriteZ`
+
+Set the z layer of a given sprite. By default every sprite is drawn at the z layer of the node itself (see `setZ`).
+Assigning an explicit z layer to a single sprite lets that sprite be drawn in front of or behind level layers
+without moving the rest of the node. This is useful for sprites that represent something travelling away from
+the enemy, such as a fired orb that should pass in front of foreground tiles while the enemy stays behind them.
+
+Valid z layers range from 0 to 50. The player is drawn at z layer 20.
+
+```lua
+function initialize()
+   addSprite()
+   setSpriteZ(1, 40)
+end
+```
+
+|Parameter Position|Type|Description|
+|-|-|-|
+|1|int32_t|Sprite id|
+|2|int32_t|z layer|
 
 
 ## `setTransform`

--- a/src/game/level/level.cpp
+++ b/src/game/level/level.cpp
@@ -1155,14 +1155,14 @@ void Level::drawLayers(sf::RenderTarget& target, sf::RenderTarget& normal, int32
          _ambient_occlusion->draw(target, layer_states);
       }
 
-      // draw enemies
+      // draw enemies; sprite layers and projectiles may have been assigned their own z index from lua
       for (auto& enemy : LuaInterface::instance().getObjectList())
       {
-         if (enemy->getZ() == z_index)
+         if (enemy->hasContentAtZ(z_index))
          {
             if (checkUpdateMechanism(player_chunk, enemy))
             {
-               enemy->draw(target, normal, layer_states);
+               enemy->drawAtZ(target, normal, layer_states, z_index);
             }
          }
       }

--- a/src/game/level/luanode.cpp
+++ b/src/game/level/luanode.cpp
@@ -3,6 +3,8 @@
 
 #include <lua.hpp>
 
+#include <algorithm>
+
 // box2d
 #include "box2d/box2d.h"
 
@@ -183,12 +185,14 @@ void LuaNode::setupLua()
    lua_register(_lua_state, "setDamage", LuaNodeCallbacks::setDamageToPlayer);
    lua_register(_lua_state, "setGravityScale", LuaNodeCallbacks::setGravityScale);
    lua_register(_lua_state, "setLinearVelocity", LuaNodeCallbacks::setLinearVelocity);
+   lua_register(_lua_state, "setProjectileZ", LuaNodeCallbacks::setProjectileZIndex);
    lua_register(_lua_state, "setReferenceVolume", LuaNodeCallbacks::setReferenceVolume);
    lua_register(_lua_state, "setSpriteColor", LuaNodeCallbacks::setSpriteColor);
    lua_register(_lua_state, "setSpriteOffset", LuaNodeCallbacks::setSpriteOffset);
    lua_register(_lua_state, "setSpriteOrigin", LuaNodeCallbacks::setSpriteOrigin);
    lua_register(_lua_state, "setSpriteScale", LuaNodeCallbacks::setSpriteScale);
    lua_register(_lua_state, "setSpriteVisible", LuaNodeCallbacks::setSpriteVisible);
+   lua_register(_lua_state, "setSpriteZ", LuaNodeCallbacks::setSpriteZIndex);
    lua_register(_lua_state, "setTransform", LuaNodeCallbacks::setTransform);
    lua_register(_lua_state, "setVisible", LuaNodeCallbacks::setVisible);
    lua_register(_lua_state, "setZ", LuaNodeCallbacks::setZIndex);
@@ -743,6 +747,7 @@ void LuaNode::addSprite()
 #endif
    _sprites.emplace_back(std::move(sprite));
    _sprite_offsets_px.emplace_back();
+   _sprite_z_indices.emplace_back();
 }
 
 void LuaNode::setSpriteOrigin(int32_t id, float x, float y)
@@ -959,6 +964,7 @@ void LuaNode::addShapePoly(const b2Vec2* points, int32_t size)
 void LuaNode::addWeapon(const std::shared_ptr<Weapon>& weapon)
 {
    _weapons.push_back(weapon);
+   _weapon_z_indices.emplace_back();
 }
 
 void LuaNode::useWeapon(size_t index, b2Vec2 from, b2Vec2 to)
@@ -1104,6 +1110,15 @@ void LuaNode::setSpriteVisible(int32_t id, bool visible)
       sf::Color current_color = sfcompat::getColor(*_sprites[id]);
       current_color.a = visible ? 255 : 0;
       sfcompat::setColor(*_sprites[id], current_color);
+   }
+}
+
+void LuaNode::setSpriteZ(int32_t id, int32_t z_index)
+{
+   if (id >= 0 && id < static_cast<int32_t>(_sprite_z_indices.size()))
+   {
+      _sprite_z_indices[id] = z_index;
+      updatePartZIndices();
    }
 }
 
@@ -1300,6 +1315,15 @@ void LuaNode::setProjectileAnimation(
    dynamic_cast<Gun&>(*_weapons[weapon_index]).setProjectileAnimation(frame_data);
 }
 
+void LuaNode::setProjectileZ(uint32_t weapon_index, int32_t z_index)
+{
+   if (weapon_index < _weapon_z_indices.size())
+   {
+      _weapon_z_indices[weapon_index] = z_index;
+      updatePartZIndices();
+   }
+}
+
 void LuaNode::startTimer(int32_t delay, int32_t timer_id)
 {
    Timer::add(
@@ -1358,12 +1382,72 @@ void LuaNode::draw(sf::RenderTarget& target, sf::RenderTarget& normal)
    draw(target, normal, {});
 }
 
-void LuaNode::draw(sf::RenderTarget& target, sf::RenderTarget& /*normal*/, const sf::RenderStates& states)
+void LuaNode::draw(sf::RenderTarget& target, sf::RenderTarget& normal, const sf::RenderStates& states)
+{
+   drawParts(target, normal, states, std::nullopt);
+}
+
+void LuaNode::drawAtZ(sf::RenderTarget& target, sf::RenderTarget& normal, const sf::RenderStates& states, int32_t z_index)
+{
+   drawParts(target, normal, states, z_index);
+}
+
+bool LuaNode::hasContentAtZ(int32_t z_index) const
+{
+   if (_z_index == z_index)
+   {
+      return true;
+   }
+
+   return std::find(_part_z_indices.begin(), _part_z_indices.end(), z_index) != _part_z_indices.end();
+}
+
+void LuaNode::updatePartZIndices()
+{
+   _part_z_indices.clear();
+
+   const auto collect = [this](const std::vector<std::optional<int32_t>>& part_z_indices)
+   {
+      for (const auto& part_z_index : part_z_indices)
+      {
+         if (!part_z_index.has_value())
+         {
+            continue;
+         }
+
+         if (std::find(_part_z_indices.begin(), _part_z_indices.end(), part_z_index.value()) == _part_z_indices.end())
+         {
+            _part_z_indices.push_back(part_z_index.value());
+         }
+      }
+   };
+
+   collect(_sprite_z_indices);
+   collect(_weapon_z_indices);
+}
+
+void LuaNode::drawParts(
+   sf::RenderTarget& target,
+   sf::RenderTarget& /*normal*/,
+   const sf::RenderStates& states,
+   std::optional<int32_t> z_index
+)
 {
    if (!_visible)
    {
       return;
    }
+
+   // parts without an explicit z index are drawn at the node's z index
+   const auto matches_z_index = [this, z_index](const std::optional<int32_t>& part_z_index)
+   {
+      if (!z_index.has_value())
+      {
+         return true;
+      }
+
+      return part_z_index.value_or(_z_index) == z_index.value();
+   };
 
    if (_hit_time.has_value())
    {
@@ -1383,13 +1467,23 @@ void LuaNode::draw(sf::RenderTarget& target, sf::RenderTarget& /*normal*/, const
    }
 
    // draw sprite on top of projectiles
-   for (auto& weapon : _weapons)
+   for (auto i = 0u; i < _weapons.size(); i++)
    {
-      weapon->draw(target, states);
+      if (!matches_z_index(_weapon_z_indices[i]))
+      {
+         continue;
+      }
+
+      _weapons[i]->draw(target, states);
    }
 
    for (auto i = 0u; i < _sprites.size(); i++)
    {
+      if (!matches_z_index(_sprite_z_indices[i]))
+      {
+         continue;
+      }
+
       auto& sprite = _sprites[i];
 
 #ifdef __EMSCRIPTEN__
@@ -1424,9 +1518,12 @@ void LuaNode::draw(sf::RenderTarget& target, sf::RenderTarget& /*normal*/, const
    }
 
    // draw debug rectangles if they were added
-   for (const auto& debug_rect : _debug_rects)
+   if (matches_z_index(std::nullopt))
    {
-      DebugDraw::drawRect(target, debug_rect);
+      for (const auto& debug_rect : _debug_rects)
+      {
+         DebugDraw::drawRect(target, debug_rect);
+      }
    }
 }
 

--- a/src/game/level/luanode.h
+++ b/src/game/level/luanode.h
@@ -48,6 +48,28 @@ struct LuaNode : public GameMechanism, public GameNode
    void draw(sf::RenderTarget& window, sf::RenderTarget& normal, const sf::RenderStates& states) override;
    using GameMechanism::draw;
 
+   /// \brief draws only those parts of the node that belong to one z index.
+   /// \param window color render target.
+   /// \param normal normal-map render target.
+   /// \param states render states to use.
+   /// \param z_index z index currently being drawn.
+   void drawAtZ(sf::RenderTarget& window, sf::RenderTarget& normal, const sf::RenderStates& states, int32_t z_index);
+
+   /// \brief checks whether the node draws anything at a given z index.
+   /// \param z_index z index to check.
+   /// \return true when the node itself, one of its sprite layers or one of its weapons draws at that z index.
+   bool hasContentAtZ(int32_t z_index) const;
+
+   /// \brief draws weapons, sprite layers and debug overlays, optionally limited to one z index.
+   /// \param window color render target.
+   /// \param normal normal-map render target.
+   /// \param states render states to use.
+   /// \param z_index z index filter; std::nullopt draws every part regardless of its z index.
+   void drawParts(sf::RenderTarget& window, sf::RenderTarget& normal, const sf::RenderStates& states, std::optional<int32_t> z_index);
+
+   /// \brief rebuilds the lookup of z indices that sprite layers and weapons were explicitly assigned to.
+   void updatePartZIndices();
+
    /// \brief returns cached world-space bounding box built from active hitboxes.
    /// \return bounding rectangle in pixels, or std::nullopt when no hitboxes exist.
    std::optional<sf::FloatRect> getBoundingBoxPx() override;
@@ -249,6 +271,11 @@ struct LuaNode : public GameMechanism, public GameNode
    /// \param visible true to draw the sprite layer.
    void setSpriteVisible(int32_t id, bool visible);
 
+   /// \brief sets the z index one sprite layer is drawn at, independently of the node z index.
+   /// \param id sprite layer index.
+   /// \param z_index z index to draw this sprite layer at.
+   void setSpriteZ(int32_t id, int32_t z_index);
+
    /// \brief toggles visibility of the whole node.
    /// \param visible true to draw the node.
    void setVisible(bool visible);
@@ -360,6 +387,11 @@ struct LuaNode : public GameMechanism, public GameNode
       uint32_t frames_per_row,
       uint32_t start_frame
    );
+
+   /// \brief sets the z index the projectiles of one weapon slot are drawn at, independently of the node z index.
+   /// \param weapon_index weapon slot index.
+   /// \param z_index z index to draw the projectiles of this weapon slot at.
+   void setProjectileZ(uint32_t weapon_index, int32_t z_index);
 
    /// \brief starts a one-shot timer that calls lua timeout callback.
    /// \param delay delay in milliseconds.
@@ -504,6 +536,11 @@ struct LuaNode : public GameMechanism, public GameNode
    std::shared_ptr<sf::Texture> _texture;
    std::vector<std::unique_ptr<sf::Sprite>> _sprites;
    std::vector<sf::Vector2f> _sprite_offsets_px;
+   std::vector<std::optional<int32_t>> _sprite_z_indices;
+
+   //!< z indices explicitly assigned to sprite layers or weapons; kept as a flat lookup so the
+   //!< per-z-index draw loop does not have to scan all sprite layers and weapons of every enemy
+   std::vector<int32_t> _part_z_indices;
    sf::Vector2f _position_px;
    std::vector<sf::Vector2f> _movement_path_px;
    sfcompat::Shader _flash_shader;
@@ -515,6 +552,7 @@ struct LuaNode : public GameMechanism, public GameNode
    b2BodyDef* _body_def{nullptr};
    std::vector<b2Shape*> _shapes_m;
    std::vector<std::shared_ptr<Weapon>> _weapons;
+   std::vector<std::optional<int32_t>> _weapon_z_indices;
 
    // damage
    std::vector<Hitbox> _hitboxes;

--- a/src/game/level/luanodecallbacks.cpp
+++ b/src/game/level/luanodecallbacks.cpp
@@ -1007,6 +1007,34 @@ int32_t setSpriteVisible(lua_State* state)
 }
 
 /**
+ * @brief setSpriteZ sets the z index one sprite is drawn at, independently of the node z index
+ * @param state lua state
+ *    param 1: sprite id
+ *    param 2: z index
+ * @return error code
+ */
+int32_t setSpriteZIndex(lua_State* state)
+{
+   const auto argc = lua_gettop(state);
+   if (argc != 2)
+   {
+      return 0;
+   }
+
+   auto node = OBJINSTANCE;
+   if (!node)
+   {
+      return 0;
+   }
+
+   const auto id = static_cast<int32_t>(lua_tointeger(state, 1));
+   const auto z_index = static_cast<int32_t>(lua_tointeger(state, 2));
+   node->setSpriteZ(id, z_index);
+
+   return 0;
+}
+
+/**
  * @brief boom make the game go booom
  * @param state lua state
  *    param 1: detonation center x
@@ -1422,6 +1450,34 @@ int32_t updateProjectileAnimation(lua_State* state)
 }
 
 /**
+ * @brief setProjectileZ sets the z index the projectiles of one weapon are drawn at, independently of the node z index
+ * @param state lua state
+ *    param 1: weapon index
+ *    param 2: z index
+ * @return error code
+ */
+int32_t setProjectileZIndex(lua_State* state)
+{
+   const auto argc = lua_gettop(state);
+   if (argc != 2)
+   {
+      return 0;
+   }
+
+   auto node = OBJINSTANCE;
+   if (!node)
+   {
+      return 0;
+   }
+
+   const auto weapon_index = static_cast<uint32_t>(lua_tointeger(state, 1));
+   const auto z_index = static_cast<int32_t>(lua_tointeger(state, 2));
+   node->setProjectileZ(weapon_index, z_index);
+
+   return 0;
+}
+
+/**
  * @brief timer start a timer
  * @param state lua state
  *    param 1: delay of the timer
@@ -1559,16 +1615,7 @@ int32_t registerHitAnimation(lua_State* state)
    const auto frames_per_row = static_cast<uint32_t>(lua_tointeger(state, 7));
    const auto start_frame = static_cast<uint32_t>(lua_tointeger(state, 8));
 
-   node->registerHitAnimation(
-      weapon_index,
-      path,
-      frame_width,
-      frame_height,
-      time_per_frame_s,
-      frame_count,
-      frames_per_row,
-      start_frame
-   );
+   node->registerHitAnimation(weapon_index, path, frame_width, frame_height, time_per_frame_s, frame_count, frames_per_row, start_frame);
 
    return 0;
 }

--- a/src/game/level/luanodecallbacks.h
+++ b/src/game/level/luanodecallbacks.h
@@ -92,6 +92,11 @@ int32_t setSpriteOffset(lua_State* state);
 /// \return number of lua return values pushed to the stack.
 int32_t setSpriteVisible(lua_State* state);
 
+/// \brief sets the z index one sprite layer is drawn at, independently of the node z index.
+/// \param state active lua state with sprite id and z index.
+/// \return number of lua return values pushed to the stack.
+int32_t setSpriteZIndex(lua_State* state);
+
 // physics queries
 /// \brief checks whether a script-provided rectangle overlaps the player bounds.
 /// \param state active lua state with rectangle coordinates in pixels.
@@ -252,6 +257,11 @@ int32_t updateProjectileTexture(lua_State* state);
 /// \param state active lua state with animation texture and frame timing parameters.
 /// \return number of lua return values pushed to the stack.
 int32_t updateProjectileAnimation(lua_State* state);
+
+/// \brief sets the z index the projectiles of one weapon are drawn at, independently of the node z index.
+/// \param state active lua state with weapon index and z index.
+/// \return number of lua return values pushed to the stack.
+int32_t setProjectileZIndex(lua_State* state);
 
 /// \brief registers impact animation data for projectile collisions.
 /// \param state active lua state with weapon index and animation parameters.


### PR DESCRIPTION
## Problem

Sprites and weapon projectiles of a `LuaNode` were always drawn at the z index of the node itself. An enemy therefore could not have a projectile travel in front of foreground layers without moving the enemy along with it — which is what the blue frog needs for its orb.

While looking at the blue frog, a second bug surfaced: the orb's hit rect did not overlap the visible orb. The orb graphic does not fill its 120x120 frame (the visible dot sits at `(36, 60)` inside it), and the script placed a 36x36 rect at *frame center + half its own size*. The result was an invisible hit box roughly 42 px right and 18 px below the dot, so the player got damaged by nothing while flying orbs passed harmlessly through them.

## Changes

**Lua interface**

- `setSpriteZ(sprite_id, z)` — draw one sprite layer at its own z index
- `setProjectileZ(weapon_index, z)` — draw the projectiles of one weapon at their own z index

Parts without an explicit z index keep inheriting the node z index, so existing scripts and the `z` map property behave exactly as before.

**Engine**

`Level::drawLayers` now asks each enemy `hasContentAtZ(z_index)` instead of comparing `getZ()`, and calls `drawAtZ(...)` so only the parts belonging to that z index are drawn. The explicitly assigned z indices are cached in a flat lookup, so a node without custom part z indices costs the same single integer comparison it did before. The enemy loop already ran once per z index, so no new iteration was introduced.

Note that this makes `LuaNode` the first drawable that can paint into more than one z bucket — `enemy->getZ()` is no longer the whole truth about where it renders. The alternative that preserves one-z-per-drawable is hoisting projectile rendering out of `LuaNode` into level-registered drawables, which means reworking `Weapon`/`Gun` lifetimes for what is a rendering-order problem.

**frog_blue.lua**

- Orb draws at z index 40 while the frog stays on its own layer, exposed as the map property `orb_z`
- Hit rect is centered on the visible dot and defaults to 16x16 (the bright core), exposed as the map property `orb_collision_size` — a property `catacombs.tmx` already sets on that frog but the script never read

**Docs**

`doc/lua_interface/readme.md` gained sections for both new calls.

## Verification

- Desktop release build compiles clean
- Drove `deceptus.exe` into catacombs, teleported to the blue frog at tile (22, 75) and captured the orb mid-flight: it renders correctly and passes in front of the foreground chain, while the frog stays behind the level geometry
