### PR TITLE
refactor: apply _px/_tl/_m unit suffix convention

### DIFF
--- a/data/scripts/enemies/archer.lua
+++ b/data/scripts/enemies/archer.lua
@@ -85,8 +85,8 @@ local aim_hold_duration_s     = 1.0
 local recover_duration_s      = 2.0
 
 -- world-space references (kept here to avoid global lookups and simplify testing)
-local archer_position         = vector2.Vector2D(0, 0)
-local player_position         = vector2.Vector2D(0, 0)
+local archer_position_px         = vector2.Vector2D(0, 0)
+local player_position_px         = vector2.Vector2D(0, 0)
 
 -- visual state (sprite, input, orientation)
 -- we keep rendering and input intent here, separate from ai logic in the state machine.
@@ -218,16 +218,16 @@ function move_right()
 end
 
 function movedTo(x, y)
-   archer_position = vector2.Vector2D(x, y)
+   archer_position_px = vector2.Vector2D(x, y)
 end
 
 function playerMovedTo(x, y)
-   player_position = vector2.Vector2D(x, y)
+   player_position_px = vector2.Vector2D(x, y)
 end
 
 -- align sprite orientation to the player's side (no movement)
 local function align_orientation_towards_player()
-   archer_visual_state.facing_left = (player_position:getX() < archer_position:getX())
+   archer_visual_state.facing_left = (player_position_px:getX() < archer_position_px:getX())
 end
 
 ------------------------------------------------------------------------------------------------------------------------
@@ -235,33 +235,33 @@ end
 -- we keep these pure and reusable so transition rules stay readable.
 
 local function is_facing_player()
-   local player_is_left = player_position:getX() < archer_position:getX()
+   local player_is_left = player_position_px:getX() < archer_position_px:getX()
    return player_is_left == archer_visual_state.facing_left
 end
 
 local function follow_player()
    -- move just enough to bring player into aim range, then stop and face them.
-   local epsilon_pixels = aim_distance_tiles * 24
-   if player_position:getX() > archer_position:getX() + epsilon_pixels then
+   local epsilon_px = aim_distance_tiles * 24
+   if player_position_px:getX() > archer_position_px:getX() + epsilon_px then
       move_right()
-   elseif player_position:getX() < archer_position:getX() - epsilon_pixels then
+   elseif player_position_px:getX() < archer_position_px:getX() - epsilon_px then
       move_left()
    else
-      archer_visual_state.facing_left = player_position:getX() < archer_position:getX()
+      archer_visual_state.facing_left = player_position_px:getX() < archer_position_px:getX()
       archer_visual_state.key_pressed_mask = 0
    end
 end
 
 local function is_player_in_follow_range()
-   local dx_tiles = math.abs(archer_position:getX() // 24 - player_position:getX() // 24)
+   local dx_tiles = math.abs(archer_position_px:getX() // 24 - player_position_px:getX() // 24)
    return dx_tiles < follow_distance_tiles
 end
 
 local function is_player_in_shoot_range()
    if not is_facing_player() then return false end
-   local dx_tiles = (archer_position:getX() - player_position:getX()) / 24.0
+   local dx_tiles = (archer_position_px:getX() - player_position_px:getX()) / 24.0
    if math.abs(dx_tiles) > aim_distance_tiles then return false end
-   local dy_tiles = math.abs(archer_position:getY() // 24 - player_position:getY() // 24)
+   local dy_tiles = math.abs(archer_position_px:getY() // 24 - player_position_px:getY() // 24)
    return dy_tiles <= 1
 end
 
@@ -317,7 +317,7 @@ archer_state_machine
       if is_player_in_follow_range() then
          follow_player()
       else
-         local handled = patrol_behavior:update_move(delta_time, archer_position, move_left, move_right)
+         local handled = patrol_behavior:update_move(delta_time, archer_position_px, move_left, move_right)
          if not handled then
             archer_visual_state.key_pressed_mask = 0
          end
@@ -364,7 +364,7 @@ on_update = function(delta_time, sm)
       archer_visual_state.key_pressed_mask = 0
       if not shot_fired_in_this_cycle and archer_visual_state.sprite_index == 0 then
          local velocity_x = archer_visual_state.facing_left and -arrow_speed_units or arrow_speed_units
-         useWeapon(0, archer_position:getX(), archer_position:getY(), velocity_x, 0.0)
+         useWeapon(0, archer_position_px:getX(), archer_position_px:getY(), velocity_x, 0.0)
          shot_fired_in_this_cycle = true
       end
    end,

--- a/data/scripts/enemies/arrowtrap.lua
+++ b/data/scripts/enemies/arrowtrap.lua
@@ -44,12 +44,12 @@ _fire_direction = v2d.Vector2D(0, 0)
 _fire_offset_px = {v2d.Vector2D(0, 0), v2d.Vector2D(0, 0), v2d.Vector2D(0, 0)}
 _speed = 1.5
 _offset_px = v2d.Vector2D(0, 0)
-_muzzle_width = 0
-_muzzle_height = 0
+_muzzle_width_px = 0
+_muzzle_height_px = 0
 _muzzle_offset_px = v2d.Vector2D(0, 0)
 
-SPRITE_WIDTH = 3 * 24
-SPRITE_HEIGHT = 3 * 24
+SPRITE_WIDTH_PX = 3 * 24
+SPRITE_HEIGHT_PX = 3 * 24
 
 
 -- physical box is just 24 * 24px
@@ -107,13 +107,13 @@ function updateAlignment(alignment)
       _fire_offset_px[2] = v2d.Vector2D(11.0, -16.0)
       _fire_offset_px[3] = v2d.Vector2D(19.0, -16.0)
       _offset_px = v2d.Vector2D(0, 9 * 24)
-      _muzzle_width = 8
-      _muzzle_height = 24
+      _muzzle_width_px = 8
+      _muzzle_height_px = 24
       _muzzle_offset_px:setX(4)
       _muzzle_offset_px:setY(-12)
       setSpriteOffset(1, _muzzle_offset_px:getX(),                     _muzzle_offset_px:getY())
-      setSpriteOffset(2, _muzzle_offset_px:getX() + _muzzle_width,     _muzzle_offset_px:getY())
-      setSpriteOffset(3, _muzzle_offset_px:getX() + _muzzle_width * 2, _muzzle_offset_px:getY())
+      setSpriteOffset(2, _muzzle_offset_px:getX() + _muzzle_width_px,     _muzzle_offset_px:getY())
+      setSpriteOffset(3, _muzzle_offset_px:getX() + _muzzle_width_px * 2, _muzzle_offset_px:getY())
    elseif (alignment == Alignment["AlignmentDown"]) then
       offset:setX(5)
       offset:setY(0)
@@ -122,13 +122,13 @@ function updateAlignment(alignment)
       _fire_offset_px[2] = v2d.Vector2D(12.0, 40.0)
       _fire_offset_px[3] = v2d.Vector2D(20.0, 40.0)
       _offset_px = v2d.Vector2D(0, 8 * 24)
-      _muzzle_width = 8
-      _muzzle_height = 24
+      _muzzle_width_px = 8
+      _muzzle_height_px = 24
       _muzzle_offset_px:setX(4)
       _muzzle_offset_px:setY(36)
       setSpriteOffset(1, _muzzle_offset_px:getX(),                     _muzzle_offset_px:getY())
-      setSpriteOffset(2, _muzzle_offset_px:getX() + _muzzle_width,     _muzzle_offset_px:getY())
-      setSpriteOffset(3, _muzzle_offset_px:getX() + _muzzle_width * 2, _muzzle_offset_px:getY())
+      setSpriteOffset(2, _muzzle_offset_px:getX() + _muzzle_width_px,     _muzzle_offset_px:getY())
+      setSpriteOffset(3, _muzzle_offset_px:getX() + _muzzle_width_px * 2, _muzzle_offset_px:getY())
    elseif (alignment == Alignment["AlignmentLeft"]) then
       offset:setX(0)
       offset:setY(0)
@@ -137,13 +137,13 @@ function updateAlignment(alignment)
       _fire_offset_px[2] = v2d.Vector2D(-16.0, 11.0)
       _fire_offset_px[3] = v2d.Vector2D(-16.0, 19.0)
       _offset_px = v2d.Vector2D(0, 6 * 24)
-      _muzzle_width = 24
-      _muzzle_height = 8
+      _muzzle_width_px = 24
+      _muzzle_height_px = 8
       _muzzle_offset_px:setX(-12)
       _muzzle_offset_px:setY(4)
       setSpriteOffset(1, _muzzle_offset_px:getX(), _muzzle_offset_px:getY())
-      setSpriteOffset(2, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height)
-      setSpriteOffset(3, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height * 2)
+      setSpriteOffset(2, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height_px)
+      setSpriteOffset(3, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height_px * 2)
    elseif (alignment == Alignment["AlignmentRight"]) then
       offset:setX(0)
       offset:setY(1)
@@ -152,21 +152,21 @@ function updateAlignment(alignment)
       _fire_offset_px[2] = v2d.Vector2D(36.0, 11.0)
       _fire_offset_px[3] = v2d.Vector2D(36.0, 19.0)
       _offset_px = v2d.Vector2D(0, 7 * 24)
-      _muzzle_width = 24
-      _muzzle_height = 8
+      _muzzle_width_px = 24
+      _muzzle_height_px = 8
       _muzzle_offset_px:setX(36)
       _muzzle_offset_px:setY(4)
       setSpriteOffset(1, _muzzle_offset_px:getX(), _muzzle_offset_px:getY())
-      setSpriteOffset(2, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height)
-      setSpriteOffset(3, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height * 2)
+      setSpriteOffset(2, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height_px)
+      setSpriteOffset(3, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height_px * 2)
    end
 
    updateSpriteRect(
       0,
-      offset:getX() * SPRITE_WIDTH,
-      offset:getY() * SPRITE_HEIGHT,
-      SPRITE_WIDTH,
-      SPRITE_HEIGHT
+      offset:getX() * SPRITE_WIDTH_PX,
+      offset:getY() * SPRITE_HEIGHT_PX,
+      SPRITE_WIDTH_PX,
+      SPRITE_HEIGHT_PX
    )
 
    for i = 1, 3, 1
@@ -175,8 +175,8 @@ function updateAlignment(alignment)
          i,
          _offset_px.x,
          _offset_px.y,
-         _muzzle_width,
-         _muzzle_height
+         _muzzle_width_px,
+         _muzzle_height_px
       )
 
    end
@@ -320,8 +320,8 @@ function update(dt)
             i,
             _offset_px:getX() + sprite_indices_current[i] * 24,
             _offset_px:getY(),
-            _muzzle_width,
-            _muzzle_height
+            _muzzle_width_px,
+            _muzzle_height_px
          )
       end
    end

--- a/data/scripts/enemies/arrowtrap.lua
+++ b/data/scripts/enemies/arrowtrap.lua
@@ -37,16 +37,16 @@ _fire_delay_elapsed = {}
 _sprite_indices = {}
 _fired = {false, false, false}
 
-_position = v2d.Vector2D(0, 0)
-_player_position = v2d.Vector2D(0, 0)
+_position_px = v2d.Vector2D(0, 0)
+_player_position_px = v2d.Vector2D(0, 0)
 _elapsed = 0.0
 _fire_direction = v2d.Vector2D(0, 0)
-_fire_offset = {v2d.Vector2D(0, 0), v2d.Vector2D(0, 0), v2d.Vector2D(0, 0)}
+_fire_offset_px = {v2d.Vector2D(0, 0), v2d.Vector2D(0, 0), v2d.Vector2D(0, 0)}
 _speed = 1.5
-_offset = v2d.Vector2D(0, 0)
+_offset_px = v2d.Vector2D(0, 0)
 _muzzle_width = 0
 _muzzle_height = 0
-_muzzle_offset = v2d.Vector2D(0, 0)
+_muzzle_offset_px = v2d.Vector2D(0, 0)
 
 SPRITE_WIDTH = 3 * 24
 SPRITE_HEIGHT = 3 * 24
@@ -103,62 +103,62 @@ function updateAlignment(alignment)
       offset:setX(5)
       offset:setY(1)
       _fire_direction = v2d.Vector2D(0.0, -1.0)
-      _fire_offset[1] = v2d.Vector2D(3.0, -16.0)
-      _fire_offset[2] = v2d.Vector2D(11.0, -16.0)
-      _fire_offset[3] = v2d.Vector2D(19.0, -16.0)
-      _offset = v2d.Vector2D(0, 9 * 24)
+      _fire_offset_px[1] = v2d.Vector2D(3.0, -16.0)
+      _fire_offset_px[2] = v2d.Vector2D(11.0, -16.0)
+      _fire_offset_px[3] = v2d.Vector2D(19.0, -16.0)
+      _offset_px = v2d.Vector2D(0, 9 * 24)
       _muzzle_width = 8
       _muzzle_height = 24
-      _muzzle_offset:setX(4)
-      _muzzle_offset:setY(-12)
-      setSpriteOffset(1, _muzzle_offset:getX(),                     _muzzle_offset:getY())
-      setSpriteOffset(2, _muzzle_offset:getX() + _muzzle_width,     _muzzle_offset:getY())
-      setSpriteOffset(3, _muzzle_offset:getX() + _muzzle_width * 2, _muzzle_offset:getY())
+      _muzzle_offset_px:setX(4)
+      _muzzle_offset_px:setY(-12)
+      setSpriteOffset(1, _muzzle_offset_px:getX(),                     _muzzle_offset_px:getY())
+      setSpriteOffset(2, _muzzle_offset_px:getX() + _muzzle_width,     _muzzle_offset_px:getY())
+      setSpriteOffset(3, _muzzle_offset_px:getX() + _muzzle_width * 2, _muzzle_offset_px:getY())
    elseif (alignment == Alignment["AlignmentDown"]) then
       offset:setX(5)
       offset:setY(0)
       _fire_direction = v2d.Vector2D(0.0, 1.0)
-      _fire_offset[1] = v2d.Vector2D(4.0, 40.0)
-      _fire_offset[2] = v2d.Vector2D(12.0, 40.0)
-      _fire_offset[3] = v2d.Vector2D(20.0, 40.0)
-      _offset = v2d.Vector2D(0, 8 * 24)
+      _fire_offset_px[1] = v2d.Vector2D(4.0, 40.0)
+      _fire_offset_px[2] = v2d.Vector2D(12.0, 40.0)
+      _fire_offset_px[3] = v2d.Vector2D(20.0, 40.0)
+      _offset_px = v2d.Vector2D(0, 8 * 24)
       _muzzle_width = 8
       _muzzle_height = 24
-      _muzzle_offset:setX(4)
-      _muzzle_offset:setY(36)
-      setSpriteOffset(1, _muzzle_offset:getX(),                     _muzzle_offset:getY())
-      setSpriteOffset(2, _muzzle_offset:getX() + _muzzle_width,     _muzzle_offset:getY())
-      setSpriteOffset(3, _muzzle_offset:getX() + _muzzle_width * 2, _muzzle_offset:getY())
+      _muzzle_offset_px:setX(4)
+      _muzzle_offset_px:setY(36)
+      setSpriteOffset(1, _muzzle_offset_px:getX(),                     _muzzle_offset_px:getY())
+      setSpriteOffset(2, _muzzle_offset_px:getX() + _muzzle_width,     _muzzle_offset_px:getY())
+      setSpriteOffset(3, _muzzle_offset_px:getX() + _muzzle_width * 2, _muzzle_offset_px:getY())
    elseif (alignment == Alignment["AlignmentLeft"]) then
       offset:setX(0)
       offset:setY(0)
       _fire_direction = v2d.Vector2D(-1.0, 0.0)
-      _fire_offset[1] = v2d.Vector2D(-16.0, 3.0)
-      _fire_offset[2] = v2d.Vector2D(-16.0, 11.0)
-      _fire_offset[3] = v2d.Vector2D(-16.0, 19.0)
-      _offset = v2d.Vector2D(0, 6 * 24)
+      _fire_offset_px[1] = v2d.Vector2D(-16.0, 3.0)
+      _fire_offset_px[2] = v2d.Vector2D(-16.0, 11.0)
+      _fire_offset_px[3] = v2d.Vector2D(-16.0, 19.0)
+      _offset_px = v2d.Vector2D(0, 6 * 24)
       _muzzle_width = 24
       _muzzle_height = 8
-      _muzzle_offset:setX(-12)
-      _muzzle_offset:setY(4)
-      setSpriteOffset(1, _muzzle_offset:getX(), _muzzle_offset:getY())
-      setSpriteOffset(2, _muzzle_offset:getX(), _muzzle_offset:getY() + _muzzle_height)
-      setSpriteOffset(3, _muzzle_offset:getX(), _muzzle_offset:getY() + _muzzle_height * 2)
+      _muzzle_offset_px:setX(-12)
+      _muzzle_offset_px:setY(4)
+      setSpriteOffset(1, _muzzle_offset_px:getX(), _muzzle_offset_px:getY())
+      setSpriteOffset(2, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height)
+      setSpriteOffset(3, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height * 2)
    elseif (alignment == Alignment["AlignmentRight"]) then
       offset:setX(0)
       offset:setY(1)
       _fire_direction = v2d.Vector2D(1.0, 0.0)
-      _fire_offset[1] = v2d.Vector2D(36.0, 3.0)
-      _fire_offset[2] = v2d.Vector2D(36.0, 11.0)
-      _fire_offset[3] = v2d.Vector2D(36.0, 19.0)
-      _offset = v2d.Vector2D(0, 7 * 24)
+      _fire_offset_px[1] = v2d.Vector2D(36.0, 3.0)
+      _fire_offset_px[2] = v2d.Vector2D(36.0, 11.0)
+      _fire_offset_px[3] = v2d.Vector2D(36.0, 19.0)
+      _offset_px = v2d.Vector2D(0, 7 * 24)
       _muzzle_width = 24
       _muzzle_height = 8
-      _muzzle_offset:setX(36)
-      _muzzle_offset:setY(4)
-      setSpriteOffset(1, _muzzle_offset:getX(), _muzzle_offset:getY())
-      setSpriteOffset(2, _muzzle_offset:getX(), _muzzle_offset:getY() + _muzzle_height)
-      setSpriteOffset(3, _muzzle_offset:getX(), _muzzle_offset:getY() + _muzzle_height * 2)
+      _muzzle_offset_px:setX(36)
+      _muzzle_offset_px:setY(4)
+      setSpriteOffset(1, _muzzle_offset_px:getX(), _muzzle_offset_px:getY())
+      setSpriteOffset(2, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height)
+      setSpriteOffset(3, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height * 2)
    end
 
    updateSpriteRect(
@@ -173,8 +173,8 @@ function updateAlignment(alignment)
    do
       updateSpriteRect(
          i,
-         _offset.x,
-         _offset.y,
+         _offset_px.x,
+         _offset_px.y,
          _muzzle_width,
          _muzzle_height
       )
@@ -228,8 +228,8 @@ end
 function fire(muzzle_index)
    useWeapon(
       0,
-      _position:getX() + _fire_offset[muzzle_index]:getX(),
-      _position:getY() + _fire_offset[muzzle_index]:getY(),
+      _position_px:getX() + _fire_offset_px[muzzle_index]:getX(),
+      _position_px:getY() + _fire_offset_px[muzzle_index]:getY(),
       _fire_direction:getX() * _speed,
       _fire_direction:getY() * _speed
    );
@@ -245,14 +245,14 @@ end
 ------------------------------------------------------------------------------------------------------------------------
 function movedTo(x, y)
    -- print(string.format("moved to: %f, %f", x, y))
-   _position = v2d.Vector2D(x, y)
+   _position_px = v2d.Vector2D(x, y)
 end
 
 
 ------------------------------------------------------------------------------------------------------------------------
 function playerMovedTo(x, y)
    -- print(string.format("player moved to: %f, %f", x, y))
-   _player_position = v2d.Vector2D(x, y)
+   _player_position_px = v2d.Vector2D(x, y)
 end
 
 
@@ -318,8 +318,8 @@ function update(dt)
       if (sprite_indices_current[i] ~= _sprite_indices[i]) then
          updateSpriteRect(
             i,
-            _offset:getX() + sprite_indices_current[i] * 24,
-            _offset:getY(),
+            _offset_px:getX() + sprite_indices_current[i] * 24,
+            _offset_px:getY(),
             _muzzle_width,
             _muzzle_height
          )

--- a/data/scripts/enemies/arrowtrap_2.lua
+++ b/data/scripts/enemies/arrowtrap_2.lua
@@ -38,16 +38,16 @@ _sprite_indices = {}
 _fired = {false, false, false}
 _load_played = false
 
-_position = v2d.Vector2D(0, 0)
-_player_position = v2d.Vector2D(0, 0)
+_position_px = v2d.Vector2D(0, 0)
+_player_position_px = v2d.Vector2D(0, 0)
 _elapsed = 0.0
 _fire_direction = v2d.Vector2D(0, 0)
-_fire_offset = {v2d.Vector2D(0, 0), v2d.Vector2D(0, 0), v2d.Vector2D(0, 0)}
+_fire_offset_px = {v2d.Vector2D(0, 0), v2d.Vector2D(0, 0), v2d.Vector2D(0, 0)}
 _speed = 1.5
-_offset = v2d.Vector2D(0, 0)
+_offset_px = v2d.Vector2D(0, 0)
 _muzzle_width = 0
 _muzzle_height = 0
-_muzzle_offset = v2d.Vector2D(0, 0)
+_muzzle_offset_px = v2d.Vector2D(0, 0)
 
 SPRITE_WIDTH = 3 * 24
 SPRITE_HEIGHT = 3 * 24
@@ -105,62 +105,62 @@ function updateAlignment(alignment)
       offset:setX(5)
       offset:setY(1)
       _fire_direction = v2d.Vector2D(0.0, -1.0)
-      _fire_offset[1] = v2d.Vector2D(3.0, -16.0)
-      _fire_offset[2] = v2d.Vector2D(11.0, -16.0)
-      _fire_offset[3] = v2d.Vector2D(19.0, -16.0)
-      _offset = v2d.Vector2D(0, 9 * 24)
+      _fire_offset_px[1] = v2d.Vector2D(3.0, -16.0)
+      _fire_offset_px[2] = v2d.Vector2D(11.0, -16.0)
+      _fire_offset_px[3] = v2d.Vector2D(19.0, -16.0)
+      _offset_px = v2d.Vector2D(0, 9 * 24)
       _muzzle_width = 8
       _muzzle_height = 24
-      _muzzle_offset:setX(4)
-      _muzzle_offset:setY(-12)
-      setSpriteOffset(1, _muzzle_offset:getX(),                     _muzzle_offset:getY())
-      setSpriteOffset(2, _muzzle_offset:getX() + _muzzle_width,     _muzzle_offset:getY())
-      setSpriteOffset(3, _muzzle_offset:getX() + _muzzle_width * 2, _muzzle_offset:getY())
+      _muzzle_offset_px:setX(4)
+      _muzzle_offset_px:setY(-12)
+      setSpriteOffset(1, _muzzle_offset_px:getX(),                     _muzzle_offset_px:getY())
+      setSpriteOffset(2, _muzzle_offset_px:getX() + _muzzle_width,     _muzzle_offset_px:getY())
+      setSpriteOffset(3, _muzzle_offset_px:getX() + _muzzle_width * 2, _muzzle_offset_px:getY())
    elseif (alignment == Alignment["AlignmentDown"]) then
       offset:setX(5)
       offset:setY(0)
       _fire_direction = v2d.Vector2D(0.0, 1.0)
-      _fire_offset[1] = v2d.Vector2D(4.0, 40.0)
-      _fire_offset[2] = v2d.Vector2D(12.0, 40.0)
-      _fire_offset[3] = v2d.Vector2D(20.0, 40.0)
-      _offset = v2d.Vector2D(0, 8 * 24)
+      _fire_offset_px[1] = v2d.Vector2D(4.0, 40.0)
+      _fire_offset_px[2] = v2d.Vector2D(12.0, 40.0)
+      _fire_offset_px[3] = v2d.Vector2D(20.0, 40.0)
+      _offset_px = v2d.Vector2D(0, 8 * 24)
       _muzzle_width = 8
       _muzzle_height = 24
-      _muzzle_offset:setX(4)
-      _muzzle_offset:setY(36)
-      setSpriteOffset(1, _muzzle_offset:getX(),                     _muzzle_offset:getY())
-      setSpriteOffset(2, _muzzle_offset:getX() + _muzzle_width,     _muzzle_offset:getY())
-      setSpriteOffset(3, _muzzle_offset:getX() + _muzzle_width * 2, _muzzle_offset:getY())
+      _muzzle_offset_px:setX(4)
+      _muzzle_offset_px:setY(36)
+      setSpriteOffset(1, _muzzle_offset_px:getX(),                     _muzzle_offset_px:getY())
+      setSpriteOffset(2, _muzzle_offset_px:getX() + _muzzle_width,     _muzzle_offset_px:getY())
+      setSpriteOffset(3, _muzzle_offset_px:getX() + _muzzle_width * 2, _muzzle_offset_px:getY())
    elseif (alignment == Alignment["AlignmentLeft"]) then
       offset:setX(0)
       offset:setY(0)
       _fire_direction = v2d.Vector2D(-1.0, 0.0)
-      _fire_offset[1] = v2d.Vector2D(-16.0, 3.0)
-      _fire_offset[2] = v2d.Vector2D(-16.0, 11.0)
-      _fire_offset[3] = v2d.Vector2D(-16.0, 19.0)
-      _offset = v2d.Vector2D(0, 6 * 24)
+      _fire_offset_px[1] = v2d.Vector2D(-16.0, 3.0)
+      _fire_offset_px[2] = v2d.Vector2D(-16.0, 11.0)
+      _fire_offset_px[3] = v2d.Vector2D(-16.0, 19.0)
+      _offset_px = v2d.Vector2D(0, 6 * 24)
       _muzzle_width = 24
       _muzzle_height = 8
-      _muzzle_offset:setX(-12)
-      _muzzle_offset:setY(4)
-      setSpriteOffset(1, _muzzle_offset:getX(), _muzzle_offset:getY())
-      setSpriteOffset(2, _muzzle_offset:getX(), _muzzle_offset:getY() + _muzzle_height)
-      setSpriteOffset(3, _muzzle_offset:getX(), _muzzle_offset:getY() + _muzzle_height * 2)
+      _muzzle_offset_px:setX(-12)
+      _muzzle_offset_px:setY(4)
+      setSpriteOffset(1, _muzzle_offset_px:getX(), _muzzle_offset_px:getY())
+      setSpriteOffset(2, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height)
+      setSpriteOffset(3, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height * 2)
    elseif (alignment == Alignment["AlignmentRight"]) then
       offset:setX(0)
       offset:setY(1)
       _fire_direction = v2d.Vector2D(1.0, 0.0)
-      _fire_offset[1] = v2d.Vector2D(36.0, 3.0)
-      _fire_offset[2] = v2d.Vector2D(36.0, 11.0)
-      _fire_offset[3] = v2d.Vector2D(36.0, 19.0)
-      _offset = v2d.Vector2D(0, 7 * 24)
+      _fire_offset_px[1] = v2d.Vector2D(36.0, 3.0)
+      _fire_offset_px[2] = v2d.Vector2D(36.0, 11.0)
+      _fire_offset_px[3] = v2d.Vector2D(36.0, 19.0)
+      _offset_px = v2d.Vector2D(0, 7 * 24)
       _muzzle_width = 24
       _muzzle_height = 8
-      _muzzle_offset:setX(36)
-      _muzzle_offset:setY(4)
-      setSpriteOffset(1, _muzzle_offset:getX(), _muzzle_offset:getY())
-      setSpriteOffset(2, _muzzle_offset:getX(), _muzzle_offset:getY() + _muzzle_height)
-      setSpriteOffset(3, _muzzle_offset:getX(), _muzzle_offset:getY() + _muzzle_height * 2)
+      _muzzle_offset_px:setX(36)
+      _muzzle_offset_px:setY(4)
+      setSpriteOffset(1, _muzzle_offset_px:getX(), _muzzle_offset_px:getY())
+      setSpriteOffset(2, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height)
+      setSpriteOffset(3, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height * 2)
    end
 
    updateSpriteRect(
@@ -175,8 +175,8 @@ function updateAlignment(alignment)
    do
       updateSpriteRect(
          i,
-         _offset.x,
-         _offset.y,
+         _offset_px.x,
+         _offset_px.y,
          _muzzle_width,
          _muzzle_height
       )
@@ -231,8 +231,8 @@ function fire(muzzle_index)
    playSample("arrow_release_1.wav", 1.0)
    useWeapon(
       0,
-      _position:getX() + _fire_offset[muzzle_index]:getX(),
-      _position:getY() + _fire_offset[muzzle_index]:getY(),
+      _position_px:getX() + _fire_offset_px[muzzle_index]:getX(),
+      _position_px:getY() + _fire_offset_px[muzzle_index]:getY(),
       _fire_direction:getX() * _speed,
       _fire_direction:getY() * _speed
    );
@@ -248,14 +248,14 @@ end
 ------------------------------------------------------------------------------------------------------------------------
 function movedTo(x, y)
    -- print(string.format("moved to: %f, %f", x, y))
-   _position = v2d.Vector2D(x, y)
+   _position_px = v2d.Vector2D(x, y)
 end
 
 
 ------------------------------------------------------------------------------------------------------------------------
 function playerMovedTo(x, y)
    -- print(string.format("player moved to: %f, %f", x, y))
-   _player_position = v2d.Vector2D(x, y)
+   _player_position_px = v2d.Vector2D(x, y)
 end
 
 
@@ -328,8 +328,8 @@ function update(dt)
       if (sprite_indices_current[i] ~= _sprite_indices[i]) then
          updateSpriteRect(
             i,
-            _offset:getX() + sprite_indices_current[i] * 24,
-            _offset:getY(),
+            _offset_px:getX() + sprite_indices_current[i] * 24,
+            _offset_px:getY(),
             _muzzle_width,
             _muzzle_height
          )

--- a/data/scripts/enemies/arrowtrap_2.lua
+++ b/data/scripts/enemies/arrowtrap_2.lua
@@ -45,12 +45,12 @@ _fire_direction = v2d.Vector2D(0, 0)
 _fire_offset_px = {v2d.Vector2D(0, 0), v2d.Vector2D(0, 0), v2d.Vector2D(0, 0)}
 _speed = 1.5
 _offset_px = v2d.Vector2D(0, 0)
-_muzzle_width = 0
-_muzzle_height = 0
+_muzzle_width_px = 0
+_muzzle_height_px = 0
 _muzzle_offset_px = v2d.Vector2D(0, 0)
 
-SPRITE_WIDTH = 3 * 24
-SPRITE_HEIGHT = 3 * 24
+SPRITE_WIDTH_PX = 3 * 24
+SPRITE_HEIGHT_PX = 3 * 24
 
 
 -- physical box is just 24 * 24px
@@ -109,13 +109,13 @@ function updateAlignment(alignment)
       _fire_offset_px[2] = v2d.Vector2D(11.0, -16.0)
       _fire_offset_px[3] = v2d.Vector2D(19.0, -16.0)
       _offset_px = v2d.Vector2D(0, 9 * 24)
-      _muzzle_width = 8
-      _muzzle_height = 24
+      _muzzle_width_px = 8
+      _muzzle_height_px = 24
       _muzzle_offset_px:setX(4)
       _muzzle_offset_px:setY(-12)
       setSpriteOffset(1, _muzzle_offset_px:getX(),                     _muzzle_offset_px:getY())
-      setSpriteOffset(2, _muzzle_offset_px:getX() + _muzzle_width,     _muzzle_offset_px:getY())
-      setSpriteOffset(3, _muzzle_offset_px:getX() + _muzzle_width * 2, _muzzle_offset_px:getY())
+      setSpriteOffset(2, _muzzle_offset_px:getX() + _muzzle_width_px,     _muzzle_offset_px:getY())
+      setSpriteOffset(3, _muzzle_offset_px:getX() + _muzzle_width_px * 2, _muzzle_offset_px:getY())
    elseif (alignment == Alignment["AlignmentDown"]) then
       offset:setX(5)
       offset:setY(0)
@@ -124,13 +124,13 @@ function updateAlignment(alignment)
       _fire_offset_px[2] = v2d.Vector2D(12.0, 40.0)
       _fire_offset_px[3] = v2d.Vector2D(20.0, 40.0)
       _offset_px = v2d.Vector2D(0, 8 * 24)
-      _muzzle_width = 8
-      _muzzle_height = 24
+      _muzzle_width_px = 8
+      _muzzle_height_px = 24
       _muzzle_offset_px:setX(4)
       _muzzle_offset_px:setY(36)
       setSpriteOffset(1, _muzzle_offset_px:getX(),                     _muzzle_offset_px:getY())
-      setSpriteOffset(2, _muzzle_offset_px:getX() + _muzzle_width,     _muzzle_offset_px:getY())
-      setSpriteOffset(3, _muzzle_offset_px:getX() + _muzzle_width * 2, _muzzle_offset_px:getY())
+      setSpriteOffset(2, _muzzle_offset_px:getX() + _muzzle_width_px,     _muzzle_offset_px:getY())
+      setSpriteOffset(3, _muzzle_offset_px:getX() + _muzzle_width_px * 2, _muzzle_offset_px:getY())
    elseif (alignment == Alignment["AlignmentLeft"]) then
       offset:setX(0)
       offset:setY(0)
@@ -139,13 +139,13 @@ function updateAlignment(alignment)
       _fire_offset_px[2] = v2d.Vector2D(-16.0, 11.0)
       _fire_offset_px[3] = v2d.Vector2D(-16.0, 19.0)
       _offset_px = v2d.Vector2D(0, 6 * 24)
-      _muzzle_width = 24
-      _muzzle_height = 8
+      _muzzle_width_px = 24
+      _muzzle_height_px = 8
       _muzzle_offset_px:setX(-12)
       _muzzle_offset_px:setY(4)
       setSpriteOffset(1, _muzzle_offset_px:getX(), _muzzle_offset_px:getY())
-      setSpriteOffset(2, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height)
-      setSpriteOffset(3, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height * 2)
+      setSpriteOffset(2, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height_px)
+      setSpriteOffset(3, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height_px * 2)
    elseif (alignment == Alignment["AlignmentRight"]) then
       offset:setX(0)
       offset:setY(1)
@@ -154,21 +154,21 @@ function updateAlignment(alignment)
       _fire_offset_px[2] = v2d.Vector2D(36.0, 11.0)
       _fire_offset_px[3] = v2d.Vector2D(36.0, 19.0)
       _offset_px = v2d.Vector2D(0, 7 * 24)
-      _muzzle_width = 24
-      _muzzle_height = 8
+      _muzzle_width_px = 24
+      _muzzle_height_px = 8
       _muzzle_offset_px:setX(36)
       _muzzle_offset_px:setY(4)
       setSpriteOffset(1, _muzzle_offset_px:getX(), _muzzle_offset_px:getY())
-      setSpriteOffset(2, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height)
-      setSpriteOffset(3, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height * 2)
+      setSpriteOffset(2, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height_px)
+      setSpriteOffset(3, _muzzle_offset_px:getX(), _muzzle_offset_px:getY() + _muzzle_height_px * 2)
    end
 
    updateSpriteRect(
       0,
-      offset:getX() * SPRITE_WIDTH,
-      offset:getY() * SPRITE_HEIGHT,
-      SPRITE_WIDTH,
-      SPRITE_HEIGHT
+      offset:getX() * SPRITE_WIDTH_PX,
+      offset:getY() * SPRITE_HEIGHT_PX,
+      SPRITE_WIDTH_PX,
+      SPRITE_HEIGHT_PX
    )
 
    for i = 1, 3, 1
@@ -177,8 +177,8 @@ function updateAlignment(alignment)
          i,
          _offset_px.x,
          _offset_px.y,
-         _muzzle_width,
-         _muzzle_height
+         _muzzle_width_px,
+         _muzzle_height_px
       )
 
    end
@@ -330,8 +330,8 @@ function update(dt)
             i,
             _offset_px:getX() + sprite_indices_current[i] * 24,
             _offset_px:getY(),
-            _muzzle_width,
-            _muzzle_height
+            _muzzle_width_px,
+            _muzzle_height_px
          )
       end
    end

--- a/data/scripts/enemies/bat_2.lua
+++ b/data/scripts/enemies/bat_2.lua
@@ -51,15 +51,15 @@ _attack_time = 0
 _idle_time = 0
 _activated = false
 _move_range_y_px = 48
-_sprite_offset_x = 0
-_sprite_offset_y = 0 -- 9 * 24
-_sprite_width = 72
-_sprite_height = 72
+_sprite_offset_x_px = 0
+_sprite_offset_y_px = 0 -- 9 * 24
+_sprite_width_px = 72
+_sprite_height_px = 72
 _start_position_px = v2d.Vector2D(0, 0)
 _dying = false
 _dead = false
 _death_time = 0
-_transform_y = 0
+_transform_y_px = 0
 _attack = false
 _can_explode = false
 _exploded = false
@@ -68,7 +68,7 @@ _energy = 3
 ANIMATION_SPEED = 40.0
 ANIMATION_SPEED_IDLE = 20.0
 ANIMATION_SPEED_DEATH = 20.0
-HIT_RADIUS = 0.3
+HIT_RADIUS_M = 0.3
 ATTACK_DURATION = 2.0
 ATTACK_SPRITE_COUNT = 9
 
@@ -77,13 +77,13 @@ ATTACK_SPRITE_COUNT = 9
 function initialize()
    addSample("boom.wav")
    addHitbox(-18, -12, 36, 24)
-   addShapeCircle(HIT_RADIUS, 0.0, 0.0)
+   addShapeCircle(HIT_RADIUS_M, 0.0, 0.0)
    updateSpriteRect(
       0,
       0,
       0,
-      _sprite_width,
-      _sprite_height
+      _sprite_width_px,
+      _sprite_height_px
    )
    setZ(30) -- somewhere in the foreground
 
@@ -104,9 +104,9 @@ function shoot()
    py = _player_position_px:getY()
 
    if (_can_explode) then
-      _sprite_offset_y = (px > bx) and (4 * _sprite_height) or (5 * _sprite_height)
+      _sprite_offset_y_px = (px > bx) and (4 * _sprite_height_px) or (5 * _sprite_height_px)
    else
-      _sprite_offset_y = (px > bx) and 0 or _sprite_height
+      _sprite_offset_y_px = (px > bx) and 0 or _sprite_height_px
    end
 
    sx = _start_position_px:getX()
@@ -136,8 +136,8 @@ function update(dt)
       if (_energy == 0) then
          _dying = true
          _death_time = _elapsed
-         _sprite_offset_x = 0
-         _sprite_offset_y = 2 * _sprite_height
+         _sprite_offset_x_px = 0
+         _sprite_offset_y_px = 2 * _sprite_height_px
          setActive(false)
          _position_at_death_px = _position_px
          setDamage(0)
@@ -165,9 +165,9 @@ function update(dt)
          end
 
          -- update transform
-         -- _transform_y = 0.25 * math.sin(_elapsed) * _move_range_y_px
-         _transform_y = 0
-         setTransform(_start_position_px:getX(), _start_position_px:getY() + _transform_y, 0.0)
+         -- _transform_y_px = 0.25 * math.sin(_elapsed) * _move_range_y_px
+         _transform_y_px = 0
+         setTransform(_start_position_px:getX(), _start_position_px:getY() + _transform_y_px, 0.0)
 
       -- carry out attack
       else
@@ -203,8 +203,8 @@ function update(dt)
    end
 
    -- update sprite index
-   if (index ~= _sprite_offset_x) then
-      _sprite_offset_x = sprite_index
+   if (index ~= _sprite_offset_x_px) then
+      _sprite_offset_x_px = sprite_index
       update_sprite = true
    end
 
@@ -238,10 +238,10 @@ function update(dt)
    if (update_sprite) then
       updateSpriteRect(
          0,
-         _sprite_offset_x * _sprite_width,
-         _sprite_offset_y,
-         _sprite_width,
-         _sprite_height
+         _sprite_offset_x_px * _sprite_width_px,
+         _sprite_offset_y_px,
+         _sprite_width_px,
+         _sprite_height_px
       ) -- x, y, width, height
    end
 
@@ -290,7 +290,7 @@ function writeProperty(key, value)
 
    if (key == "exploding") then
       _can_explode = true
-      _sprite_offset_y = 4 * 3 * 24
+      _sprite_offset_y_px = 4 * 3 * 24
    elseif (key == "audio_update_behavior") then
       update_behavior = audioUpdateBehaviorFromString(value)
       setAudioUpdateBehavior(update_behavior)

--- a/data/scripts/enemies/bat_guard.lua
+++ b/data/scripts/enemies/bat_guard.lua
@@ -27,10 +27,10 @@ _player_position_previous_px = v2d.Vector2D(0, 0)
 _elapsed = math.random(0, 3) -- also acts as per-bat phase seed
 _activated = false
 
-_sprite_offset_x = 0
-_sprite_offset_y = 0
-_sprite_width = 72
-_sprite_height = 72
+_sprite_offset_x_px = 0
+_sprite_offset_y_px = 0
+_sprite_width_px = 72
+_sprite_height_px = 72
 
 _start_position_px = v2d.Vector2D(0, 0)
 _dying = false
@@ -43,7 +43,7 @@ _energy = 3
 
 ANIMATION_SPEED_IDLE = 20.0
 ANIMATION_SPEED_DEATH = 20.0
-HIT_RADIUS = 0.3
+HIT_RADIUS_M = 0.3
 ATTACK_SPRITE_COUNT = 9
 
 ------------------------------------------------------------------------------------------------------------------------
@@ -60,8 +60,8 @@ _vel = v2d.Vector2D(0, 0)
 
 ------------------------------------------------------------------------------------------------------------------------
 -- Hover tuning (idle)
-HOVER_OX_AMPL = 6.0
-HOVER_OY_AMPL = 12.0
+HOVER_OX_AMPL_PX = 6.0
+HOVER_OY_AMPL_PX = 12.0
 HOVER_OX_FREQ = 1.7
 HOVER_OY_FREQ = 2.3
 HOVER_EASE = 7.0
@@ -80,12 +80,12 @@ LEASH_Y_TILES = 9
 -- Follow tuning (feel)
 FOLLOW_SPEED = 105.0
 FOLLOW_TURN  = 4.5
-FOLLOW_OFFSET_Y = -28.0
+FOLLOW_OFFSET_Y_PX = -28.0
 FOLLOW_LEAD = 3.0
 
 -- When bat gets close to its follow target, make it "orbit" / flutter instead of sticking to 1 pixel
-ORBIT_START_DIST = 18.0    -- start fluttering when closer than this (px)
-ORBIT_RADIUS = 62.0        -- how wide it circles (px)
+ORBIT_START_DIST_PX = 18.0    -- start fluttering when closer than this (px)
+ORBIT_RADIUS_PX = 62.0        -- how wide it circles (px)
 ORBIT_FREQ = 8.4           -- radians/sec-ish (bigger = faster orbit)
 ORBIT_MIX = 0.85           -- 0..1, how much of orbit offset to apply when very close
 
@@ -93,8 +93,8 @@ ORBIT_MIX = 0.85           -- 0..1, how much of orbit offset to apply when very 
 -- Return tuning (smooth drift back, with deceleration near home)
 RETURN_SPEED = 65.0
 RETURN_TURN  = 2.5
-RETURN_SLOW_RADIUS = 18.0
-RETURN_DONE_DIST  = 0.75
+RETURN_SLOW_RADIUS_PX = 18.0
+RETURN_DONE_DIST_PX  = 0.75
 
 ------------------------------------------------------------------------------------------------------------------------
 -- small helper
@@ -127,9 +127,9 @@ end
 function initialize()
    addSample("boom.wav")
    addHitbox(-18, -12, 36, 24)
-   addShapeCircle(HIT_RADIUS, 0.0, 0.0)
+   addShapeCircle(HIT_RADIUS_M, 0.0, 0.0)
 
-   updateSpriteRect(0, 0, 0, _sprite_width, _sprite_height)
+   updateSpriteRect(0, 0, 0, _sprite_width_px, _sprite_height_px)
    setZ(30)
 end
 
@@ -148,8 +148,8 @@ function update(dt)
       if (_energy == 0) then
          _dying = true
          _death_time = _elapsed
-         _sprite_offset_x = 0
-         _sprite_offset_y = 2 * _sprite_height
+         _sprite_offset_x_px = 0
+         _sprite_offset_y_px = 2 * _sprite_height_px
          setActive(false)
          _position_at_death_px = _position_px
          setDamage(0)
@@ -213,8 +213,8 @@ end
 -- Idle state behavior
 function updateStateIdle(dt)
    local t = _elapsed
-   local ox = math.sin(t * HOVER_OX_FREQ) * HOVER_OX_AMPL
-   local oy = math.sin(t * HOVER_OY_FREQ) * HOVER_OY_AMPL
+   local ox = math.sin(t * HOVER_OX_FREQ) * HOVER_OX_AMPL_PX
+   local oy = math.sin(t * HOVER_OY_FREQ) * HOVER_OY_AMPL_PX
 
    local blend = clamp(_state_time / IDLE_HOVER_BLEND_TIME, 0.0, 1.0)
 
@@ -235,21 +235,21 @@ function updateStateFollow(dt)
 
    -- base target: above player with slight lead
    local target = _player_position_px:add(lead)
-   target = v2d.Vector2D(target:getX(), target:getY() + FOLLOW_OFFSET_Y)
+   target = v2d.Vector2D(target:getX(), target:getY() + FOLLOW_OFFSET_Y_PX)
 
    -- add orbit/fluter when very close so it doesn't "pin" to a single pixel
    -- compute closeness BEFORE leashing (more natural), then leash final target
    local toTarget = target:sub(_pos_px)
    local dist = toTarget:len()
 
-   if (dist < ORBIT_START_DIST) then
+   if (dist < ORBIT_START_DIST_PX) then
       -- closeness factor: 0 at startDist, 1 at 0
-      local k = clamp(1.0 - (dist / ORBIT_START_DIST), 0.0, 1.0) * ORBIT_MIX
+      local k = clamp(1.0 - (dist / ORBIT_START_DIST_PX), 0.0, 1.0) * ORBIT_MIX
 
       -- per-bat phase from initial _elapsed seed
       local phase = (_elapsed * ORBIT_FREQ) + (_attack_time or 0.0)
-      local ox = math.cos(phase) * ORBIT_RADIUS
-      local oy = math.sin(phase * 1.3) * (ORBIT_RADIUS * 0.65)
+      local ox = math.cos(phase) * ORBIT_RADIUS_PX
+      local oy = math.sin(phase * 1.3) * (ORBIT_RADIUS_PX * 0.65)
 
       target = v2d.Vector2D(target:getX() + ox * k, target:getY() + oy * k)
    end
@@ -269,13 +269,13 @@ function updateStateReturn(dt)
    local toHome = home:sub(_pos_px)
    local dist = toHome:len()
 
-   if (dist <= RETURN_DONE_DIST) then
+   if (dist <= RETURN_DONE_DIST_PX) then
       _pos_px = home
       _vel = v2d.Vector2D(0, 0)
       enterState(STATE_IDLE)
       _state_time = 0.0
    else
-      local slow = clamp(dist / RETURN_SLOW_RADIUS, 0.15, 1.0)
+      local slow = clamp(dist / RETURN_SLOW_RADIUS_PX, 0.15, 1.0)
       local desired = toHome:norm():mul(RETURN_SPEED * slow)
 
       _vel = _vel:add(desired:sub(_vel):mul(clamp(RETURN_TURN * dt, 0.0, 1.0)))
@@ -290,9 +290,9 @@ function updateSpriteDirection()
    local bx = _pos_px:getX()
    local px = _player_position_px:getX()
    if (_can_explode) then
-      _sprite_offset_y = (px > bx) and (4 * _sprite_height) or (5 * _sprite_height)
+      _sprite_offset_y_px = (px > bx) and (4 * _sprite_height_px) or (5 * _sprite_height_px)
    else
-      _sprite_offset_y = (px > bx) and 0 or _sprite_height
+      _sprite_offset_y_px = (px > bx) and 0 or _sprite_height_px
    end
 end
 
@@ -310,18 +310,18 @@ function updateAnimation(dt)
    end
 
    local update_sprite = false
-   if (sprite_index ~= _sprite_offset_x) then
-      _sprite_offset_x = sprite_index
+   if (sprite_index ~= _sprite_offset_x_px) then
+      _sprite_offset_x_px = sprite_index
       update_sprite = true
    end
 
    if (update_sprite) then
       updateSpriteRect(
          0,
-         _sprite_offset_x * _sprite_width,
-         _sprite_offset_y,
-         _sprite_width,
-         _sprite_height
+         _sprite_offset_x_px * _sprite_width_px,
+         _sprite_offset_y_px,
+         _sprite_width_px,
+         _sprite_height_px
       )
    end
 end
@@ -383,7 +383,7 @@ end
 function writeProperty(key, value)
    if (key == "exploding") then
       _can_explode = true
-      _sprite_offset_y = 4 * 3 * 24
+      _sprite_offset_y_px = 4 * 3 * 24
    elseif (key == "audio_update_behavior") then
       local update_behavior = audioUpdateBehaviorFromString(value)
       setAudioUpdateBehavior(update_behavior)

--- a/data/scripts/enemies/bat_guard.lua
+++ b/data/scripts/enemies/bat_guard.lua
@@ -55,7 +55,7 @@ STATE_RETURN = 2
 _state = STATE_IDLE
 _state_time = 0.0
 
-_pos = v2d.Vector2D(0, 0)  -- internally driven position
+_pos_px = v2d.Vector2D(0, 0)  -- internally driven position
 _vel = v2d.Vector2D(0, 0)
 
 ------------------------------------------------------------------------------------------------------------------------
@@ -162,7 +162,7 @@ function update(dt)
       updateStateTransitions(dt)
       updateStateBehavior(dt)
       updateSpriteDirection()
-      _position_px = _pos
+      _position_px = _pos_px
    end
 
    if (_dead) then
@@ -184,8 +184,8 @@ function updateStateTransitions(dt)
 
    -- If bat is outside leash already (dt spike / edge case), force return
    local outOfLeash =
-      (math.abs((_pos:getX() // 24) - (_start_position_px:getX() // 24)) > LEASH_X_TILES) or
-      (math.abs((_pos:getY() // 24) - (_start_position_px:getY() // 24)) > LEASH_Y_TILES)
+      (math.abs((_pos_px:getX() // 24) - (_start_position_px:getX() // 24)) > LEASH_X_TILES) or
+      (math.abs((_pos_px:getY() // 24) - (_start_position_px:getY() // 24)) > LEASH_Y_TILES)
 
    -- state transitions
    if (playerInAggro and (not outOfLeash)) then
@@ -223,9 +223,9 @@ function updateStateIdle(dt)
       _start_position_px:getY() + oy * blend
    )
 
-   _pos = _pos:add(target:sub(_pos):mul(clamp(HOVER_EASE * dt, 0.0, 1.0)))
+   _pos_px = _pos_px:add(target:sub(_pos_px):mul(clamp(HOVER_EASE * dt, 0.0, 1.0)))
    _vel = _vel:mul(0.85)
-   setTransform(_pos:getX(), _pos:getY(), 0.0)
+   setTransform(_pos_px:getX(), _pos_px:getY(), 0.0)
 end
 
 -- Follow state behavior
@@ -239,7 +239,7 @@ function updateStateFollow(dt)
 
    -- add orbit/fluter when very close so it doesn't "pin" to a single pixel
    -- compute closeness BEFORE leashing (more natural), then leash final target
-   local toTarget = target:sub(_pos)
+   local toTarget = target:sub(_pos_px)
    local dist = toTarget:len()
 
    if (dist < ORBIT_START_DIST) then
@@ -257,20 +257,20 @@ function updateStateFollow(dt)
    -- leash the target so bat never leaves its base zone
    target = clampToLeash(target)
 
-   local desired = target:sub(_pos):norm():mul(FOLLOW_SPEED)
+   local desired = target:sub(_pos_px):norm():mul(FOLLOW_SPEED)
    _vel = _vel:add(desired:sub(_vel):mul(clamp(FOLLOW_TURN * dt, 0.0, 1.0)))
-   _pos = _pos:add(_vel:mul(dt))
-   setTransform(_pos:getX(), _pos:getY(), 0.0)
+   _pos_px = _pos_px:add(_vel:mul(dt))
+   setTransform(_pos_px:getX(), _pos_px:getY(), 0.0)
 end
 
 -- Return state behavior
 function updateStateReturn(dt)
    local home = v2d.Vector2D(_start_position_px:getX(), _start_position_px:getY())
-   local toHome = home:sub(_pos)
+   local toHome = home:sub(_pos_px)
    local dist = toHome:len()
 
    if (dist <= RETURN_DONE_DIST) then
-      _pos = home
+      _pos_px = home
       _vel = v2d.Vector2D(0, 0)
       enterState(STATE_IDLE)
       _state_time = 0.0
@@ -279,15 +279,15 @@ function updateStateReturn(dt)
       local desired = toHome:norm():mul(RETURN_SPEED * slow)
 
       _vel = _vel:add(desired:sub(_vel):mul(clamp(RETURN_TURN * dt, 0.0, 1.0)))
-      _pos = _pos:add(_vel:mul(dt))
+      _pos_px = _pos_px:add(_vel:mul(dt))
    end
 
-   setTransform(_pos:getX(), _pos:getY(), 0.0)
+   setTransform(_pos_px:getX(), _pos_px:getY(), 0.0)
 end
 
 -- Update sprite direction based on player position
 function updateSpriteDirection()
-   local bx = _pos:getX()
+   local bx = _pos_px:getX()
    local px = _player_position_px:getX()
    if (_can_explode) then
       _sprite_offset_y = (px > bx) and (4 * _sprite_height) or (5 * _sprite_height)
@@ -350,9 +350,9 @@ end
 ------------------------------------------------------------------------------------------------------------------------
 function setStartPosition(x, y)
    _start_position_px = v2d.Vector2D(x, y)
-   _pos = v2d.Vector2D(x, y)
+   _pos_px = v2d.Vector2D(x, y)
    _vel = v2d.Vector2D(0, 0)
-   _position_px = _pos
+   _position_px = _pos_px
    _state = STATE_IDLE
    _state_time = 0.0
 end
@@ -365,7 +365,7 @@ function movedTo(x, y)
       _start_position_px = v2d.Vector2D(x, y)
    end
 
-   _pos = v2d.Vector2D(x, y)
+   _pos_px = v2d.Vector2D(x, y)
 end
 
 ------------------------------------------------------------------------------------------------------------------------

--- a/data/scripts/enemies/bat_oneway.lua
+++ b/data/scripts/enemies/bat_oneway.lua
@@ -42,9 +42,9 @@ properties = {
 
 
 ------------------------------------------------------------------------------------------------------------------------
-_position = v2d.Vector2D(0, 0)
+_position_px = v2d.Vector2D(0, 0)
 _positionAtDeath = v2d.Vector2D(0, 0)
-_player_position = v2d.Vector2D(0, 0)
+_player_position_px = v2d.Vector2D(0, 0)
 _player_positionPrevious = v2d.Vector2D(0, 0)
 _elapsed = math.random(0, 3)
 _attackTime = 0
@@ -55,7 +55,7 @@ _sprite_offset_x = 0
 _sprite_offset_y = 0 -- 9 * 24
 _sprite_width = 72
 _sprite_height = 72
-_start_position = v2d.Vector2D(0, 0)
+_start_position_px = v2d.Vector2D(0, 0)
 _dying = false
 _dead = false
 _death_time = 0
@@ -100,11 +100,11 @@ function shoot()
 
    _attackTime = _elapsed
 
-   bx = _position:getX()
-   by = _position:getY()
+   bx = _position_px:getX()
+   by = _position_px:getY()
 
-   px = _player_position:getX()
-   py = _player_position:getY()
+   px = _player_position_px:getX()
+   py = _player_position_px:getY()
 
    if (_can_explode) then
       _sprite_offset_y = (px > bx) and (4 * _sprite_height) or (5 * _sprite_height)
@@ -112,8 +112,8 @@ function shoot()
       _sprite_offset_y = (px > bx) and 0 or _sprite_height
    end
 
-   sx = _start_position:getX()
-   sy = _start_position:getY()
+   sx = _start_position_px:getX()
+   sy = _start_position_px:getY()
 
    k1 = Key:create{x = bx, y = by, time = 0.0}
    k2 = Key:create{x = px, y = py, time = 0.5} -- player pos
@@ -142,7 +142,7 @@ function update(dt)
          _sprite_offset_x = 0
          _sprite_offset_y = 2 * _sprite_height
          setActive(false)
-         _positionAtDeath = _position
+         _positionAtDeath = _position_px
       end
    end
 
@@ -162,7 +162,7 @@ function update(dt)
          if (_activated) then
             _transform_x = _transform_x + dt * _speed
          end
-         setTransform(_start_position:getX() + _transform_x, _start_position:getY() + _transform_y, 0.0)
+         setTransform(_start_position_px:getX() + _transform_x, _start_position_px:getY() + _transform_y, 0.0)
       end
    end
 
@@ -190,7 +190,7 @@ function update(dt)
       updateSprite = true
    end
 
-   -- updateDebugRect(0, _position:getX() - 12, _position:getY() + 12, 24, 24)
+   -- updateDebugRect(0, _position_px:getX() - 12, _position_px:getY() + 12, 24, 24)
 
    if (_activated and _can_explode and not _exploded and not _dead) then
 
@@ -203,7 +203,7 @@ function update(dt)
       -- |    |(XX)|    |
       -- +----+----+----+
 
-      intersects = intersectsWithPlayer(_position:getX() - 12, _position:getY() + 12, 24, 24)
+      intersects = intersectsWithPlayer(_position_px:getX() - 12, _position_px:getY() + 12, 24, 24)
 
       if (intersects) then
 
@@ -212,7 +212,7 @@ function update(dt)
 
          boom(0.0, 1.0, 0.5)
          playSample("boom.wav")
-         playDetonationAnimation(_position:getX(), _position:getY())
+         playDetonationAnimation(_position_px:getX(), _position_px:getY())
          damage(10, 0.0, 0.0)
       end
    end
@@ -243,19 +243,19 @@ end
 
 ------------------------------------------------------------------------------------------------------------------------
 function setStartPosition(x, y)
-   _start_position = v2d.Vector2D(x, y)
+   _start_position_px = v2d.Vector2D(x, y)
 end
 
 
 ------------------------------------------------------------------------------------------------------------------------
 function movedTo(x, y)
-   _position = v2d.Vector2D(x, y)
+   _position_px = v2d.Vector2D(x, y)
 end
 
 
 ------------------------------------------------------------------------------------------------------------------------
 function playerMovedTo(x, y)
-   _player_position = v2d.Vector2D(x, y)
+   _player_position_px = v2d.Vector2D(x, y)
 end
 
 

--- a/data/scripts/enemies/bat_oneway.lua
+++ b/data/scripts/enemies/bat_oneway.lua
@@ -51,16 +51,16 @@ _attackTime = 0
 _idle_time = 0
 _activated = false
 _move_range_y = 48
-_sprite_offset_x = 0
-_sprite_offset_y = 0 -- 9 * 24
-_sprite_width = 72
-_sprite_height = 72
+_sprite_offset_x_px = 0
+_sprite_offset_y_px = 0 -- 9 * 24
+_sprite_width_px = 72
+_sprite_height_px = 72
 _start_position_px = v2d.Vector2D(0, 0)
 _dying = false
 _dead = false
 _death_time = 0
 _transform_x = 0
-_transform_y = 0
+_transform_y_px = 0
 _attack = false
 _can_explode = false
 _exploded = false
@@ -71,7 +71,7 @@ _speed = 0.1
 ANIMATION_SPEED = 40.0
 ANIMATION_SPEED_IDLE = 20.0
 ANIMATION_SPEED_DEATH = 20.0
-HIT_RADIUS = 0.3
+HIT_RADIUS_M = 0.3
 ATTACK_DURATION = 1.0
 ATTACK_SPRITE_COUNT = 9
 
@@ -80,13 +80,13 @@ ATTACK_SPRITE_COUNT = 9
 function initialize()
    addSample("boom.wav")
    addHitbox(-18, -12, 36, 24)
-   addShapeCircle(HIT_RADIUS, 0.0, 0.0)
+   addShapeCircle(HIT_RADIUS_M, 0.0, 0.0)
    updateSpriteRect(
       0,
       0,
       0,
-      _sprite_width,
-      _sprite_height
+      _sprite_width_px,
+      _sprite_height_px
    )
    setZ(30) -- somewhere in the foreground
 
@@ -107,9 +107,9 @@ function shoot()
    py = _player_position_px:getY()
 
    if (_can_explode) then
-      _sprite_offset_y = (px > bx) and (4 * _sprite_height) or (5 * _sprite_height)
+      _sprite_offset_y_px = (px > bx) and (4 * _sprite_height_px) or (5 * _sprite_height_px)
    else
-      _sprite_offset_y = (px > bx) and 0 or _sprite_height
+      _sprite_offset_y_px = (px > bx) and 0 or _sprite_height_px
    end
 
    sx = _start_position_px:getX()
@@ -139,8 +139,8 @@ function update(dt)
       if (_energy == 0) then
          _dying = true
          _death_time = _elapsed
-         _sprite_offset_x = 0
-         _sprite_offset_y = 2 * _sprite_height
+         _sprite_offset_x_px = 0
+         _sprite_offset_y_px = 2 * _sprite_height_px
          setActive(false)
          _positionAtDeath = _position_px
       end
@@ -156,13 +156,13 @@ function update(dt)
       if (not _attack or idle) then
 
          -- update transform
-         -- _transform_y = 0.25 * math.sin(_elapsed) * _move_range_y
-         _transform_y = 0
+         -- _transform_y_px = 0.25 * math.sin(_elapsed) * _move_range_y
+         _transform_y_px = 0
 
          if (_activated) then
             _transform_x = _transform_x + dt * _speed
          end
-         setTransform(_start_position_px:getX() + _transform_x, _start_position_px:getY() + _transform_y, 0.0)
+         setTransform(_start_position_px:getX() + _transform_x, _start_position_px:getY() + _transform_y_px, 0.0)
       end
    end
 
@@ -185,8 +185,8 @@ function update(dt)
    end
 
    -- update sprite index
-   if (index ~= _sprite_offset_x) then
-      _sprite_offset_x = sprite_index
+   if (index ~= _sprite_offset_x_px) then
+      _sprite_offset_x_px = sprite_index
       updateSprite = true
    end
 
@@ -220,10 +220,10 @@ function update(dt)
    if (updateSprite) then
       updateSpriteRect(
          0,
-         _sprite_offset_x * _sprite_width,
-         _sprite_offset_y,
-         _sprite_width,
-         _sprite_height
+         _sprite_offset_x_px * _sprite_width_px,
+         _sprite_offset_y_px,
+         _sprite_width_px,
+         _sprite_height_px
       ) -- x, y, width, height
    end
 
@@ -276,7 +276,7 @@ function writeProperty(key, value)
       _speed = tonumber(value)
    elseif (key == "exploding") then
       _can_explode = true
-      _sprite_offset_y = 4 * 3 * 24
+      _sprite_offset_y_px = 4 * 3 * 24
    elseif (key == "audio_update_behavior") then
       update_behavior = audioUpdateBehaviorFromString(value)
       setAudioUpdateBehavior(update_behavior)

--- a/data/scripts/enemies/bat_patrol.lua
+++ b/data/scripts/enemies/bat_patrol.lua
@@ -28,8 +28,8 @@ mDirection = "horizontal"
 mElapsed = math.random(0, 3)
 
 -- sprite / animation
-SPRITE_W = 72
-SPRITE_H = 72
+SPRITE_W_PX = 72
+SPRITE_H_PX = 72
 SPRITE_FRAMES = 9
 ANIM_SPEED = 20.0
 
@@ -43,7 +43,7 @@ function initialize()
    addHitbox(-18, -12, 36, 24)
    addShapeCircle(0.3, 0.0, 0.0)
 
-   updateSpriteRect(0, 0, 0, SPRITE_W, SPRITE_H)
+   updateSpriteRect(0, 0, 0, SPRITE_W_PX, SPRITE_H_PX)
    setZ(30)
 end
 
@@ -76,7 +76,7 @@ function update(dt)
          yOffset = 0
       else
          pointsLeft = true
-         yOffset = SPRITE_H
+         yOffset = SPRITE_H_PX
       end      
    end
 
@@ -97,7 +97,7 @@ function update(dt)
    end
 
    if (updateSprite) then
-      updateSpriteRect(0, mSpriteIndex * SPRITE_W, yOffset, SPRITE_W, SPRITE_H)
+      updateSpriteRect(0, mSpriteIndex * SPRITE_W_PX, yOffset, SPRITE_W_PX, SPRITE_H_PX)
    end
 end
 

--- a/data/scripts/enemies/blob_2.lua
+++ b/data/scripts/enemies/blob_2.lua
@@ -49,8 +49,8 @@ IDLE_CYCLE_COUNT = 3
 
 COLLISION_THRESHOLD = 24
 
-_position = v2d.Vector2D(0, 0)
-_player_position = v2d.Vector2D(0, 0)
+_position_px = v2d.Vector2D(0, 0)
+_player_position_px = v2d.Vector2D(0, 0)
 _elapsed = 0.0
 _sprite_index = 0
 _animation_row = 0
@@ -252,13 +252,13 @@ end
 
 ------------------------------------------------------------------------------------------------------------------------
 function movedTo(x, y)
-   _position = v2d.Vector2D(x, y)
+   _position_px = v2d.Vector2D(x, y)
 end
 
 
 ------------------------------------------------------------------------------------------------------------------------
 function playerMovedTo(x, y)
-   _player_position = v2d.Vector2D(x, y)
+   _player_position_px = v2d.Vector2D(x, y)
 end
 
 
@@ -267,9 +267,9 @@ end
 -- |          p      o          | x
 function followPlayer()
    local epsilon = 5
-   if (_player_position:getX() > _position:getX() + epsilon) then
+   if (_player_position_px:getX() > _position_px:getX() + epsilon) then
       goRight()
-   elseif (_player_position:getX() < _position:getX() - epsilon) then
+   elseif (_player_position_px:getX() < _position_px:getX() - epsilon) then
       goLeft()
    else
       _key_pressed = 0
@@ -352,10 +352,10 @@ function updatePatrol()
    local keyVec = v2d.Vector2D(key:getX(), key:getY())
    local count = #_patrol_path
 
-   if     (_position:getX() > keyVec:getX() + _patrol_epsilon) then
+   if     (_position_px:getX() > keyVec:getX() + _patrol_epsilon) then
       -- print(string.format("go left %d", _tick))
       goLeft()
-   elseif (_position:getX() < keyVec:getX() - _patrol_epsilon) then
+   elseif (_position_px:getX() < keyVec:getX() - _patrol_epsilon) then
       -- print(string.format("go right %d", _tick))
       goRight()
    else
@@ -392,7 +392,7 @@ function updateJump(dt)
 
    y = _jump_start_position:getY() - jump_height * jump_value + 12;
 
-   setTransform(_position:getX(), y, 0.0)
+   setTransform(_position_px:getX(), y, 0.0)
 
    index = 0
    row = 0
@@ -434,22 +434,22 @@ function updateDrop(dt)
    -- check if need to drop
    if (not _drop_prepare and _alignment_offset > 0) then
 
-      dx = _position:getX() - _player_position:getX()
+      dx = _position_px:getX() - _player_position_px:getX()
 
       if (dx > -COLLISION_THRESHOLD and dx < COLLISION_THRESHOLD) then
 
          -- make sure stone is not too far away (10 tiles) and above player
-         y_diff = _position:getY() // 24 - _player_position:getY() // 24
+         y_diff = _position_px:getY() // 24 - _player_position_px:getY() // 24
 
          if (y_diff < 0 and y_diff > -10) then
 
             -- make sure there's nothing in the way
             if (
                isPhsyicsPathClear(
-                  _position:getX(),
-                  _position:getY(),
-                  _player_position:getX(),
-                  _player_position:getY()
+                  _position_px:getX(),
+                  _position_px:getY(),
+                  _player_position_px:getX(),
+                  _player_position_px:getY()
                )
             )
             then

--- a/data/scripts/enemies/blob_2.lua
+++ b/data/scripts/enemies/blob_2.lua
@@ -17,8 +17,8 @@ properties = {
 _patrol_timer = 1
 _key_pressed = 0
 
-SPRITE_WIDTH = 72
-SPRITE_HEIGHT = 72
+SPRITE_WIDTH_PX = 72
+SPRITE_HEIGHT_PX = 72
 
 -- idle         row 0    15 sprites
 -- left         row 1    16 sprites
@@ -47,7 +47,7 @@ SPRITE_COUNT_LANDING = 11 -- last one is skipped, that doesn't make sense
 ANIMATION_SPEED = 20.0
 IDLE_CYCLE_COUNT = 3
 
-COLLISION_THRESHOLD = 24
+COLLISION_THRESHOLD_PX = 24
 
 _position_px = v2d.Vector2D(0, 0)
 _player_position_px = v2d.Vector2D(0, 0)
@@ -102,7 +102,7 @@ function initialize()
 
    addShapeCircle(0.12, 0.0, 0.12)                        -- radius, x, y
    addShapeRect(0.2, 0.07, 0.0, 0.1)                      -- width, height, x, y
-   updateSpriteRect(0, 0, 0, SPRITE_WIDTH, SPRITE_HEIGHT) -- id, x, y, width, height
+   updateSpriteRect(0, 0, 0, SPRITE_WIDTH_PX, SPRITE_HEIGHT_PX) -- id, x, y, width, height
    addHitbox(-18, -18, 36, 36)                            -- x offset, y offset, width, height
 
    addSample("splat_01.wav")
@@ -182,10 +182,10 @@ function goLeft()
 
       updateSpriteRect(
          0,
-         _sprite_index * SPRITE_WIDTH,
-         _animation_row * SPRITE_HEIGHT + _alignment_offset,
-         SPRITE_WIDTH,
-         SPRITE_HEIGHT
+         _sprite_index * SPRITE_WIDTH_PX,
+         _animation_row * SPRITE_HEIGHT_PX + _alignment_offset,
+         SPRITE_WIDTH_PX,
+         SPRITE_HEIGHT_PX
       )
 
    end
@@ -206,10 +206,10 @@ function goRight()
 
       updateSpriteRect(
          0,
-         _sprite_index * SPRITE_WIDTH,
-         _animation_row * SPRITE_HEIGHT + _alignment_offset,
-         SPRITE_WIDTH,
-         SPRITE_HEIGHT
+         _sprite_index * SPRITE_WIDTH_PX,
+         _animation_row * SPRITE_HEIGHT_PX + _alignment_offset,
+         SPRITE_WIDTH_PX,
+         SPRITE_HEIGHT_PX
       )
 
    end
@@ -238,10 +238,10 @@ function updateDeath()
 
       updateSpriteRect(
          0,
-         _sprite_index * SPRITE_WIDTH,
-         _animation_row * SPRITE_HEIGHT,
-         SPRITE_WIDTH,
-         SPRITE_HEIGHT
+         _sprite_index * SPRITE_WIDTH_PX,
+         _animation_row * SPRITE_HEIGHT_PX,
+         SPRITE_WIDTH_PX,
+         SPRITE_HEIGHT_PX
       )
 
    end
@@ -287,10 +287,10 @@ function wait()
             _sprite_index = sprite_index
             updateSpriteRect(
                0,
-               _sprite_index * SPRITE_WIDTH,
-               _animation_row * SPRITE_HEIGHT + _alignment_offset,
-               SPRITE_WIDTH,
-               SPRITE_HEIGHT
+               _sprite_index * SPRITE_WIDTH_PX,
+               _animation_row * SPRITE_HEIGHT_PX + _alignment_offset,
+               SPRITE_WIDTH_PX,
+               SPRITE_HEIGHT_PX
             )
          end
       else
@@ -305,10 +305,10 @@ function wait()
          _sprite_index = sprite_index
          updateSpriteRect(
             0,
-            _sprite_index * SPRITE_WIDTH,
-            _animation_row * SPRITE_HEIGHT + _alignment_offset,
-            SPRITE_WIDTH,
-            SPRITE_HEIGHT
+            _sprite_index * SPRITE_WIDTH_PX,
+            _animation_row * SPRITE_HEIGHT_PX + _alignment_offset,
+            SPRITE_WIDTH_PX,
+            SPRITE_HEIGHT_PX
          )
 
          -- after 1 cycle, go back to business
@@ -407,10 +407,10 @@ function updateJump(dt)
 
    updateSpriteRect(
       0,
-      index * SPRITE_WIDTH,
-      row * SPRITE_HEIGHT,
-      SPRITE_WIDTH,
-      SPRITE_HEIGHT
+      index * SPRITE_WIDTH_PX,
+      row * SPRITE_HEIGHT_PX,
+      SPRITE_WIDTH_PX,
+      SPRITE_HEIGHT_PX
    )
 
    _jump_time = _jump_time + dt * jump_speed
@@ -436,7 +436,7 @@ function updateDrop(dt)
 
       dx = _position_px:getX() - _player_position_px:getX()
 
-      if (dx > -COLLISION_THRESHOLD and dx < COLLISION_THRESHOLD) then
+      if (dx > -COLLISION_THRESHOLD_PX and dx < COLLISION_THRESHOLD_PX) then
 
          -- make sure stone is not too far away (10 tiles) and above player
          y_diff = _position_px:getY() // 24 - _player_position_px:getY() // 24
@@ -507,10 +507,10 @@ function updateDrop(dt)
             end
             updateSpriteRect(
                0,
-               _sprite_index * SPRITE_WIDTH,
-               _animation_row * SPRITE_HEIGHT - (12 - sprite_offset),
-               SPRITE_WIDTH,
-               SPRITE_HEIGHT
+               _sprite_index * SPRITE_WIDTH_PX,
+               _animation_row * SPRITE_HEIGHT_PX - (12 - sprite_offset),
+               SPRITE_WIDTH_PX,
+               SPRITE_HEIGHT_PX
             )
 
             -- once we reach column 5, the blob is more or less detach from the ceiling,
@@ -562,10 +562,10 @@ function updateDrop(dt)
 
             updateSpriteRect(
                0,
-               _sprite_index * SPRITE_WIDTH,
-               _animation_row * SPRITE_HEIGHT,
-               SPRITE_WIDTH,
-               SPRITE_HEIGHT
+               _sprite_index * SPRITE_WIDTH_PX,
+               _animation_row * SPRITE_HEIGHT_PX,
+               SPRITE_WIDTH_PX,
+               SPRITE_HEIGHT_PX
             )
          end
       end

--- a/data/scripts/enemies/cannon_2.lua
+++ b/data/scripts/enemies/cannon_2.lua
@@ -34,8 +34,8 @@ mProjectileIndex = 0
 mIdle = true
 mFired = false
 
-SPRITE_WIDTH = 6 * 24
-SPRITE_HEIGHT = 3 * 24
+SPRITE_WIDTH_PX = 6 * 24
+SPRITE_HEIGHT_PX = 3 * 24
 
 
 ------------------------------------------------------------------------------------------------------------------------
@@ -94,8 +94,8 @@ function initialize()
       0,
       0,
       0,
-      SPRITE_WIDTH,
-      SPRITE_HEIGHT
+      SPRITE_WIDTH_PX,
+      SPRITE_HEIGHT_PX
    )
 end
 
@@ -107,7 +107,7 @@ function writeProperty(key, value)
       if (value == "right") then
          -- print("setting alignment to left")
          mX = 1.0
-         mAlignmentOffset = 5 * SPRITE_HEIGHT
+         mAlignmentOffset = 5 * SPRITE_HEIGHT_PX
       end
    elseif (key == "time_offset_s") then
       mElapsedUntilFired = mElapsedUntilFired + tonumber(value)
@@ -227,10 +227,10 @@ function update(dt)
    if (index ~= mSpriteIndex) then
       updateSpriteRect(
          0,
-         col * SPRITE_WIDTH,
-         row * SPRITE_HEIGHT + mAlignmentOffset,
-         SPRITE_WIDTH,
-         SPRITE_HEIGHT
+         col * SPRITE_WIDTH_PX,
+         row * SPRITE_HEIGHT_PX + mAlignmentOffset,
+         SPRITE_WIDTH_PX,
+         SPRITE_HEIGHT_PX
       )
    end
 

--- a/data/scripts/enemies/frog.lua
+++ b/data/scripts/enemies/frog.lua
@@ -42,16 +42,16 @@ v2d = require "data/scripts/enemies/vectorial2"
 
 ROW_OFFSET_RIGHT = 3
 FRAME_COUNTS = {8, 8, 6, 19}
-DEBUG_ATTACK_OFFSET = 0 * 48  -- 8x48 px offset when attacking
+DEBUG_ATTACK_OFFSET_PX = 0 * 48  -- 8x48 px offset when attacking
 
 MIN_ATTACK_WAIT = 1.5  -- Minimum wait time in seconds between attacks
 
 MAX_TONGUE_SCALE = 5.0  -- Maximum scale factor for the tongue extension
-SPRITE_WIDTH = 48
-SPRITE_HEIGHT = 48
+SPRITE_WIDTH_PX = 48
+SPRITE_HEIGHT_PX = 48
 
-SPRITE_WIDTH_DYING = 72
-SPRITE_HEIGHT_DYING = 72
+SPRITE_WIDTH_DYING_PX = 72
+SPRITE_HEIGHT_DYING_PX = 72
 SPRITE_ROW_DYING = 6
 
 STATE_IDLE = 1
@@ -243,7 +243,7 @@ end
 ------------------------------------------------------------------------------------------------------------------------
 function logSprite(dt)
 
-   local current_row = math.floor(y / SPRITE_HEIGHT)
+   local current_row = math.floor(y / SPRITE_HEIGHT_PX)
 
    if _prev_log_sprite_row ~= current_row then
 
@@ -474,7 +474,7 @@ function writeProperty(key, value)
       _tongue_extension_x = 288
 
       if (value == "right") then
-         _alignment_offset = 3 * SPRITE_HEIGHT
+         _alignment_offset = 3 * SPRITE_HEIGHT_PX
          _points_left = false
          _tongue_direction_multiplier = 1  -- 1 for right
          _tongue_extension_y = 264
@@ -526,11 +526,11 @@ function getIdleSpriteCoords()
    end
    
    local frame_index = math.floor(_animation_frame) % max_frames
-   local x = frame_index * SPRITE_WIDTH
-   local y = (cycle - 1) * SPRITE_HEIGHT
+   local x = frame_index * SPRITE_WIDTH_PX
+   local y = (cycle - 1) * SPRITE_HEIGHT_PX
    y = y + _alignment_offset
    
-   return x, y, SPRITE_WIDTH, SPRITE_WIDTH
+   return x, y, SPRITE_WIDTH_PX, SPRITE_WIDTH_PX
 end
 
 ------------------------------------------------------------------------------------------------------------------------
@@ -568,25 +568,25 @@ function getAttackSpriteCoords()
    end
 
    -- calculate sprite coordinates
-   local x = frame_index * SPRITE_WIDTH
-   local y = (cycle - 1) * SPRITE_HEIGHT
+   local x = frame_index * SPRITE_WIDTH_PX
+   local y = (cycle - 1) * SPRITE_HEIGHT_PX
 
    -- Apply attack sprite offset when attacking
-   x = x + DEBUG_ATTACK_OFFSET
+   x = x + DEBUG_ATTACK_OFFSET_PX
 
    -- Apply alignment offset for non-dying states
    y = y + _alignment_offset
 
-   return x, y, SPRITE_WIDTH, SPRITE_HEIGHT
+   return x, y, SPRITE_WIDTH_PX, SPRITE_HEIGHT_PX
 end
 
 ------------------------------------------------------------------------------------------------------------------------
 function getDyingSpriteCoords()
    local death_frame_index = math.floor(_death_animation_frame)
    
-   local x = death_frame_index * SPRITE_WIDTH_DYING
-   local y = SPRITE_ROW_DYING * SPRITE_HEIGHT_DYING
-   return x, y, SPRITE_WIDTH_DYING, SPRITE_HEIGHT_DYING
+   local x = death_frame_index * SPRITE_WIDTH_DYING_PX
+   local y = SPRITE_ROW_DYING * SPRITE_HEIGHT_DYING_PX
+   return x, y, SPRITE_WIDTH_DYING_PX, SPRITE_HEIGHT_DYING_PX
 end
 
 ------------------------------------------------------------------------------------------------------------------------

--- a/data/scripts/enemies/frog.lua
+++ b/data/scripts/enemies/frog.lua
@@ -67,8 +67,8 @@ CYCLE_DYING = 4
 ------------------------------------------------------------------------------------------------------------------------
 -- member variables
 _done = false
-_position = v2d.Vector2D(0, 0)
-_player_position = v2d.Vector2D(0, 0)
+_position_px = v2d.Vector2D(0, 0)
+_player_position_px = v2d.Vector2D(0, 0)
 _elapsed = 0
 _alignment_offset = 0
 _state = STATE_IDLE
@@ -159,8 +159,8 @@ function checkAttackCondition(next_state)
    -- only check for attack transition if we're in a state that allows it
    if next_state == _state and _state ~= STATE_DYING and _state ~= STATE_ATTACK then
       -- check for attack transition
-      x_diff = _player_position:getX() // 24 - _position:getX() // 24
-      y_diff = _player_position:getY() // 24 - _position:getY() // 24
+      x_diff = _player_position_px:getX() // 24 - _position_px:getX() // 24
+      y_diff = _player_position_px:getY() // 24 - _position_px:getY() // 24
 
       x_in_range =
          (_points_left and x_diff >= -5 and x_diff <= 0) or
@@ -177,10 +177,10 @@ function checkAttackCondition(next_state)
       if (y_in_range and x_in_range and tongue_retracted and can_attack) then
          if (
             isPhsyicsPathClear(
-               _position:getX(),
-               _position:getY(),
-               _player_position:getX(),
-               _player_position:getY()
+               _position_px:getX(),
+               _position_px:getY(),
+               _player_position_px:getX(),
+               _player_position_px:getY()
             )
          ) then
             -- print("Frog: Attack triggered, x_diff: " .. x_diff)
@@ -300,7 +300,7 @@ function updateSpriteAttack(dt)
    local current_attack_frame = math.floor(_animation_frame)
 
    -- calculate distance to player to determine tongue length
-   local dist_to_player = math.abs(_player_position:getX() - _position:getX())
+   local dist_to_player = math.abs(_player_position_px:getX() - _position_px:getX())
 
    -- Calculate the current frame index to determine if animation has completed
    local current_frame_index = math.floor(_attack_animation_time * _attack_animation_speed * _attack_anim_speed)
@@ -336,8 +336,8 @@ function updateSpriteAttack(dt)
    local displayed_tongue_width = 24 * _tongue_scale
 
    local base_x, base_y
-   base_x = _position:getX()
-   base_y = _position:getY()
+   base_x = _position_px:getX()
+   base_y = _position_px:getY()
    local tongue_tip_offset_x = 0
    local tongue_base_offset_x = 36
 
@@ -421,7 +421,7 @@ end
 
 ------------------------------------------------------------------------------------------------------------------------
 function movedTo(x, y)
-   _position = v2d.Vector2D(x, y)
+   _position_px = v2d.Vector2D(x, y)
 end
 
 
@@ -432,8 +432,8 @@ function playerMovedTo(x, y)
       return
    end
 
-   _player_position = v2d.Vector2D(x, y)
-   distance_to_player = (_player_position - _position):getLength()
+   _player_position_px = v2d.Vector2D(x, y)
+   distance_to_player = (_player_position_px - _position_px):getLength()
 end
 
 

--- a/data/scripts/enemies/frog_blue.lua
+++ b/data/scripts/enemies/frog_blue.lua
@@ -112,8 +112,8 @@ CYCLE_DYING = 4
 ------------------------------------------------------------------------------------------------------------------------
 -- member variables
 _done = false
-_position = v2d.Vector2D(0, 0)
-_player_position = v2d.Vector2D(0, 0)
+_position_px = v2d.Vector2D(0, 0)
+_player_position_px = v2d.Vector2D(0, 0)
 _elapsed = 0
 _alignment_offset = 0
 _state = STATE_IDLE
@@ -399,8 +399,8 @@ function updateFireball(dt)
 
    -- Use a smaller hit area inside the orb so the visual feels fair. The rect is centered on the
    -- visible dot, which is offset from the center of the 120x120 sprite frame.
-   local orb_center_x = _position:getX() + fireball_offset_x + FIREBALL_VISUAL_CENTER_X - FIREBALL_WIDTH / 2
-   local orb_center_y = _position:getY() + fireball_offset_y + FIREBALL_VISUAL_CENTER_Y - FIREBALL_HEIGHT / 2
+   local orb_center_x = _position_px:getX() + fireball_offset_x + FIREBALL_VISUAL_CENTER_X - FIREBALL_WIDTH / 2
+   local orb_center_y = _position_px:getY() + fireball_offset_y + FIREBALL_VISUAL_CENTER_Y - FIREBALL_HEIGHT / 2
    local hitbox_x = orb_center_x - _orb_collision_size / 2
    local hitbox_y = orb_center_y - _orb_collision_size / 2
    if not _fireball_hit_player and intersectsWithPlayer(hitbox_x, hitbox_y, _orb_collision_size, _orb_collision_size) then
@@ -486,7 +486,7 @@ end
 
 ------------------------------------------------------------------------------------------------------------------------
 function movedTo(x, y)
-   _position = v2d.Vector2D(x, y)
+   _position_px = v2d.Vector2D(x, y)
 end
 
 
@@ -497,8 +497,8 @@ function playerMovedTo(x, y)
       return
    end
 
-   _player_position = v2d.Vector2D(x, y)
-   distance_to_player = (_player_position - _position):getLength()
+   _player_position_px = v2d.Vector2D(x, y)
+   distance_to_player = (_player_position_px - _position_px):getLength()
 end
 
 

--- a/data/scripts/enemies/frog_blue.lua
+++ b/data/scripts/enemies/frog_blue.lua
@@ -46,8 +46,8 @@ v2d = require "data/scripts/enemies/vectorial2"
 
 ROW_OFFSET_RIGHT = 3
 FRAME_COUNTS = {8, 8, 6, 19}
-BLUE_FROG_X_OFFSET = 768  -- Blue frog frames start here on the sprite sheet
-DEBUG_ATTACK_OFFSET = 0 * 48  -- extra debug x offset when attacking
+BLUE_FROG_X_OFFSET_PX = 768  -- Blue frog frames start here on the sprite sheet
+DEBUG_ATTACK_OFFSET_PX = 0 * 48  -- extra debug x offset when attacking
 
 DEFAULT_ATTACK_INTERVAL = 3.0  -- Shoot automatically every 3 seconds, regardless of player range
 
@@ -55,25 +55,25 @@ DEFAULT_FIREBALL_SPEED = 160.0
 DEFAULT_ORB_LIFETIME = 3000  -- lifetime in milliseconds before disappearing
 
 DEFAULT_ORB_PATH = "straight"
-DEFAULT_WAVE_STRENGTH = 24.0
+DEFAULT_WAVE_STRENGTH_PX = 24.0
 DEFAULT_WAVE_SPEED = 8.0
 -- First visible fireball position. Tweaked so the orb appears right at the blue frog mouth,
 -- not one full orb-width away from the body.
-FIREBALL_START_OFFSET_LEFT = 18
-FIREBALL_START_OFFSET_RIGHT =28
-FIREBALL_START_OFFSET_Y = 0
-FIREBALL_WIDTH = 120
-FIREBALL_HEIGHT = 120
-FIREBALL_ROW_Y = 312
-FIREBALL_FRAME_SPACING = 120
+FIREBALL_START_OFFSET_LEFT_PX = 18
+FIREBALL_START_OFFSET_RIGHT_PX =28
+FIREBALL_START_OFFSET_Y_PX = 0
+FIREBALL_WIDTH_PX = 120
+FIREBALL_HEIGHT_PX = 120
+FIREBALL_ROW_Y_PX = 312
+FIREBALL_FRAME_SPACING_PX = 120
 FIREBALL_FRAME_COUNT = 8
 -- The orb graphic does not fill its 120x120 frame; the visible dot sits at (36, 60) inside the frame
 -- while the engine draws the sprite centered on the node position plus the sprite offset.
 -- Both values are needed to place the hit rect on the dot instead of on the frame center.
-FIREBALL_VISUAL_CENTER_X = 36
-FIREBALL_VISUAL_CENTER_Y = 60
+FIREBALL_VISUAL_CENTER_X_PX = 36
+FIREBALL_VISUAL_CENTER_Y_PX = 60
 -- Size of the bright core of the orb. The surrounding glow is intentionally not part of the hit area.
-DEFAULT_ORB_COLLISION_SIZE = 16
+DEFAULT_ORB_COLLISION_SIZE_PX = 16
 -- z index the orb is drawn at. The frog itself stays on its own z index, so the orb can travel
 -- in front of foreground tiles without dragging the frog along.
 DEFAULT_ORB_Z = 40
@@ -92,11 +92,11 @@ ATTACK_CLOSE_FRAME_TIME = 0.10
 ATTACK_WINDUP_FRAMES = {0, 1, 2}
 ATTACK_FIRE_FRAMES = {3, 4, 5}
 ATTACK_CLOSE_FRAMES = {5, 4, 3, 0}
-SPRITE_WIDTH = 48
-SPRITE_HEIGHT = 48
+SPRITE_WIDTH_PX = 48
+SPRITE_HEIGHT_PX = 48
 
-SPRITE_WIDTH_DYING = 72
-SPRITE_HEIGHT_DYING = 72
+SPRITE_WIDTH_DYING_PX = 72
+SPRITE_HEIGHT_DYING_PX = 72
 SPRITE_ROW_DYING = 6
 
 STATE_IDLE = 1
@@ -133,7 +133,7 @@ _blink_anim_speed = 1.0
 -- attack state variables
 _attack_interval = DEFAULT_ATTACK_INTERVAL
 _fireball_active = false          -- Whether the fireball is currently visible/travelling
-_fireball_distance = 0.0          -- Distance travelled by the current fireball
+_fireball_distance_px = 0.0          -- Distance travelled by the current fireball
 _orb_elapsed_ms = 0.0             -- Current orb lifetime timer in milliseconds
 _fireball_hit_player = false      -- Flag to track if fireball has hit the player
 _retracting_tongue = false        -- Re-used as the attack closing phase flag
@@ -149,10 +149,10 @@ _last_attack_time = 0.0  -- Time of the last attack
 _orb_path = DEFAULT_ORB_PATH
 _orb_speed = DEFAULT_FIREBALL_SPEED
 _orb_lifetime = DEFAULT_ORB_LIFETIME
-_wave_strength = DEFAULT_WAVE_STRENGTH
+_wave_strength_px = DEFAULT_WAVE_STRENGTH_PX
 _wave_speed = DEFAULT_WAVE_SPEED
 _orb_z = DEFAULT_ORB_Z
-_orb_collision_size = DEFAULT_ORB_COLLISION_SIZE
+_orb_collision_size_px = DEFAULT_ORB_COLLISION_SIZE_PX
 
 -- health and death variables
 _energy = 30  -- frog's health points
@@ -171,7 +171,7 @@ _prev_animation_frame = 0
 
 -- fireball sprite dimensions
 _fireball_sprite_x = 0
-_fireball_sprite_y = FIREBALL_ROW_Y
+_fireball_sprite_y = FIREBALL_ROW_Y_PX
 
 
 ------------------------------------------------------------------------------------------------------------------------
@@ -190,10 +190,10 @@ properties = {
    orb_speed = DEFAULT_FIREBALL_SPEED,
    orb_lifetime = DEFAULT_ORB_LIFETIME,
    orb_z = DEFAULT_ORB_Z,
-   orb_collision_size = DEFAULT_ORB_COLLISION_SIZE,
+   orb_collision_size = DEFAULT_ORB_COLLISION_SIZE_PX,
 
    -- sine path tuning
-   wave_strength = DEFAULT_WAVE_STRENGTH,
+   wave_strength = DEFAULT_WAVE_STRENGTH_PX,
    wave_speed = DEFAULT_WAVE_SPEED
 }
 
@@ -244,7 +244,7 @@ function resetOnStateTransition(next_state, previous_state)
 
    if not keep_fireball then
       _fireball_active = false
-      _fireball_distance = 0.0
+      _fireball_distance_px = 0.0
       _orb_elapsed_ms = 0.0
       _fireball_hit_player = false
       setSpriteVisible(1, false)
@@ -295,7 +295,7 @@ end
 ------------------------------------------------------------------------------------------------------------------------
 function logSprite(dt)
 
-   local current_row = math.floor(y / SPRITE_HEIGHT)
+   local current_row = math.floor(y / SPRITE_HEIGHT_PX)
 
    if _prev_log_sprite_row ~= current_row then
 
@@ -355,10 +355,10 @@ end
 
 ------------------------------------------------------------------------------------------------------------------------
 function getFireballPathOffsetY()
-   local base_y = FIREBALL_START_OFFSET_Y
+   local base_y = FIREBALL_START_OFFSET_Y_PX
 
    if _orb_path == "sine" then
-      return base_y + math.sin(_fireball_distance * 0.05 * _wave_speed) * _wave_strength
+      return base_y + math.sin(_fireball_distance_px * 0.05 * _wave_speed) * _wave_strength_px
    end
 
    return base_y
@@ -373,23 +373,23 @@ function updateFireball(dt)
       return
    end
 
-   _fireball_distance = _fireball_distance + dt * _orb_speed
+   _fireball_distance_px = _fireball_distance_px + dt * _orb_speed
    _orb_elapsed_ms = _orb_elapsed_ms + dt * 1000.0
 
    local fireball_frame = math.floor(_elapsed * 18.0) % FIREBALL_FRAME_COUNT
    updateSpriteRect(
       1,
-      _fireball_sprite_x + fireball_frame * FIREBALL_FRAME_SPACING,
+      _fireball_sprite_x + fireball_frame * FIREBALL_FRAME_SPACING_PX,
       _fireball_sprite_y,
-      FIREBALL_WIDTH,
-      FIREBALL_HEIGHT
+      FIREBALL_WIDTH_PX,
+      FIREBALL_HEIGHT_PX
    )
 
    local fireball_offset_x
    if _points_left then
-      fireball_offset_x = FIREBALL_START_OFFSET_LEFT - _fireball_distance
+      fireball_offset_x = FIREBALL_START_OFFSET_LEFT_PX - _fireball_distance_px
    else
-      fireball_offset_x = FIREBALL_START_OFFSET_RIGHT + _fireball_distance
+      fireball_offset_x = FIREBALL_START_OFFSET_RIGHT_PX + _fireball_distance_px
    end
 
    local fireball_offset_y = getFireballPathOffsetY()
@@ -399,11 +399,11 @@ function updateFireball(dt)
 
    -- Use a smaller hit area inside the orb so the visual feels fair. The rect is centered on the
    -- visible dot, which is offset from the center of the 120x120 sprite frame.
-   local orb_center_x = _position_px:getX() + fireball_offset_x + FIREBALL_VISUAL_CENTER_X - FIREBALL_WIDTH / 2
-   local orb_center_y = _position_px:getY() + fireball_offset_y + FIREBALL_VISUAL_CENTER_Y - FIREBALL_HEIGHT / 2
-   local hitbox_x = orb_center_x - _orb_collision_size / 2
-   local hitbox_y = orb_center_y - _orb_collision_size / 2
-   if not _fireball_hit_player and intersectsWithPlayer(hitbox_x, hitbox_y, _orb_collision_size, _orb_collision_size) then
+   local orb_center_x = _position_px:getX() + fireball_offset_x + FIREBALL_VISUAL_CENTER_X_PX - FIREBALL_WIDTH_PX / 2
+   local orb_center_y = _position_px:getY() + fireball_offset_y + FIREBALL_VISUAL_CENTER_Y_PX - FIREBALL_HEIGHT_PX / 2
+   local hitbox_x = orb_center_x - _orb_collision_size_px / 2
+   local hitbox_y = orb_center_y - _orb_collision_size_px / 2
+   if not _fireball_hit_player and intersectsWithPlayer(hitbox_x, hitbox_y, _orb_collision_size_px, _orb_collision_size_px) then
       damage(properties.damage, 0, 0)
       _fireball_hit_player = true
    end
@@ -422,7 +422,7 @@ function updateSpriteAttack(dt)
    -- only starts the travelling fireball at the exact transition from windup to fire.
    if _attack_animation_time >= ATTACK_WINDUP_TIME and not _fireball_active and _fireball_fired_time == nil then
       _fireball_active = true
-      _fireball_distance = 0.0
+      _fireball_distance_px = 0.0
       _orb_elapsed_ms = 0.0
       _fireball_hit_player = false
       _fireball_fired_time = _attack_animation_time
@@ -536,7 +536,7 @@ function writeProperty(key, value)
    if (key == "alignment") then
 
       if (value == "right") then
-         _alignment_offset = 3 * SPRITE_HEIGHT
+         _alignment_offset = 3 * SPRITE_HEIGHT_PX
          _points_left = false
          _fireball_direction_multiplier = 1  -- 1 for right
       else
@@ -549,8 +549,8 @@ function writeProperty(key, value)
          1,
          _fireball_sprite_x,
          _fireball_sprite_y,
-         FIREBALL_WIDTH,
-         FIREBALL_HEIGHT
+         FIREBALL_WIDTH_PX,
+         FIREBALL_HEIGHT_PX
       )
       setSpriteVisible(1, false)
 
@@ -607,7 +607,7 @@ function writeProperty(key, value)
    elseif (key == "orb_collision_size") then
       local collision_size = tonumber(value)
       if (collision_size ~= nil and collision_size > 0) then
-         _orb_collision_size = collision_size
+         _orb_collision_size_px = collision_size
          properties.orb_collision_size = collision_size
       end
 
@@ -622,7 +622,7 @@ function writeProperty(key, value)
    elseif (key == "wave_strength") then
       local v = tonumber(value)
       if (v ~= nil) then
-         _wave_strength = v
+         _wave_strength_px = v
          properties.wave_strength = v
       end
 
@@ -649,11 +649,11 @@ function getIdleSpriteCoords()
    end
    
    local frame_index = math.floor(_animation_frame) % max_frames
-   local x = BLUE_FROG_X_OFFSET + frame_index * SPRITE_WIDTH
-   local y = (cycle - 1) * SPRITE_HEIGHT
+   local x = BLUE_FROG_X_OFFSET_PX + frame_index * SPRITE_WIDTH_PX
+   local y = (cycle - 1) * SPRITE_HEIGHT_PX
    y = y + _alignment_offset
    
-   return x, y, SPRITE_WIDTH, SPRITE_WIDTH
+   return x, y, SPRITE_WIDTH_PX, SPRITE_WIDTH_PX
 end
 
 ------------------------------------------------------------------------------------------------------------------------
@@ -699,18 +699,18 @@ function getAttackSpriteCoords()
       frame_index = ATTACK_CLOSE_FRAMES[i]
    end
 
-   local x = BLUE_FROG_X_OFFSET + frame_index * SPRITE_WIDTH + DEBUG_ATTACK_OFFSET
-   local y = (CYCLE_ATTACK - 1) * SPRITE_HEIGHT + _alignment_offset
+   local x = BLUE_FROG_X_OFFSET_PX + frame_index * SPRITE_WIDTH_PX + DEBUG_ATTACK_OFFSET_PX
+   local y = (CYCLE_ATTACK - 1) * SPRITE_HEIGHT_PX + _alignment_offset
 
-   return x, y, SPRITE_WIDTH, SPRITE_HEIGHT
+   return x, y, SPRITE_WIDTH_PX, SPRITE_HEIGHT_PX
 end
 ------------------------------------------------------------------------------------------------------------------------
 function getDyingSpriteCoords()
    local death_frame_index = math.floor(_death_animation_frame)
    
-   local x = death_frame_index * SPRITE_WIDTH_DYING
-   local y = SPRITE_ROW_DYING * SPRITE_HEIGHT_DYING
-   return x, y, SPRITE_WIDTH_DYING, SPRITE_HEIGHT_DYING
+   local x = death_frame_index * SPRITE_WIDTH_DYING_PX
+   local y = SPRITE_ROW_DYING * SPRITE_HEIGHT_DYING_PX
+   return x, y, SPRITE_WIDTH_DYING_PX, SPRITE_HEIGHT_DYING_PX
 end
 
 ------------------------------------------------------------------------------------------------------------------------

--- a/data/scripts/enemies/frog_bubble.lua
+++ b/data/scripts/enemies/frog_bubble.lua
@@ -24,7 +24,7 @@ v2d = require "data/scripts/enemies/vectorial2"
 
 ROW_OFFSET_RIGHT = 3
 FRAME_COUNTS = {8, 8, 6, 19}
-DEBUG_ATTACK_OFFSET = 0 * 48
+DEBUG_ATTACK_OFFSET_PX = 0 * 48
 
 BURP_MODE_PLAYER_PROXIMITY = 1
 BURP_MODE_FIXED_INTERVAL   = 2
@@ -33,11 +33,11 @@ BURP_MODE     = BURP_MODE_FIXED_INTERVAL
 BURP_INTERVAL = 4.0   -- used by BURP_MODE_FIXED_INTERVAL
 MIN_ATTACK_WAIT = 1.5  -- used by BURP_MODE_PLAYER_PROXIMITY
 
-SPRITE_WIDTH = 48
-SPRITE_HEIGHT = 48
+SPRITE_WIDTH_PX = 48
+SPRITE_HEIGHT_PX = 48
 
-SPRITE_WIDTH_DYING = 72
-SPRITE_HEIGHT_DYING = 72
+SPRITE_WIDTH_DYING_PX = 72
+SPRITE_HEIGHT_DYING_PX = 72
 SPRITE_ROW_DYING = 6
 
 STATE_IDLE = 1
@@ -60,8 +60,8 @@ BUBBLE_SPEED_H        = 0.05  -- base horizontal impulse
 BUBBLE_SPEED_H_SPREAD = 0.015 -- random ± spread on horizontal impulse
 BUBBLE_SPEED_V        = 0.003 -- base upward impulse (~11 deg slope at base speed)
 BUBBLE_SPEED_V_SPREAD = 0.008 -- random spread added to upward impulse (always positive)
-BUBBLE_SPAWN_SPREAD_X = 6     -- random ± pixel spread on spawn x
-BUBBLE_SPAWN_SPREAD_Y = 8     -- random ± pixel spread on spawn y
+BUBBLE_SPAWN_SPREAD_X_PX = 6     -- random ± pixel spread on spawn x
+BUBBLE_SPAWN_SPREAD_Y_PX = 8     -- random ± pixel spread on spawn y
 
 
 ------------------------------------------------------------------------------------------------------------------------
@@ -272,8 +272,8 @@ local function fireBubble()
    for slot = 0, BUBBLE_BURST_SIZE - 1 do
       local horiz  = BUBBLE_SPEED_H + (math.random() - 0.5) * 2.0 * BUBBLE_SPEED_H_SPREAD
       local upward = BUBBLE_SPEED_V + math.random() * BUBBLE_SPEED_V_SPREAD
-      local spawn_x = spawn_x_base + (math.random() - 0.5) * 2.0 * BUBBLE_SPAWN_SPREAD_X
-      local spawn_y = spawn_y_base + (math.random() - 0.5) * 2.0 * BUBBLE_SPAWN_SPREAD_Y
+      local spawn_x = spawn_x_base + (math.random() - 0.5) * 2.0 * BUBBLE_SPAWN_SPREAD_X_PX
+      local spawn_y = spawn_y_base + (math.random() - 0.5) * 2.0 * BUBBLE_SPAWN_SPREAD_Y_PX
       useWeapon(slot, spawn_x, spawn_y, _direction_multiplier * horiz, -upward)
    end
 end
@@ -414,7 +414,7 @@ function writeProperty(key, value)
    if (key == "alignment") then
 
       if (value == "right") then
-         _alignment_offset = 3 * SPRITE_HEIGHT
+         _alignment_offset = 3 * SPRITE_HEIGHT_PX
          _points_left = false
          _direction_multiplier = 1
       else
@@ -445,11 +445,11 @@ function getIdleSpriteCoords()
    end
 
    local frame_index = math.floor(_animation_frame) % max_frames
-   local x = frame_index * SPRITE_WIDTH
-   local y = (cycle - 1) * SPRITE_HEIGHT
+   local x = frame_index * SPRITE_WIDTH_PX
+   local y = (cycle - 1) * SPRITE_HEIGHT_PX
    y = y + _alignment_offset
 
-   return x, y, SPRITE_WIDTH, SPRITE_WIDTH
+   return x, y, SPRITE_WIDTH_PX, SPRITE_WIDTH_PX
 end
 
 ------------------------------------------------------------------------------------------------------------------------
@@ -478,18 +478,18 @@ function getAttackSpriteCoords()
       frame_index = math.min(frame_index, max_frames)
    end
 
-   local x = frame_index * SPRITE_WIDTH + DEBUG_ATTACK_OFFSET
-   local y = (cycle - 1) * SPRITE_HEIGHT + _alignment_offset
+   local x = frame_index * SPRITE_WIDTH_PX + DEBUG_ATTACK_OFFSET_PX
+   local y = (cycle - 1) * SPRITE_HEIGHT_PX + _alignment_offset
 
-   return x, y, SPRITE_WIDTH, SPRITE_HEIGHT
+   return x, y, SPRITE_WIDTH_PX, SPRITE_HEIGHT_PX
 end
 
 ------------------------------------------------------------------------------------------------------------------------
 function getDyingSpriteCoords()
    local death_frame_index = math.floor(_death_animation_frame)
-   local x = death_frame_index * SPRITE_WIDTH_DYING
-   local y = SPRITE_ROW_DYING * SPRITE_HEIGHT_DYING
-   return x, y, SPRITE_WIDTH_DYING, SPRITE_HEIGHT_DYING
+   local x = death_frame_index * SPRITE_WIDTH_DYING_PX
+   local y = SPRITE_ROW_DYING * SPRITE_HEIGHT_DYING_PX
+   return x, y, SPRITE_WIDTH_DYING_PX, SPRITE_HEIGHT_DYING_PX
 end
 
 ------------------------------------------------------------------------------------------------------------------------

--- a/data/scripts/enemies/frog_bubble.lua
+++ b/data/scripts/enemies/frog_bubble.lua
@@ -67,8 +67,8 @@ BUBBLE_SPAWN_SPREAD_Y = 8     -- random ± pixel spread on spawn y
 ------------------------------------------------------------------------------------------------------------------------
 -- member variables
 _done = false
-_position = v2d.Vector2D(0, 0)
-_player_position = v2d.Vector2D(0, 0)
+_position_px = v2d.Vector2D(0, 0)
+_player_position_px = v2d.Vector2D(0, 0)
 _elapsed = 0
 _alignment_offset = 0
 _state = STATE_IDLE
@@ -165,8 +165,8 @@ function checkAttackCondition(next_state)
 
       elseif BURP_MODE == BURP_MODE_PLAYER_PROXIMITY then
 
-         local x_diff = _player_position:getX() // 24 - _position:getX() // 24
-         local y_diff = _player_position:getY() // 24 - _position:getY() // 24
+         local x_diff = _player_position_px:getX() // 24 - _position_px:getX() // 24
+         local y_diff = _player_position_px:getY() // 24 - _position_px:getY() // 24
 
          local x_in_range =
             (_points_left and x_diff >= -5 and x_diff <= 0) or
@@ -176,8 +176,8 @@ function checkAttackCondition(next_state)
 
          if y_in_range and x_in_range and _elapsed - _last_attack_time >= MIN_ATTACK_WAIT then
             if isPhsyicsPathClear(
-               _position:getX(), _position:getY(),
-               _player_position:getX(), _player_position:getY()
+               _position_px:getX(), _position_px:getY(),
+               _player_position_px:getX(), _player_position_px:getY()
             ) then
                next_state = STATE_ATTACK
             end
@@ -266,8 +266,8 @@ end
 -- fires one burst event: all BUBBLE_BURST_SIZE slots simultaneously with randomized
 -- velocities and spawn positions, matching the WaterBubbles scatter pattern.
 local function fireBubble()
-   local spawn_x_base = _position:getX() + _direction_multiplier * 20
-   local spawn_y_base = _position:getY()
+   local spawn_x_base = _position_px:getX() + _direction_multiplier * 20
+   local spawn_y_base = _position_px:getY()
 
    for slot = 0, BUBBLE_BURST_SIZE - 1 do
       local horiz  = BUBBLE_SPEED_H + (math.random() - 0.5) * 2.0 * BUBBLE_SPEED_H_SPREAD
@@ -365,7 +365,7 @@ end
 
 ------------------------------------------------------------------------------------------------------------------------
 function movedTo(x, y)
-   _position = v2d.Vector2D(x, y)
+   _position_px = v2d.Vector2D(x, y)
 end
 
 
@@ -376,7 +376,7 @@ function playerMovedTo(x, y)
       return
    end
 
-   _player_position = v2d.Vector2D(x, y)
+   _player_position_px = v2d.Vector2D(x, y)
 end
 
 

--- a/data/scripts/enemies/klonk_2.lua
+++ b/data/scripts/enemies/klonk_2.lua
@@ -20,7 +20,7 @@ mCycle = 0
 mSpeed = 35.0
 mRandomizedOffset = math.random(100)/100.0
 
-COLLISION_THRESHOLD = 24
+COLLISION_THRESHOLD_PX = 24
 SPRITE_SIZE_PX = 4 * 24
 CYCLE_IDLE = 0
 CYCLE_WAKE = 1
@@ -77,7 +77,7 @@ function update(dt)
 
       dx = mPosition:getX() - mPlayerPosition:getX()
 
-      if (dx > -COLLISION_THRESHOLD and dx < COLLISION_THRESHOLD) then
+      if (dx > -COLLISION_THRESHOLD_PX and dx < COLLISION_THRESHOLD_PX) then
 
          -- make sure stone is not too far away (10 tiles) and above player
          yDiff = mPosition:getY() // 24 - mPlayerPosition:getY() // 24

--- a/data/scripts/enemies/minik_bomber.lua
+++ b/data/scripts/enemies/minik_bomber.lua
@@ -51,8 +51,8 @@ properties = {
 
 
 ------------------------------------------------------------------------------------------------------------------------
-SPRITE_WIDTH = 4 * 24
-SPRITE_HEIGHT = 2 * 24
+SPRITE_WIDTH_PX = 4 * 24
+SPRITE_HEIGHT_PX = 2 * 24
 
 CYCLE_IDLE = 0
 CYCLE_IDLE_BLINK = 1
@@ -162,7 +162,7 @@ function writeProperty(key, value)
          -- print("setting alignment to left")
          _points_to_left = false
          _throw_dir_x = 1.0
-         _alignment_offset = 5 * SPRITE_HEIGHT
+         _alignment_offset = 5 * SPRITE_HEIGHT_PX
       end
    elseif (key == "audio_update_behavior") then
       update_behavior = audioUpdateBehaviorFromString(value)
@@ -291,10 +291,10 @@ function updateSprite(dt)
 
       updateSpriteRect(
          0,
-         sprite_index * SPRITE_WIDTH + CYCLE_START_INDEX[_current_cycle + 1] * SPRITE_WIDTH,
-         getSpriteOffsetY() * SPRITE_HEIGHT,
-         SPRITE_WIDTH,
-         SPRITE_HEIGHT
+         sprite_index * SPRITE_WIDTH_PX + CYCLE_START_INDEX[_current_cycle + 1] * SPRITE_WIDTH_PX,
+         getSpriteOffsetY() * SPRITE_HEIGHT_PX,
+         SPRITE_WIDTH_PX,
+         SPRITE_HEIGHT_PX
       )
    end
 end

--- a/data/scripts/enemies/minik_bomber.lua
+++ b/data/scripts/enemies/minik_bomber.lua
@@ -75,8 +75,8 @@ THROW_DISTANCE_PX = 300
 
 ------------------------------------------------------------------------------------------------------------------------
 _ready_to_throw = true
-_pos = v2d.Vector2D(0, 0)
-_pos_player = v2d.Vector2D(0, 0)
+_pos_px = v2d.Vector2D(0, 0)
+_pos_player_px = v2d.Vector2D(0, 0)
 
 _sprite_index = 0
 
@@ -191,7 +191,7 @@ function throw()
       velocity = v2d.Vector2D(_velocity_x, _velocity_y)
    else
       velocity = calculateVelocity(
-         math.abs(_pos:getX() - _pos_player:getX()),
+         math.abs(_pos_px:getX() - _pos_player_px:getX()),
          60.0,
          0.0015
       )
@@ -204,8 +204,8 @@ function throw()
 
    useWeapon(
       0,
-      _pos:getX() + _throw_dir_x * (_points_to_left and 32 or 64),
-      _pos:getY(),
+      _pos_px:getX() + _throw_dir_x * (_points_to_left and 32 or 64),
+      _pos_px:getY(),
       _throw_dir_x * (velocity:getX() / 48.0),
       -velocity:getY() / 48.0
    );
@@ -221,13 +221,13 @@ end
 
 ------------------------------------------------------------------------------------------------------------------------
 function movedTo(x, y)
-   _pos = v2d.Vector2D(x, y)
+   _pos_px = v2d.Vector2D(x, y)
 end
 
 
 ------------------------------------------------------------------------------------------------------------------------
 function playerMovedTo(x, y)
-   _pos_player = v2d.Vector2D(x, y)
+   _pos_player_px = v2d.Vector2D(x, y)
 end
 
 
@@ -343,10 +343,10 @@ function updateThrowCondition(dt)
          end
 
       -- check if player is nearby
-      elseif (math.abs(_pos:getY() - _pos_player:getY()) < 24) then
-         if (math.abs(_pos:getX() - _pos_player:getX()) < THROW_DISTANCE_PX) then
+      elseif (math.abs(_pos_px:getY() - _pos_player_px:getY()) < 24) then
+         if (math.abs(_pos_px:getX() - _pos_player_px:getX()) < THROW_DISTANCE_PX) then
 
-            player_is_left = (_pos:getX() > _pos_player:getX())
+            player_is_left = (_pos_px:getX() > _pos_player_px:getX())
 
             within_throw_distance = false
             if (player_is_left and _points_to_left) then
@@ -357,19 +357,19 @@ function updateThrowCondition(dt)
 
             -- print(
             --    string.format("pos player: %f %f, pos self: %f, %f",
-            --       _pos_player:getX(),
-            --       _pos_player:getY(),
-            --       _pos:getX(),
-            --       _pos:getY()
+            --       _pos_player_px:getX(),
+            --       _pos_player_px:getY(),
+            --       _pos_px:getX(),
+            --       _pos_px:getY()
             --    )
             -- )
 
             if (within_throw_distance) then
                _can_throw = isPhsyicsPathClear(
-                     _pos:getX(),
-                     _pos:getY(),
-                     _pos_player:getX(),
-                     _pos_player:getY()
+                     _pos_px:getX(),
+                     _pos_px:getY(),
+                     _pos_player_px:getX(),
+                     _pos_player_px:getY()
                   )
             end
          end

--- a/data/scripts/enemies/nukumaru.lua
+++ b/data/scripts/enemies/nukumaru.lua
@@ -18,8 +18,8 @@ properties = {
    density = 0.1
 }
 
-SPRITE_WIDTH = 128
-SPRITE_HEIGHT = 128
+SPRITE_WIDTH_PX = 128
+SPRITE_HEIGHT_PX = 128
 SPRITE_COUNT = 60
 ANIMATION_SPEED = 100.0
 
@@ -33,7 +33,7 @@ _impulse_y = 0.1
 function initialize()
 
    addShapeCircle(0.6, 0.0, -0.06)                        -- radius, x, y
-   updateSpriteRect(0, 0, 0, SPRITE_WIDTH, SPRITE_HEIGHT) -- id, x, y, width, height
+   updateSpriteRect(0, 0, 0, SPRITE_WIDTH_PX, SPRITE_HEIGHT_PX) -- id, x, y, width, height
    addHitbox(-18, -18, 36, 36)                            -- x offset, y offset, width, height
    setZ(30)                                               -- place in foreground
    setGravityScale(0.0)                                   -- nukumaru is not impacted by gravity
@@ -55,10 +55,10 @@ function update(dt)
       _sprite_index = sprite_index
       updateSpriteRect(
          0,
-         _sprite_index * SPRITE_WIDTH,
+         _sprite_index * SPRITE_WIDTH_PX,
          0,
-         SPRITE_WIDTH,
-         SPRITE_HEIGHT
+         SPRITE_WIDTH_PX,
+         SPRITE_HEIGHT_PX
       ) -- id, x, y, width, height
    end
 end

--- a/data/scripts/enemies/rat.lua
+++ b/data/scripts/enemies/rat.lua
@@ -30,7 +30,7 @@ properties = {
 -- 6: 7 IDLE 3
 -- 8: 2 UP/DOWN
 
-SPRITE_SIZE = 24
+SPRITE_SIZE_PX = 24
 CYCLE_RUN = 0
 CYCLE_IDLE_1 = 1
 CYCLE_IDLE_2 = 2
@@ -214,7 +214,7 @@ end
 
 ------------------------------------------------------------------------------------------------------------------------
 function getSpriteOffsetY()
-   return (_current_cycle * 2 + (_points_left and 0 or 1)) * SPRITE_SIZE
+   return (_current_cycle * 2 + (_points_left and 0 or 1)) * SPRITE_SIZE_PX
 end
 
 
@@ -237,7 +237,7 @@ function updateSprite(dt)
          sprite_index = getMaxCycle() - sprite_index - 1
       end
 
-      updateSpriteRect(0, sprite_index * SPRITE_SIZE, getSpriteOffsetY(), SPRITE_SIZE, SPRITE_SIZE)
+      updateSpriteRect(0, sprite_index * SPRITE_SIZE_PX, getSpriteOffsetY(), SPRITE_SIZE_PX, SPRITE_SIZE_PX)
    end
 end
 

--- a/data/scripts/enemies/rat.lua
+++ b/data/scripts/enemies/rat.lua
@@ -42,8 +42,8 @@ DELAY_BETWEEN_IDLE_FRAMES = 1.0
 
 
 ------------------------------------------------------------------------------------------------------------------------
-_position = v2d.Vector2D(0, 0)
-_player_position = v2d.Vector2D(0, 0)
+_position_px = v2d.Vector2D(0, 0)
+_player_position_px = v2d.Vector2D(0, 0)
 _points_left = false
 _current_cycle = CYCLE_IDLE_1
 _current_sprite = 0
@@ -73,7 +73,7 @@ end
 
 ------------------------------------------------------------------------------------------------------------------------
 function playerMovedTo(x, y)
-   _player_position = v2d.Vector2D(x, y)
+   _player_position_px = v2d.Vector2D(x, y)
 end
 
 
@@ -100,12 +100,12 @@ function patrol()
    local key_vec = v2d.Vector2D(key:getX(), key:getY())
    local count = #_patrol_path
 
-   if (_position:getX() > key_vec:getX() + _patrol_epsilon) then
+   if (_position_px:getX() > key_vec:getX() + _patrol_epsilon) then
       _points_left = true
       _patrol_path_arrived = false
       keyReleased(Key["KeyRight"])
       keyPressed(Key["KeyLeft"])
-   elseif (_position:getX() < key_vec:getX() - _patrol_epsilon) then
+   elseif (_position_px:getX() < key_vec:getX() - _patrol_epsilon) then
       _points_left = false
       _patrol_path_arrived = false
       keyReleased(Key["KeyLeft"])
@@ -122,9 +122,9 @@ function patrol()
       end
 
       -- update to new alignment after reaching a position
-      if (_position:getX() > key_vec:getX() + _patrol_epsilon) then
+      if (_position_px:getX() > key_vec:getX() + _patrol_epsilon) then
          _points_left = true
-      elseif (_position:getX() < key_vec:getX() - _patrol_epsilon) then
+      elseif (_position_px:getX() < key_vec:getX() - _patrol_epsilon) then
          _points_left = false
       end
 
@@ -244,7 +244,7 @@ end
 
 ------------------------------------------------------------------------------------------------------------------------
 function movedTo(x, y)
-   _position = v2d.Vector2D(x, y)
+   _position_px = v2d.Vector2D(x, y)
 end
 
 

--- a/data/scripts/enemies/shadow_monk.lua
+++ b/data/scripts/enemies/shadow_monk.lua
@@ -11,8 +11,8 @@ properties = {
 -- row 2: blink, 20 sprites
 -- row 3: appear 24 sprites
 
-SPRITE_WIDTH = 72
-SPRITE_HEIGHT = 120
+SPRITE_WIDTH_PX = 72
+SPRITE_HEIGHT_PX = 120
 SPRITE_COUNTS = {20, 20, 24}
 ANIMATION_SPEEDS = {13.0, 13.0, 50.0}
 ROW_IDLE = 1
@@ -31,8 +31,8 @@ _animation_dir_forward = true
 ------------------------------------------------------------------------------------------------------------------------
 function initialize()
    addShapeRect(0.75, 1.25, 0.75, 0.0)
-   updateSpriteRect(0, 0, 0, SPRITE_WIDTH, SPRITE_HEIGHT) -- id, x, y, width, height
-   setSpriteOrigin(0, -SPRITE_WIDTH/2, 0)
+   updateSpriteRect(0, 0, 0, SPRITE_WIDTH_PX, SPRITE_HEIGHT_PX) -- id, x, y, width, height
+   setSpriteOrigin(0, -SPRITE_WIDTH_PX/2, 0)
    setZ(19)                                               -- place behind player
    addSample("spawn_01.wav")
    setAudioUpdateBehavior(AudioUpdateBehavior["AlwaysOn"])
@@ -118,10 +118,10 @@ function update(dt)
       _sprite_index = sprite_index
       updateSpriteRect(
          0,
-         _sprite_index * SPRITE_WIDTH,
-         (_current_cycle - 1) * SPRITE_HEIGHT,
-         SPRITE_WIDTH,
-         SPRITE_HEIGHT
+         _sprite_index * SPRITE_WIDTH_PX,
+         (_current_cycle - 1) * SPRITE_HEIGHT_PX,
+         SPRITE_WIDTH_PX,
+         SPRITE_HEIGHT_PX
       ) -- id, x, y, width, height
    end
 end

--- a/data/scripts/enemies/spiky.lua
+++ b/data/scripts/enemies/spiky.lua
@@ -50,8 +50,8 @@ SPRITES_PER_ROW = 12
 
 ------------------------------------------------------------------------------------------------------------------------
 _keys_pressed = 0
-_position = v2d.Vector2D(0, 0)
-_player_position = v2d.Vector2D(0, 0)
+_position_px = v2d.Vector2D(0, 0)
+_player_position_px = v2d.Vector2D(0, 0)
 _points_to_left = false
 _patrol_time = 0.0
 _current_sprite_elapsed = 99.0
@@ -114,13 +114,13 @@ end
 
 ------------------------------------------------------------------------------------------------------------------------
 function movedTo(x, y)
-   _position = v2d.Vector2D(x, y)
+   _position_px = v2d.Vector2D(x, y)
 end
 
 
 ------------------------------------------------------------------------------------------------------------------------
 function playerMovedTo(x, y)
-   _player_position = v2d.Vector2D(x, y)
+   _player_position_px = v2d.Vector2D(x, y)
 end
 
 
@@ -129,9 +129,9 @@ end
 -- |          p      o          | x
 function followPlayer()
    local epsilon = 5
-   if (_player_position:getX() > _position:getX() + epsilon) then
+   if (_player_position_px:getX() > _position_px:getX() + epsilon) then
       goRight()
-   elseif (_player_position:getX() < _position:getX() - epsilon) then
+   elseif (_player_position_px:getX() < _position_px:getX() - epsilon) then
       goLeft()
    else
       _keys_pressed = 0
@@ -208,9 +208,9 @@ function patrol(dt)
    local key = _patrol_path[_patrol_index]
    local keyVec = v2d.Vector2D(key:getX(), key:getY())
 
-   if (_position:getX() > keyVec:getX() + _patrol_epsilon) then
+   if (_position_px:getX() > keyVec:getX() + _patrol_epsilon) then
       goLeft()
-   elseif (_position:getX() < keyVec:getX() - _patrol_epsilon) then
+   elseif (_position_px:getX() < keyVec:getX() - _patrol_epsilon) then
       goRight()
    else
       keyReleased(Key["KeyLeft"])

--- a/data/scripts/enemies/spiky.lua
+++ b/data/scripts/enemies/spiky.lua
@@ -44,7 +44,7 @@ CYCLE_LENGTHS =  {12, 12, 12, 15, 4}
 CYCLE_ROWS_LEFT = {0, 2, 4, 6, 4}
 CYCLE_ROWS_RIGHT = {1, 3, 5, 8, 5}
 ANIMATION_SPEEDS = {10.0, 20.0, 10.0, 10.0, 10.0}
-SPRITE_SIZE = 48
+SPRITE_SIZE_PX = 48
 SPRITES_PER_ROW = 12
 
 
@@ -158,10 +158,10 @@ function updateSprite(dt)
 
       updateSpriteRect(
          0,
-         sprite_index * SPRITE_SIZE,
-         getSpriteOffsetY() + wrapped_y * SPRITE_SIZE,
-         SPRITE_SIZE,
-         SPRITE_SIZE
+         sprite_index * SPRITE_SIZE_PX,
+         getSpriteOffsetY() + wrapped_y * SPRITE_SIZE_PX,
+         SPRITE_SIZE_PX,
+         SPRITE_SIZE_PX
       )
    end
 end
@@ -169,7 +169,7 @@ end
 
 ------------------------------------------------------------------------------------------------------------------------
 function getSpriteOffsetY()
-   return _points_to_left and (CYCLE_ROWS_LEFT[_current_cycle + 1] * SPRITE_SIZE) or (CYCLE_ROWS_RIGHT[_current_cycle + 1] * SPRITE_SIZE)
+   return _points_to_left and (CYCLE_ROWS_LEFT[_current_cycle + 1] * SPRITE_SIZE_PX) or (CYCLE_ROWS_RIGHT[_current_cycle + 1] * SPRITE_SIZE_PX)
 end
 
 

--- a/src/game/constants.h
+++ b/src/game/constants.h
@@ -24,13 +24,13 @@ constexpr auto PIXELS_PER_TILE = 24;
 constexpr auto PIXELS_PER_HALF_TILE = PIXELS_PER_TILE / 2;
 constexpr auto PIXELS_PER_PHYSICS_TILE = 8;  // each tile is 8x8 px
 
-constexpr auto DIFF_PLAYER_TILE_TO_PHYSICS = 15;  // 20
+constexpr auto DIFF_PLAYER_TILE_TO_PHYSICS_PX = 15;  // 20
 
 constexpr auto PLAYER_ANIMATION_CYCLES = 8;
-constexpr auto PLAYER_TILES_WIDTH = 24;
-constexpr auto PLAYER_TILES_HEIGHT = 48;
-constexpr auto PLAYER_ACTUAL_WIDTH = 20;   // the actual width can be smaller than the tile width
-constexpr auto PLAYER_ACTUAL_HEIGHT = 32;  // the actual height can be smaller than the tile height
+constexpr auto PLAYER_TILES_WIDTH_PX = 24;
+constexpr auto PLAYER_TILES_HEIGHT_PX = 48;
+constexpr auto PLAYER_ACTUAL_WIDTH_PX = 20;   // the actual width can be smaller than the tile width
+constexpr auto PLAYER_ACTUAL_HEIGHT_PX = 32;  // the actual height can be smaller than the tile height
 
 constexpr auto FACTOR_DEG_TO_RAD = 0.0174532925199432957f;
 constexpr auto FACTOR_RAD_TO_DEG = 57.295779513082320876f;

--- a/src/game/level/level.cpp
+++ b/src/game/level/level.cpp
@@ -508,8 +508,8 @@ bool Level::load()
 
 void Level::loadStartPosition()
 {
-   _start_position_px.x = static_cast<float_t>(_description->_start_position_tl.at(0) * PIXELS_PER_TILE + PLAYER_ACTUAL_WIDTH / 2);
-   _start_position_px.y = static_cast<float_t>(_description->_start_position_tl.at(1) * PIXELS_PER_TILE + DIFF_PLAYER_TILE_TO_PHYSICS);
+   _start_position_px.x = static_cast<float_t>(_description->_start_position_tl.at(0) * PIXELS_PER_TILE + PLAYER_ACTUAL_WIDTH_PX / 2);
+   _start_position_px.y = static_cast<float_t>(_description->_start_position_tl.at(1) * PIXELS_PER_TILE + DIFF_PLAYER_TILE_TO_PHYSICS_PX);
 }
 
 void Level::loadLevelScript()

--- a/src/game/level/level.cpp
+++ b/src/game/level/level.cpp
@@ -508,8 +508,8 @@ bool Level::load()
 
 void Level::loadStartPosition()
 {
-   _start_position.x = static_cast<float_t>(_description->_start_position.at(0) * PIXELS_PER_TILE + PLAYER_ACTUAL_WIDTH / 2);
-   _start_position.y = static_cast<float_t>(_description->_start_position.at(1) * PIXELS_PER_TILE + DIFF_PLAYER_TILE_TO_PHYSICS);
+   _start_position_px.x = static_cast<float_t>(_description->_start_position_tl.at(0) * PIXELS_PER_TILE + PLAYER_ACTUAL_WIDTH / 2);
+   _start_position_px.y = static_cast<float_t>(_description->_start_position_tl.at(1) * PIXELS_PER_TILE + DIFF_PLAYER_TILE_TO_PHYSICS);
 }
 
 void Level::loadLevelScript()
@@ -570,8 +570,8 @@ void Level::loadSaveState()
    if (checkpoint)
    {
       auto pos = checkpoint->spawnPoint();
-      _start_position.x = static_cast<float>(pos.x);
-      _start_position.y = static_cast<float>(pos.y);
+      _start_position_px.x = static_cast<float>(pos.x);
+      _start_position_px.y = static_cast<float>(pos.y);
       Log::Info() << "move to checkpoint: " << checkpoint_index;
    }
    else
@@ -584,7 +584,7 @@ void Level::loadSaveState()
    const auto transition_spawn_position_px = LevelTransitionHandler::getInstance().takeSpawnPosition();
    if (transition_spawn_position_px.has_value())
    {
-      _start_position = transition_spawn_position_px.value();
+      _start_position_px = transition_spawn_position_px.value();
    }
 
    if (save_state._level_state.is_null())
@@ -677,8 +677,8 @@ void Level::spawnEnemies()
 
       EnemyDescription json_description;
       json_description._position_in_tiles = false;
-      json_description._start_position.push_back(it.second._pixel_position.x);
-      json_description._start_position.push_back(it.second._pixel_position.y);
+      json_description._start_position.push_back(it.second._position_px.x);
+      json_description._start_position.push_back(it.second._position_px.y);
       json_description._id = it.second._id;
       json_description._name = it.second._name;
 
@@ -690,9 +690,9 @@ void Level::spawnEnemies()
          it.second.addPaths(_world_chains);
       }
 
-      if (!it.second._pixel_path.empty())
+      if (!it.second._path_px.empty())
       {
-         json_description._path = it.second._pixel_path;
+         json_description._path = it.second._path_px;
       }
 
       // z index
@@ -1883,7 +1883,7 @@ void Level::parsePhysicsTiles(
 
 const sf::Vector2f& Level::getStartPosition() const
 {
-   return _start_position;
+   return _start_position_px;
 }
 
 #ifdef DEVELOPMENT_MODE

--- a/src/game/level/level.h
+++ b/src/game/level/level.h
@@ -346,7 +346,7 @@ protected:
 
    Atmosphere _atmosphere;
    Physics _physics;
-   sf::Vector2f _start_position;
+   sf::Vector2f _start_position_px;
 
    std::vector<std::unique_ptr<ParallaxLayer>> _parallax_layers;
 

--- a/src/game/level/leveldescription.cpp
+++ b/src/game/level/leveldescription.cpp
@@ -12,13 +12,13 @@ using json = nlohmann::json;
 
 void to_json(json& j, const LevelDescription& d)
 {
-   j = json{{"filename", d._filename}, {"startposition", d._start_position}, {"enemies", d._enemies}};
+   j = json{{"filename", d._filename}, {"startposition", d._start_position_tl}, {"enemies", d._enemies}};
 }
 
 void from_json(const json& j, LevelDescription& d)
 {
    d._filename = j.at("filename").get<std::string>();
-   d._start_position = j.at("startposition").get<std::vector<int>>();
+   d._start_position_tl = j.at("startposition").get<std::vector<int>>();
 
    if (j.find("enemies") != j.end())
    {

--- a/src/game/level/leveldescription.h
+++ b/src/game/level/leveldescription.h
@@ -11,7 +11,7 @@ struct LevelDescription
    LevelDescription() = default;
 
    std::string _filename;
-   std::vector<int32_t> _start_position;
+   std::vector<int32_t> _start_position_tl;
    std::vector<EnemyDescription> _enemies;
 
    /// \brief reads and parses a level description json file.

--- a/src/game/level/room.cpp
+++ b/src/game/level/room.cpp
@@ -160,7 +160,7 @@ void Room::RoomEnterArea::deserializeEnterArea(const GameDeserializeData& data)
       if (start_position_x_it != data._tmx_object->_properties->_map.end() &&
           start_position_y_it != data._tmx_object->_properties->_map.end())
       {
-         _start_position = {start_position_x_it->second->_value_int.value(), start_position_y_it->second->_value_int.value()};
+         _start_position_px = {start_position_x_it->second->_value_int.value(), start_position_y_it->second->_value_int.value()};
       }
 
       const auto start_offset_x_it = data._tmx_object->_properties->_map.find("start_offset_x_px");
@@ -333,10 +333,10 @@ void Room::movePlayerToRoomStartPosition()
 
    const auto area = entered_direction.value();
 
-   if (area._start_position.has_value())
+   if (area._start_position_px.has_value())
    {
       PlayerRegistry::getFirst()->setBodyViaPixelPosition(
-         static_cast<float>(area._start_position.value().x), static_cast<float>(area._start_position.value().y)
+         static_cast<float>(area._start_position_px.value().x), static_cast<float>(area._start_position_px.value().y)
       );
    }
 
@@ -442,24 +442,28 @@ void Room::SubRoom::deserialize(const GameDeserializeData& data)
 
       if (start_position_l_x_it != data._tmx_object->_properties->_map.end())
       {
-         area_left._start_position = {start_position_l_x_it->second->_value_int.value(), start_position_l_y_it->second->_value_int.value()};
+         area_left._start_position_px = {
+            start_position_l_x_it->second->_value_int.value(), start_position_l_y_it->second->_value_int.value()
+         };
       }
 
       if (start_position_r_x_it != data._tmx_object->_properties->_map.end())
       {
-         area_right._start_position = {
+         area_right._start_position_px = {
             start_position_r_x_it->second->_value_int.value(), start_position_r_y_it->second->_value_int.value()
          };
       }
 
       if (start_position_t_x_it != data._tmx_object->_properties->_map.end())
       {
-         area_top._start_position = {start_position_t_x_it->second->_value_int.value(), start_position_t_y_it->second->_value_int.value()};
+         area_top._start_position_px = {
+            start_position_t_x_it->second->_value_int.value(), start_position_t_y_it->second->_value_int.value()
+         };
       }
 
       if (start_position_b_x_it != data._tmx_object->_properties->_map.end())
       {
-         area_bottom._start_position = {
+         area_bottom._start_position_px = {
             start_position_b_x_it->second->_value_int.value(), start_position_b_y_it->second->_value_int.value()
          };
       }

--- a/src/game/level/room.h
+++ b/src/game/level/room.h
@@ -39,7 +39,7 @@ struct Room : std::enable_shared_from_this<Room>, public GameNode
       void deserializeEnterArea(const GameDeserializeData& data);
       std::string _name;
       sf::FloatRect _rect;
-      std::optional<sf::Vector2i> _start_position;
+      std::optional<sf::Vector2i> _start_position_px;
       std::optional<sf::Vector2i> _start_offset;
    };
 

--- a/src/game/level/tilemap.cpp
+++ b/src/game/level/tilemap.cpp
@@ -61,16 +61,16 @@ void TileMap::storeAnimation(const std::array<sf::Vertex, 4>& quad, int32_t tx, 
    const auto& frames = animation->_frames;
 
    auto animated_tile = new AnimatedTile();
-   animated_tile->_tile_x = tx;
-   animated_tile->_tile_y = ty;
+   animated_tile->_x_tl = tx;
+   animated_tile->_y_tl = ty;
    animated_tile->_animation = animation;
 
    auto duration = 0.0f;
    for (const auto& frame : frames)
    {
       auto offset_frame = new AnimatedTileFrame();
-      offset_frame->_x_px = frame->_tile_id % (_texture_map->getSize().x / _tile_size.x);
-      offset_frame->_y_px = frame->_tile_id / (_texture_map->getSize().x / _tile_size.x);
+      offset_frame->_x_px = frame->_tile_id % (_texture_map->getSize().x / _tile_size_px.x);
+      offset_frame->_y_px = frame->_tile_id / (_texture_map->getSize().x / _tile_size_px.x);
       offset_frame->_duration_ms = frame->_duration_ms;
       animated_tile->_frames.push_back(offset_frame);
       duration += frame->_duration_ms;
@@ -89,8 +89,8 @@ void TileMap::storeAnimation(const std::array<sf::Vertex, 4>& quad, int32_t tx, 
 void TileMap::storeStaticVertices(const std::array<sf::Vertex, 4>& quad, float parallax_scale)
 {
    // if no animation is available, just store the tile in the static buffer
-   const auto bx = static_cast<int32_t>((quad[0].position.x / static_cast<float>(_tile_size.x) / parallax_scale) / tile_count_per_block);
-   const auto by = static_cast<int32_t>((quad[0].position.y / static_cast<float>(_tile_size.y) / parallax_scale) / tile_count_per_block);
+   const auto bx = static_cast<int32_t>((quad[0].position.x / static_cast<float>(_tile_size_px.x) / parallax_scale) / tile_count_per_block);
+   const auto by = static_cast<int32_t>((quad[0].position.y / static_cast<float>(_tile_size_px.y) / parallax_scale) / tile_count_per_block);
 
    auto y_it = _vertices_static_blocks.find(by);
    if (y_it == _vertices_static_blocks.end())
@@ -164,7 +164,7 @@ bool TileMap::load(
 
    // Log::Info() << "TileMap::load: loading tileset: " << tileSet->mName << " with: texture " << path;
 
-   _tile_size = sf::Vector2u(tileset->_tile_width_px, tileset->_tile_height_px);
+   _tile_size_px = sf::Vector2u(tileset->_tile_width_px, tileset->_tile_height_px);
    _visible = layer->_visible;
    _z_index = layer->_z;
 
@@ -186,31 +186,31 @@ bool TileMap::load(
          }
 
          // find its position in the tileset texture
-         const auto tu = (tile_number - tileset->_first_gid) % (_texture_map->getSize().x / _tile_size.x);
-         const auto tv = (tile_number - tileset->_first_gid) / (_texture_map->getSize().x / _tile_size.x);
+         const auto tu = (tile_number - tileset->_first_gid) % (_texture_map->getSize().x / _tile_size_px.x);
+         const auto tv = (tile_number - tileset->_first_gid) / (_texture_map->getSize().x / _tile_size_px.x);
          const auto tx = static_cast<int32_t>(pos_x);
          const auto ty = static_cast<int32_t>(pos_y);
-         const auto tile_x_px = tx * static_cast<int32_t>(_tile_size.x) + layer->_position_x_px;
-         const auto tile_y_px = ty * static_cast<int32_t>(_tile_size.y) + layer->_position_y_px;
+         const auto tile_x_px = tx * static_cast<int32_t>(_tile_size_px.x) + layer->_position_x_px;
+         const auto tile_y_px = ty * static_cast<int32_t>(_tile_size_px.y) + layer->_position_y_px;
 
          constexpr auto size = 1;
 
          // shrink UV range a TINY bit to avoid fetching data from undefined texture space
-         const auto tile_eps_x = 0.5f * (1.0f / static_cast<float>(_tile_size.x));
-         const auto tile_eps_y = 0.5f * (1.0f / static_cast<float>(_tile_size.y));
+         const auto tile_eps_x = 0.5f * (1.0f / static_cast<float>(_tile_size_px.x));
+         const auto tile_eps_y = 0.5f * (1.0f / static_cast<float>(_tile_size_px.y));
 
          // define its 4 corners
          // clang-format off
          std::array<sf::Vertex, 4> quad;
          quad[0].position = sf::Vector2f(static_cast<float>(tile_x_px), static_cast<float>(tile_y_px));
-         quad[1].position = sf::Vector2f(static_cast<float>(tile_x_px + static_cast<int32_t>(_tile_size.x) * size), static_cast<float>(tile_y_px));
-         quad[2].position = sf::Vector2f(static_cast<float>(tile_x_px + static_cast<int32_t>(_tile_size.x) * size), static_cast<float>(tile_y_px + static_cast<int32_t>(_tile_size.y) * size));
-         quad[3].position = sf::Vector2f(static_cast<float>(tile_x_px), static_cast<float>(tile_y_px + static_cast<int32_t>(_tile_size.y) * size));
+         quad[1].position = sf::Vector2f(static_cast<float>(tile_x_px + static_cast<int32_t>(_tile_size_px.x) * size), static_cast<float>(tile_y_px));
+         quad[2].position = sf::Vector2f(static_cast<float>(tile_x_px + static_cast<int32_t>(_tile_size_px.x) * size), static_cast<float>(tile_y_px + static_cast<int32_t>(_tile_size_px.y) * size));
+         quad[3].position = sf::Vector2f(static_cast<float>(tile_x_px), static_cast<float>(tile_y_px + static_cast<int32_t>(_tile_size_px.y) * size));
          
-         quad[0].texCoords = sf::Vector2f(static_cast<float>(tu * _tile_size.x) + tile_eps_x, static_cast<float>(tv * _tile_size.y) + tile_eps_y);
-         quad[1].texCoords = sf::Vector2f(static_cast<float>((tu + 1) * _tile_size.x) - tile_eps_x, static_cast<float>(tv * _tile_size.y) + tile_eps_y);
-         quad[2].texCoords = sf::Vector2f(static_cast<float>((tu + 1) * _tile_size.x) - tile_eps_x, static_cast<float>((tv + 1) * _tile_size.y) - tile_eps_y);
-         quad[3].texCoords = sf::Vector2f(static_cast<float>(tu * _tile_size.x) + tile_eps_x, static_cast<float>((tv + 1) * _tile_size.y) - tile_eps_y);
+         quad[0].texCoords = sf::Vector2f(static_cast<float>(tu * _tile_size_px.x) + tile_eps_x, static_cast<float>(tv * _tile_size_px.y) + tile_eps_y);
+         quad[1].texCoords = sf::Vector2f(static_cast<float>((tu + 1) * _tile_size_px.x) - tile_eps_x, static_cast<float>(tv * _tile_size_px.y) + tile_eps_y);
+         quad[2].texCoords = sf::Vector2f(static_cast<float>((tu + 1) * _tile_size_px.x) - tile_eps_x, static_cast<float>((tv + 1) * _tile_size_px.y) - tile_eps_y);
+         quad[3].texCoords = sf::Vector2f(static_cast<float>(tu * _tile_size_px.x) + tile_eps_x, static_cast<float>((tv + 1) * _tile_size_px.y) - tile_eps_y);
 
          const auto alpha = std::clamp(static_cast<int32_t>(layer->_opacity * 255.0f), 0, 255);
          quad[0].color = sf::Color(255, 255, 255, alpha);
@@ -248,8 +248,8 @@ void TileMap::update(const sf::Time& dt)
       }
 
       // only add those that are close enough to the player
-      const auto bx = static_cast<int32_t>((anim->_tile_x) / tile_count_per_block);
-      const auto by = static_cast<int32_t>((anim->_tile_y) / tile_count_per_block);
+      const auto bx = static_cast<int32_t>((anim->_x_tl) / tile_count_per_block);
+      const auto by = static_cast<int32_t>((anim->_y_tl) / tile_count_per_block);
       if (std::abs(player_block[0] - bx) > block_range_half_x || std::abs(player_block[1] - by) > block_range_half_y)
       {
          continue;
@@ -278,10 +278,11 @@ void TileMap::update(const sf::Time& dt)
       const auto tv = static_cast<uint32_t>(frame->_y_px);
 
       // re-define its 4 texture coordinates
-      anim->_vertices[0].texCoords = sf::Vector2f(static_cast<float>(tu * _tile_size.x), static_cast<float>(tv * _tile_size.y));
-      anim->_vertices[1].texCoords = sf::Vector2f(static_cast<float>((tu + 1) * _tile_size.x), static_cast<float>(tv * _tile_size.y));
-      anim->_vertices[2].texCoords = sf::Vector2f(static_cast<float>((tu + 1) * _tile_size.x), static_cast<float>((tv + 1) * _tile_size.y));
-      anim->_vertices[3].texCoords = sf::Vector2f(static_cast<float>(tu * _tile_size.x), static_cast<float>((tv + 1) * _tile_size.y));
+      anim->_vertices[0].texCoords = sf::Vector2f(static_cast<float>(tu * _tile_size_px.x), static_cast<float>(tv * _tile_size_px.y));
+      anim->_vertices[1].texCoords = sf::Vector2f(static_cast<float>((tu + 1) * _tile_size_px.x), static_cast<float>(tv * _tile_size_px.y));
+      anim->_vertices[2].texCoords =
+         sf::Vector2f(static_cast<float>((tu + 1) * _tile_size_px.x), static_cast<float>((tv + 1) * _tile_size_px.y));
+      anim->_vertices[3].texCoords = sf::Vector2f(static_cast<float>(tu * _tile_size_px.x), static_cast<float>((tv + 1) * _tile_size_px.y));
 
       _vertices_animated.append(anim->_vertices[0]);
       _vertices_animated.append(anim->_vertices[1]);
@@ -471,9 +472,8 @@ void TileMap::setZ(int32_t z)
 
 void TileMap::hideTile(int32_t x, int32_t y)
 {
-   const auto& it = std::find_if(
-      std::begin(_animations), std::end(_animations), [x, y](auto* tile) { return (tile->_tile_x == x && tile->_tile_y == y); }
-   );
+   const auto& it =
+      std::find_if(std::begin(_animations), std::end(_animations), [x, y](auto* tile) { return (tile->_x_tl == x && tile->_y_tl == y); });
 
    if (it != _animations.end())
    {

--- a/src/game/level/tilemap.h
+++ b/src/game/level/tilemap.h
@@ -117,8 +117,8 @@ private:
       /// \brief releases owned animation frame pointers.
       virtual ~AnimatedTile();
 
-      int32_t _tile_x = 0;
-      int32_t _tile_y = 0;
+      int32_t _x_tl = 0;
+      int32_t _y_tl = 0;
       std::vector<AnimatedTileFrame*> _frames;
       int32_t _current_frame = 0;
       float _elapsed_ms = 0.0f;
@@ -128,7 +128,7 @@ private:
       std::shared_ptr<TmxAnimation> _animation;
    };
 
-   sf::Vector2u _tile_size;
+   sf::Vector2u _tile_size_px;
 
    mutable std::map<int32_t, std::map<int32_t, sf::VertexArray>> _vertices_static_blocks;
    sf::VertexArray _vertices_animated;

--- a/src/game/level/tmxenemy.cpp
+++ b/src/game/level/tmxenemy.cpp
@@ -14,7 +14,7 @@ void TmxEnemy::parse(const std::shared_ptr<TmxObject>& object)
 {
    _id = object->_id;
    _name = object->_name;
-   _pixel_position = {static_cast<int32_t>(object->_x_px), static_cast<int32_t>(object->_y_px)};
+   _position_px = {static_cast<int32_t>(object->_x_px), static_cast<int32_t>(object->_y_px)};
 
    if (object->_properties)
    {
@@ -37,16 +37,16 @@ void TmxEnemy::parse(const std::shared_ptr<TmxObject>& object)
       {
          if (!field.empty())
          {
-            _pixel_path.push_back(std::stoi(field) * PIXELS_PER_TILE);
+            _path_px.push_back(std::stoi(field) * PIXELS_PER_TILE);
          }
       }
 
       // if the path just consists of a single position, add another position which is the
       // pixel position of the tmx object
-      if (_pixel_path.size() == 2)
+      if (_path_px.size() == 2)
       {
-         _pixel_path.insert(_pixel_path.begin(), _pixel_position.y);
-         _pixel_path.insert(_pixel_path.begin(), _pixel_position.x);
+         _path_px.insert(_path_px.begin(), _position_px.y);
+         _path_px.insert(_path_px.begin(), _position_px.x);
       }
    }
 
@@ -69,10 +69,10 @@ void TmxEnemy::parse(const std::shared_ptr<TmxObject>& object)
    top -= PIXELS_PER_TILE / 2;
    left -= PIXELS_PER_TILE / 2;
 
-   _pixel_rect.position.y = top;
-   _pixel_rect.position.x = left;
-   _pixel_rect.size.x = w;
-   _pixel_rect.size.y = h;
+   _rect_px.position.y = top;
+   _rect_px.position.x = left;
+   _rect_px.size.x = w;
+   _rect_px.size.y = h;
 
    _vertices[0].x = left;
    _vertices[0].y = top;
@@ -104,7 +104,7 @@ void TmxEnemy::addPaths(const std::vector<std::vector<b2Vec2>>& paths)
          sf::Vector2i v0{static_cast<int32_t>(path[i0].x * PPM), static_cast<int32_t>(path[i0].y * PPM)};
 
          // check if rect contains point, then we have a match
-         if (_pixel_rect.contains(v0))
+         if (_rect_px.contains(v0))
          {
             _path = path;
             _has_path = true;
@@ -145,16 +145,16 @@ void TmxEnemy::addPaths(const std::vector<std::vector<b2Vec2>>& paths)
       {
          for (const auto& v : std::ranges::views::reverse(_path))
          {
-            _pixel_path.push_back(static_cast<int32_t>(v.x * PPM));
-            _pixel_path.push_back(static_cast<int32_t>(v.y * PPM));
+            _path_px.push_back(static_cast<int32_t>(v.x * PPM));
+            _path_px.push_back(static_cast<int32_t>(v.y * PPM));
          }
       }
       else
       {
          for (const auto& v : _path)
          {
-            _pixel_path.push_back(static_cast<int32_t>(v.x * PPM));
-            _pixel_path.push_back(static_cast<int32_t>(v.y * PPM));
+            _path_px.push_back(static_cast<int32_t>(v.x * PPM));
+            _path_px.push_back(static_cast<int32_t>(v.y * PPM));
          }
       }
    }

--- a/src/game/level/tmxenemy.h
+++ b/src/game/level/tmxenemy.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "box2d/box2d.h"
 #include <SFML/Graphics.hpp>
+#include "box2d/box2d.h"
 
 #include <array>
 #include <optional>
@@ -30,13 +30,13 @@ struct TmxEnemy
    /// \return matching property, or std::nullopt when not found.
    std::optional<ScriptProperty> findProperty(const std::string& key);
 
-   sf::Vector2i _pixel_position;
+   sf::Vector2i _position_px;
    std::string _id;
    std::string _name;
-   sf::IntRect _pixel_rect;
+   sf::IntRect _rect_px;
    std::array<sf::Vector2i, 4> _vertices;
    std::vector<b2Vec2> _path;
-   std::vector<int32_t> _pixel_path;
+   std::vector<int32_t> _path_px;
    bool _has_path = false;
    bool _inverse_path = false;
    std::vector<ScriptProperty> _properties;

--- a/src/game/mechanisms/bouncer.cpp
+++ b/src/game/mechanisms/bouncer.cpp
@@ -12,8 +12,8 @@
 #include "game/mechanisms/gamemechanismdeserializerregistry.h"
 #include "game/player/playerregistry.h"
 
-const auto SPRITE_WIDTH = 24;
-const auto SPRITE_HEIGHT = 24;
+const auto SPRITE_WIDTH_PX = 24;
+const auto SPRITE_HEIGHT_PX = 24;
 
 //
 //        +--------------------------------------------------+ <-
@@ -135,10 +135,10 @@ Bouncer::Bouncer(GameNode* parent, const GameDeserializeData& data) : FixtureNod
    _texture = TexturePool::getInstance().get(data._base_path / "tilesets" / "bumper.png");
 #ifdef __EMSCRIPTEN__
    _sprite = std::make_unique<sf::Sprite>();
-   _sprite->position = _position_sfml - sf::Vector2f(0.0f, static_cast<float>(SPRITE_HEIGHT));
+   _sprite->position = _position_sfml - sf::Vector2f(0.0f, static_cast<float>(SPRITE_HEIGHT_PX));
 #else
    _sprite = std::make_unique<sf::Sprite>(*_texture);
-   _sprite->setPosition(_position_sfml - sf::Vector2f(0.0f, static_cast<float>(SPRITE_HEIGHT)));
+   _sprite->setPosition(_position_sfml - sf::Vector2f(0.0f, static_cast<float>(SPRITE_HEIGHT_PX)));
 #endif
 }
 
@@ -190,7 +190,7 @@ void Bouncer::update(const sf::Time& /*dt*/)
    if (!_previous_step.has_value() || step != _previous_step)
    {
       _previous_step = step;
-      sfcompat::setTextureRect(*_sprite, sf::IntRect({step * SPRITE_WIDTH, 0}, {SPRITE_WIDTH, SPRITE_HEIGHT}));
+      sfcompat::setTextureRect(*_sprite, sf::IntRect({step * SPRITE_WIDTH_PX, 0}, {SPRITE_WIDTH_PX, SPRITE_HEIGHT_PX}));
    }
 }
 

--- a/src/game/mechanisms/conveyorbelt.cpp
+++ b/src/game/mechanisms/conveyorbelt.cpp
@@ -119,7 +119,7 @@ void ConveyorBelt::setEnabled(bool enabled)
 
 std::optional<sf::FloatRect> ConveyorBelt::getBoundingBoxPx()
 {
-   return _belt_pixel_rect;
+   return _belt_rect_px;
 }
 
 void ConveyorBelt::updateSprite()
@@ -147,7 +147,8 @@ void ConveyorBelt::updateSprite()
       }
 
       sfcompat::setTextureRect(
-         _belt_sprites[i], sf::IntRect({offset_x_px * PIXELS_PER_TILE, static_cast<int32_t>(offset_y_px)}, {PIXELS_PER_TILE, PIXELS_PER_TILE})
+         _belt_sprites[i],
+         sf::IntRect({offset_x_px * PIXELS_PER_TILE, static_cast<int32_t>(offset_y_px)}, {PIXELS_PER_TILE, PIXELS_PER_TILE})
       );
    }
 }
@@ -177,13 +178,13 @@ ConveyorBelt::ConveyorBelt(GameNode* parent, const GameDeserializeData& data) : 
 
    setVelocity(velocity);
 
-   _position_b2d = b2Vec2(x * MPP, y * MPP);
-   _position_sfml.x = x;
-   _position_sfml.y = y;
+   _position_m = b2Vec2(x * MPP, y * MPP);
+   _position_px.x = x;
+   _position_px.y = y;
 
    b2BodyDef body_def;
    body_def.type = b2_staticBody;
-   body_def.position = _position_b2d;
+   body_def.position = _position_m;
    _body = data._world->CreateBody(&body_def);
 
    const auto width_m = width_px * MPP;
@@ -209,10 +210,10 @@ ConveyorBelt::ConveyorBelt(GameNode* parent, const GameDeserializeData& data) : 
    auto* boundary_fixture = _body->CreateFixture(&boundary_fixture_def);
    boundary_fixture->SetUserData(static_cast<void*>(this));
 
-   _belt_pixel_rect.position.x = x;
-   _belt_pixel_rect.position.y = y;
-   _belt_pixel_rect.size.y = height_px;
-   _belt_pixel_rect.size.x = width_px;
+   _belt_rect_px.position.x = x;
+   _belt_rect_px.position.y = y;
+   _belt_rect_px.size.y = height_px;
+   _belt_rect_px.size.x = width_px;
 
    static auto ROUND_EPSILON = 0.5f;
    auto tile_count = static_cast<uint32_t>((width_px / PIXELS_PER_TILE) + ROUND_EPSILON);
@@ -319,7 +320,7 @@ void ConveyorBelt::processFixtureNode(FixtureNode* fixture_node, b2Body* collidi
 
 sf::FloatRect ConveyorBelt::getPixelRect() const
 {
-   return _belt_pixel_rect;
+   return _belt_rect_px;
 }
 
 void ConveyorBelt::processContact(b2Contact* contact)

--- a/src/game/mechanisms/conveyorbelt.cpp
+++ b/src/game/mechanisms/conveyorbelt.cpp
@@ -54,7 +54,7 @@ const auto registered_conveyorbelt = []
 
 namespace
 {
-static const auto Y_OFFSET = -10;
+static const auto Y_OFFSET_PX = -10;
 static const auto BELT_TILE_COUNT = 8;
 static const auto ARROW_INDEX_X = 11;
 static const auto ARROW_INDEX_LEFT_Y = 0;
@@ -226,7 +226,7 @@ ConveyorBelt::ConveyorBelt(GameNode* parent, const GameDeserializeData& data) : 
 #else
       sf::Sprite belt_sprite(*_texture);
 #endif
-      sfcompat::setPosition(belt_sprite, {x + i * PIXELS_PER_TILE, y + Y_OFFSET});
+      sfcompat::setPosition(belt_sprite, {x + i * PIXELS_PER_TILE, y + Y_OFFSET_PX});
 
       _belt_sprites.push_back(belt_sprite);
    }

--- a/src/game/mechanisms/conveyorbelt.h
+++ b/src/game/mechanisms/conveyorbelt.h
@@ -2,8 +2,8 @@
 
 #include <filesystem>
 
-#include "box2d/box2d.h"
 #include "SFML/Graphics.hpp"
+#include "box2d/box2d.h"
 #include "game/constants.h"
 #include "game/io/gamedeserializedata.h"
 #include "game/level/fixturenode.h"
@@ -81,11 +81,11 @@ public:
 
 private:
    b2Body* _body = nullptr;
-   b2Vec2 _position_b2d;
-   sf::Vector2f _position_sfml;
+   b2Vec2 _position_m;
+   sf::Vector2f _position_px;
    b2PolygonShape _shape;
-   sf::FloatRect _belt_pixel_rect;
-   sf::FloatRect _arrow_pixel_rect;
+   sf::FloatRect _belt_rect_px;
+   sf::FloatRect _arrow_rect_px;
    float _elapsed = 0.0f;
    bool _points_right = true;
    float _lever_lag = 1.0f;

--- a/src/game/mechanisms/crusher.cpp
+++ b/src/game/mechanisms/crusher.cpp
@@ -65,11 +65,11 @@ namespace
 constexpr auto BLADE_HORIZONTAL_TILES = 5;
 constexpr auto BLADE_VERTICAL_TILES = 1;
 
-constexpr auto BLADE_SIZE_X = (BLADE_HORIZONTAL_TILES * PIXELS_PER_TILE) / PPM;
-constexpr auto BLADE_SIZE_Y = (BLADE_VERTICAL_TILES * PIXELS_PER_TILE) / PPM;
+constexpr auto BLADE_SIZE_X_M = (BLADE_HORIZONTAL_TILES * PIXELS_PER_TILE) / PPM;
+constexpr auto BLADE_SIZE_Y_M = (BLADE_VERTICAL_TILES * PIXELS_PER_TILE) / PPM;
 
-constexpr auto BLADE_SHARPNESS = 0.1f;
-constexpr auto BLADE_TOLERANCE = 0.06f;
+constexpr auto BLADE_SHARPNESS_M = 0.1f;
+constexpr auto BLADE_TOLERANCE_M = 0.06f;
 
 }  // namespace
 
@@ -466,34 +466,35 @@ void Crusher::setupBody(const std::shared_ptr<b2World>& world)
    {
       case Alignment::PointsLeft:
       {
-         blade_vertices[0] = b2Vec2(0, BLADE_SHARPNESS + BLADE_TOLERANCE - BLADE_SIZE_X);
-         blade_vertices[1] = b2Vec2(0, BLADE_SIZE_X - BLADE_SHARPNESS - BLADE_TOLERANCE - BLADE_SIZE_X);
-         blade_vertices[2] = b2Vec2(BLADE_SIZE_Y, BLADE_TOLERANCE - BLADE_SIZE_X);
-         blade_vertices[3] = b2Vec2(BLADE_SIZE_Y, BLADE_SIZE_X - BLADE_TOLERANCE - BLADE_SIZE_X);
+         blade_vertices[0] = b2Vec2(0, BLADE_SHARPNESS_M + BLADE_TOLERANCE_M - BLADE_SIZE_X_M);
+         blade_vertices[1] = b2Vec2(0, BLADE_SIZE_X_M - BLADE_SHARPNESS_M - BLADE_TOLERANCE_M - BLADE_SIZE_X_M);
+         blade_vertices[2] = b2Vec2(BLADE_SIZE_Y_M, BLADE_TOLERANCE_M - BLADE_SIZE_X_M);
+         blade_vertices[3] = b2Vec2(BLADE_SIZE_Y_M, BLADE_SIZE_X_M - BLADE_TOLERANCE_M - BLADE_SIZE_X_M);
          break;
       }
       case Alignment::PointsRight:
       {
-         blade_vertices[0] = b2Vec2(0 + PIXELS_PER_TILE / PPM, BLADE_TOLERANCE - BLADE_SIZE_X);
-         blade_vertices[1] = b2Vec2(BLADE_SIZE_Y + PIXELS_PER_TILE / PPM, BLADE_SHARPNESS + BLADE_TOLERANCE - BLADE_SIZE_X);
-         blade_vertices[2] = b2Vec2(BLADE_SIZE_Y + PIXELS_PER_TILE / PPM, BLADE_SIZE_X - BLADE_SHARPNESS - BLADE_TOLERANCE - BLADE_SIZE_X);
-         blade_vertices[3] = b2Vec2(0 + PIXELS_PER_TILE / PPM, BLADE_SIZE_X - BLADE_TOLERANCE - BLADE_SIZE_X);
+         blade_vertices[0] = b2Vec2(0 + PIXELS_PER_TILE / PPM, BLADE_TOLERANCE_M - BLADE_SIZE_X_M);
+         blade_vertices[1] = b2Vec2(BLADE_SIZE_Y_M + PIXELS_PER_TILE / PPM, BLADE_SHARPNESS_M + BLADE_TOLERANCE_M - BLADE_SIZE_X_M);
+         blade_vertices[2] =
+            b2Vec2(BLADE_SIZE_Y_M + PIXELS_PER_TILE / PPM, BLADE_SIZE_X_M - BLADE_SHARPNESS_M - BLADE_TOLERANCE_M - BLADE_SIZE_X_M);
+         blade_vertices[3] = b2Vec2(0 + PIXELS_PER_TILE / PPM, BLADE_SIZE_X_M - BLADE_TOLERANCE_M - BLADE_SIZE_X_M);
          break;
       }
       case Alignment::PointsDown:
       {
-         blade_vertices[0] = b2Vec2(BLADE_TOLERANCE, 0);
-         blade_vertices[1] = b2Vec2(BLADE_SHARPNESS + BLADE_TOLERANCE, BLADE_SIZE_Y);
-         blade_vertices[2] = b2Vec2(BLADE_SIZE_X - BLADE_SHARPNESS - BLADE_TOLERANCE, BLADE_SIZE_Y);
-         blade_vertices[3] = b2Vec2(BLADE_SIZE_X - BLADE_TOLERANCE, 0);
+         blade_vertices[0] = b2Vec2(BLADE_TOLERANCE_M, 0);
+         blade_vertices[1] = b2Vec2(BLADE_SHARPNESS_M + BLADE_TOLERANCE_M, BLADE_SIZE_Y_M);
+         blade_vertices[2] = b2Vec2(BLADE_SIZE_X_M - BLADE_SHARPNESS_M - BLADE_TOLERANCE_M, BLADE_SIZE_Y_M);
+         blade_vertices[3] = b2Vec2(BLADE_SIZE_X_M - BLADE_TOLERANCE_M, 0);
          break;
       }
       case Alignment::PointsUp:
       {
-         blade_vertices[0] = b2Vec2(BLADE_TOLERANCE, BLADE_SIZE_Y - PIXELS_PER_TILE / PPM);
-         blade_vertices[1] = b2Vec2(BLADE_SHARPNESS + BLADE_TOLERANCE, 0 - PIXELS_PER_TILE / PPM);
-         blade_vertices[2] = b2Vec2(BLADE_SIZE_X - BLADE_SHARPNESS - BLADE_TOLERANCE, 0 - PIXELS_PER_TILE / PPM);
-         blade_vertices[3] = b2Vec2(BLADE_SIZE_X - BLADE_TOLERANCE, BLADE_SIZE_Y - PIXELS_PER_TILE / PPM);
+         blade_vertices[0] = b2Vec2(BLADE_TOLERANCE_M, BLADE_SIZE_Y_M - PIXELS_PER_TILE / PPM);
+         blade_vertices[1] = b2Vec2(BLADE_SHARPNESS_M + BLADE_TOLERANCE_M, 0 - PIXELS_PER_TILE / PPM);
+         blade_vertices[2] = b2Vec2(BLADE_SIZE_X_M - BLADE_SHARPNESS_M - BLADE_TOLERANCE_M, 0 - PIXELS_PER_TILE / PPM);
+         blade_vertices[3] = b2Vec2(BLADE_SIZE_X_M - BLADE_TOLERANCE_M, BLADE_SIZE_Y_M - PIXELS_PER_TILE / PPM);
          break;
       }
       case Alignment::PointsNowhere:
@@ -522,32 +523,32 @@ void Crusher::setupBody(const std::shared_ptr<b2World>& world)
    {
       case Alignment::PointsLeft:
       {
-         box_width = BLADE_SIZE_Y * 0.5f;
-         box_height = BLADE_SIZE_X * 0.5f;
+         box_width = BLADE_SIZE_Y_M * 0.5f;
+         box_height = BLADE_SIZE_X_M * 0.5f;
          box_center = {box_width, box_height};
          box_center.x += PIXELS_PER_TILE / PPM;
-         box_center.y -= BLADE_SIZE_X;
+         box_center.y -= BLADE_SIZE_X_M;
          break;
       }
       case Alignment::PointsRight:
       {
-         box_width = BLADE_SIZE_Y * 0.5f;
-         box_height = BLADE_SIZE_X * 0.5f;
+         box_width = BLADE_SIZE_Y_M * 0.5f;
+         box_height = BLADE_SIZE_X_M * 0.5f;
          box_center = {box_width, box_height};
-         box_center.y -= BLADE_SIZE_X;
+         box_center.y -= BLADE_SIZE_X_M;
          break;
       }
       case Alignment::PointsUp:
       {
-         box_width = BLADE_SIZE_X * 0.5f;
-         box_height = BLADE_SIZE_Y * 0.5f;
+         box_width = BLADE_SIZE_X_M * 0.5f;
+         box_height = BLADE_SIZE_Y_M * 0.5f;
          box_center = {box_width, box_height};
          break;
       }
       case Alignment::PointsDown:
       {
-         box_width = BLADE_SIZE_X * 0.5f;
-         box_height = BLADE_SIZE_Y * 0.5f;
+         box_width = BLADE_SIZE_X_M * 0.5f;
+         box_height = BLADE_SIZE_Y_M * 0.5f;
          box_center = {box_width, box_height};
          box_center.y -= PIXELS_PER_TILE / PPM;
          break;

--- a/src/game/mechanisms/crusher.cpp
+++ b/src/game/mechanisms/crusher.cpp
@@ -331,8 +331,8 @@ void Crusher::setup(const GameDeserializeData& data)
       _idle_time_max = sf::seconds(idle_time_s);
    }
 
-   _pixel_position.x = data._tmx_object->_x_px;
-   _pixel_position.y = data._tmx_object->_y_px;
+   _position_px.x = data._tmx_object->_x_px;
+   _position_px.y = data._tmx_object->_y_px;
 
 #ifdef __EMSCRIPTEN__
    _sprite_mount = std::make_unique<sf::Sprite>();
@@ -361,9 +361,9 @@ void Crusher::setup(const GameDeserializeData& data)
          _sprite_spike->setTextureRect({{7 * PIXELS_PER_TILE, 8 * PIXELS_PER_TILE}, {5 * PIXELS_PER_TILE, 3 * PIXELS_PER_TILE}});
 #endif
 
-         _pixel_offset_mount.x = 2 * PIXELS_PER_TILE;
-         _pixel_offset_pusher.y = 2 * PIXELS_PER_TILE;
-         _pixel_offset_spike.y = 2 * PIXELS_PER_TILE;
+         _offset_mount_px.x = 2 * PIXELS_PER_TILE;
+         _offset_pusher_px.y = 2 * PIXELS_PER_TILE;
+         _offset_spike_px.y = 2 * PIXELS_PER_TILE;
 
          break;
       }
@@ -380,9 +380,9 @@ void Crusher::setup(const GameDeserializeData& data)
          _sprite_spike->setTextureRect({{0 * PIXELS_PER_TILE, 5 * PIXELS_PER_TILE}, {5 * PIXELS_PER_TILE, 3 * PIXELS_PER_TILE}});
 #endif
 
-         _pixel_offset_pusher.y = 6 * PIXELS_PER_TILE;
-         _pixel_offset_spike.y = 3 * PIXELS_PER_TILE;
-         _pixel_offset_mount.y = 6 * PIXELS_PER_TILE;
+         _offset_pusher_px.y = 6 * PIXELS_PER_TILE;
+         _offset_spike_px.y = 3 * PIXELS_PER_TILE;
+         _offset_mount_px.y = 6 * PIXELS_PER_TILE;
 
          break;
       }
@@ -399,11 +399,11 @@ void Crusher::setup(const GameDeserializeData& data)
          _sprite_spike->setTextureRect({{0 * PIXELS_PER_TILE, 0 * PIXELS_PER_TILE}, {3 * PIXELS_PER_TILE, 5 * PIXELS_PER_TILE}});
 #endif
 
-         _pixel_offset_pusher.y = -1 * PIXELS_PER_TILE;
-         _pixel_offset_pusher.x = 3 * PIXELS_PER_TILE;
-         _pixel_offset_spike.y = -1 * PIXELS_PER_TILE;
-         _pixel_offset_mount.y = -1 * PIXELS_PER_TILE;
-         _pixel_offset_mount.x = 3 * PIXELS_PER_TILE;
+         _offset_pusher_px.y = -1 * PIXELS_PER_TILE;
+         _offset_pusher_px.x = 3 * PIXELS_PER_TILE;
+         _offset_spike_px.y = -1 * PIXELS_PER_TILE;
+         _offset_mount_px.y = -1 * PIXELS_PER_TILE;
+         _offset_mount_px.x = 3 * PIXELS_PER_TILE;
 
          break;
       }
@@ -420,12 +420,12 @@ void Crusher::setup(const GameDeserializeData& data)
          _sprite_spike->setTextureRect({{10 * PIXELS_PER_TILE, 0 * PIXELS_PER_TILE}, {3 * PIXELS_PER_TILE, 5 * PIXELS_PER_TILE}});
 #endif
 
-         _pixel_offset_pusher.y = -1 * PIXELS_PER_TILE;
-         _pixel_offset_pusher.x = -1 * PIXELS_PER_TILE;
-         _pixel_offset_spike.y = -1 * PIXELS_PER_TILE;
-         _pixel_offset_spike.x = -1 * PIXELS_PER_TILE;
-         _pixel_offset_mount.y = -1 * PIXELS_PER_TILE;
-         _pixel_offset_mount.x = -3 * PIXELS_PER_TILE;
+         _offset_pusher_px.y = -1 * PIXELS_PER_TILE;
+         _offset_pusher_px.x = -1 * PIXELS_PER_TILE;
+         _offset_spike_px.y = -1 * PIXELS_PER_TILE;
+         _offset_spike_px.x = -1 * PIXELS_PER_TILE;
+         _offset_mount_px.y = -1 * PIXELS_PER_TILE;
+         _offset_mount_px.x = -3 * PIXELS_PER_TILE;
 
          break;
       }
@@ -439,8 +439,8 @@ void Crusher::setup(const GameDeserializeData& data)
 
 void Crusher::updateTransform()
 {
-   const auto x = (_blade_offset.x + _pixel_position.x) / PPM;
-   const auto y = (_blade_offset.y + _pixel_position.y - PIXELS_PER_TILE) / PPM + (5 * PIXELS_PER_TILE) / PPM;
+   const auto x = (_blade_offset.x + _position_px.x) / PPM;
+   const auto y = (_blade_offset.y + _position_px.y - PIXELS_PER_TILE) / PPM + (5 * PIXELS_PER_TILE) / PPM;
    const auto target_position = b2Vec2(x, y);
    const auto current_position = _body->GetPosition();
    const auto direction = target_position - current_position;
@@ -611,12 +611,12 @@ void Crusher::updateSpritePositions()
    }
 
 #ifdef __EMSCRIPTEN__
-   _sprite_mount->position = _pixel_position + _pixel_offset_mount;
-   _sprite_pusher->position = _pixel_position + _pixel_offset_pusher;
-   _sprite_spike->position = _pixel_position + _pixel_offset_spike + _blade_offset;
+   _sprite_mount->position = _position_px + _offset_mount_px;
+   _sprite_pusher->position = _position_px + _offset_pusher_px;
+   _sprite_spike->position = _position_px + _offset_spike_px + _blade_offset;
 #else
-   _sprite_mount->setPosition(_pixel_position + _pixel_offset_mount);
-   _sprite_pusher->setPosition(_pixel_position + _pixel_offset_pusher);
-   _sprite_spike->setPosition(_pixel_position + _pixel_offset_spike + _blade_offset);
+   _sprite_mount->setPosition(_position_px + _offset_mount_px);
+   _sprite_pusher->setPosition(_position_px + _offset_pusher_px);
+   _sprite_spike->setPosition(_position_px + _offset_spike_px + _blade_offset);
 #endif
 }

--- a/src/game/mechanisms/crusher.h
+++ b/src/game/mechanisms/crusher.h
@@ -88,7 +88,7 @@ private:
    Alignment _alignment = Alignment::PointsDown;
 
    b2Body* _body{nullptr};
-   sf::Vector2f _pixel_position;
+   sf::Vector2f _position_px;
    sf::Vector2f _blade_offset;
    sf::FloatRect _rect;
 
@@ -103,9 +103,9 @@ private:
    std::unique_ptr<sf::Sprite> _sprite_spike;
    std::unique_ptr<sf::Sprite> _sprite_pusher;
    std::unique_ptr<sf::Sprite> _sprite_mount;
-   sf::Vector2f _pixel_offset_mount;
-   sf::Vector2f _pixel_offset_pusher;
-   sf::Vector2f _pixel_offset_spike;
+   sf::Vector2f _offset_mount_px;
+   sf::Vector2f _offset_pusher_px;
+   sf::Vector2f _offset_spike_px;
 
    bool _shake{true};
    bool _shake_shown{false};

--- a/src/game/mechanisms/damagerect.cpp
+++ b/src/game/mechanisms/damagerect.cpp
@@ -63,8 +63,8 @@ std::string_view DamageRect::objectName() const
 void DamageRect::update(const sf::Time& /*dt*/)
 {
    auto player = PlayerRegistry::getFirst();
-   const auto player_pixel_rect = player->getPixelRectFloat();
-   const auto player_intersects = sfcompat::findIntersection(player_pixel_rect, _rect).has_value();
+   const auto player_rect_px = player->getPixelRectFloat();
+   const auto player_intersects = sfcompat::findIntersection(player_rect_px, _rect).has_value();
 
    if (player_intersects)
    {

--- a/src/game/mechanisms/deathblock.cpp
+++ b/src/game/mechanisms/deathblock.cpp
@@ -129,8 +129,8 @@ void DeathBlock::draw(sf::RenderTarget& color, sf::RenderTarget& /*normal*/, con
 
 void DeathBlock::setupTransform()
 {
-   auto x = _pixel_positions.x / PPM - (PIXELS_PER_TILE / (2 * PPM));
-   auto y = _pixel_positions.y / PPM;
+   auto x = _positions_px.x / PPM - (PIXELS_PER_TILE / (2 * PPM));
+   auto y = _positions_px.y / PPM;
    _body->SetTransform(b2Vec2(x, y), 0);
 }
 
@@ -522,8 +522,8 @@ void DeathBlock::setup(const GameDeserializeData& data)
 
    setZ(static_cast<int32_t>(ZDepth::ForegroundMin) + 1);
 
-   _pixel_positions.x = data._tmx_object->_x_px;
-   _pixel_positions.y = data._tmx_object->_y_px;
+   _positions_px.x = data._tmx_object->_x_px;
+   _positions_px.y = data._tmx_object->_y_px;
 
    _time_off = sf::seconds(ValueReader::readValue<float>("time_off", map).value_or(default_death_block_time_off));
    _time_on = sf::seconds(ValueReader::readValue<float>("time_on", map).value_or(default_death_block_time_on));
@@ -552,17 +552,17 @@ void DeathBlock::setup(const GameDeserializeData& data)
 
    // setup velocity
    const auto velocity = ValueReader::readValue<float>("velocity", map).value_or(default_death_block_velocity);
-   auto pixel_path = data._tmx_object->_polyline ? data._tmx_object->_polyline->_path : data._tmx_object->_polygon->_polyline;
-   const auto start_pos = pixel_path.at(0);
-   pixel_path.push_back(start_pos);
-   _velocity = 50.0f / SfmlMath::length(pixel_path);
+   auto path_px = data._tmx_object->_polyline ? data._tmx_object->_polyline->_path : data._tmx_object->_polygon->_polyline;
+   const auto start_pos = path_px.at(0);
+   path_px.push_back(start_pos);
+   _velocity = 50.0f / SfmlMath::length(path_px);
 
    // setup path
    auto pos_index = 0;
-   for (const auto& poly_pos : pixel_path)
+   for (const auto& poly_pos : path_px)
    {
       b2Vec2 world_pos;
-      const auto time = pos_index / static_cast<float>(pixel_path.size() - 1);
+      const auto time = pos_index / static_cast<float>(path_px.size() - 1);
 
       const auto x = (data._tmx_object->_x_px + poly_pos.x - (PIXELS_PER_TILE) / 2.0f) * MPP;
       const auto y = (data._tmx_object->_y_px + poly_pos.y - (PIXELS_PER_TILE) / 2.0f) * MPP;

--- a/src/game/mechanisms/deathblock.h
+++ b/src/game/mechanisms/deathblock.h
@@ -19,7 +19,6 @@ struct TmxTileSet;
 class DeathBlock : public GameMechanism, public GameNode
 {
 public:
-
    /// \brief creates a death block node.
    /// \param parent parent node in the scene graph.
    DeathBlock(GameNode* parent = nullptr);
@@ -62,8 +61,8 @@ private:
       Rotate
    };
 
-    /// \brief per-side spike animation and collision state for one orientation.
-    struct Spike
+   /// \brief per-side spike animation and collision state for one orientation.
+   struct Spike
    {
       enum class State
       {
@@ -84,30 +83,30 @@ private:
       /// \brief starts a spike in the default retracted state.
       Spike();
 
-       /// \brief checks whether sprite index changed since the previous frame.
-       /// \return true when a new frame should be applied to the sprite.
-       bool hasChanged() const;
+      /// \brief checks whether sprite index changed since the previous frame.
+      /// \return true when a new frame should be applied to the sprite.
+      bool hasChanged() const;
 
-       /// \brief stores previous and current sprite indices from the animation timer.
-       void updateIndex();
+      /// \brief stores previous and current sprite indices from the animation timer.
+      void updateIndex();
 
-       /// \brief advances extracting animation until fully extended.
-       /// \param dt elapsed frame time.
-       void extract(const sf::Time& dt);
+      /// \brief advances extracting animation until fully extended.
+      /// \param dt elapsed frame time.
+      void extract(const sf::Time& dt);
 
-       /// \brief keeps spike extended until on-time expires.
-       /// \param dt elapsed frame time.
-       /// \param time_on duration to keep spikes extended.
-       void extracted(const sf::Time& dt, const sf::Time& time_on);
+      /// \brief keeps spike extended until on-time expires.
+      /// \param dt elapsed frame time.
+      /// \param time_on duration to keep spikes extended.
+      void extracted(const sf::Time& dt, const sf::Time& time_on);
 
-       /// \brief advances retracting animation until fully retracted.
-       /// \param dt elapsed frame time.
-       void retract(const sf::Time& dt);
+      /// \brief advances retracting animation until fully retracted.
+      /// \param dt elapsed frame time.
+      void retract(const sf::Time& dt);
 
-       /// \brief keeps spike retracted until off-time expires.
-       /// \param dt elapsed frame time.
-       /// \param time_off duration to keep spikes retracted.
-       void retracted(const sf::Time& dt, const sf::Time& time_off);
+      /// \brief keeps spike retracted until off-time expires.
+      /// \param dt elapsed frame time.
+      /// \param time_off duration to keep spikes retracted.
+      void retracted(const sf::Time& dt, const sf::Time& time_off);
 
       State _state{State::Retracted};
       sf::Time _wait_time;
@@ -121,41 +120,41 @@ private:
       bool _active{true};
    };
 
-    /// \brief positions the physics body from configured pixel coordinates.
-    void setupTransform();
+   /// \brief positions the physics body from configured pixel coordinates.
+   void setupTransform();
 
-    /// \brief creates the kinematic body and fixture used for trap collisions.
-    /// \param world physics world that owns the body.
-    void setupBody(const std::shared_ptr<b2World>& world);
+   /// \brief creates the kinematic body and fixture used for trap collisions.
+   /// \param world physics world that owns the body.
+   void setupBody(const std::shared_ptr<b2World>& world);
 
-    /// \brief eases lever lag toward enabled or disabled target.
-    /// \param dt elapsed frame time.
-    void updateLeverLag(const sf::Time& dt);
+   /// \brief eases lever lag toward enabled or disabled target.
+   /// \param dt elapsed frame time.
+   void updateLeverLag(const sf::Time& dt);
 
-    /// \brief updates absolute spike hit rects and damages the player on lethal overlap.
-    void updateCollision();
+   /// \brief updates absolute spike hit rects and damages the player on lethal overlap.
+   void updateCollision();
 
-    /// \brief updates spike states according to the selected operating mode.
-    /// \param dt elapsed frame time.
-    void updateStates(const sf::Time& dt);
+   /// \brief updates spike states according to the selected operating mode.
+   /// \param dt elapsed frame time.
+   void updateStates(const sf::Time& dt);
 
-    /// \brief updates cached bounding rectangle from the current body position.
-    void updateBoundingBox();
+   /// \brief updates cached bounding rectangle from the current body position.
+   void updateBoundingBox();
 
-    /// \brief applies current animation frame and position to all sprites.
-    void updateSprites();
+   /// \brief applies current animation frame and position to all sprites.
+   void updateSprites();
 
-    /// \brief moves the trap along its interpolation path and updates platform coupling for the player.
-    /// \param dt elapsed frame time.
-    void updatePosition(const sf::Time& dt);
+   /// \brief moves the trap along its interpolation path and updates platform coupling for the player.
+   /// \param dt elapsed frame time.
+   void updatePosition(const sf::Time& dt);
 
-    /// \brief updates all spikes using the interval mode state machine.
-    /// \param dt elapsed frame time.
-    void updateStatesInterval(const sf::Time& dt);
+   /// \brief updates all spikes using the interval mode state machine.
+   /// \param dt elapsed frame time.
+   void updateStatesInterval(const sf::Time& dt);
 
-    /// \brief updates one active spike at a time and rotates active side after each cycle.
-    /// \param dt elapsed frame time.
-    void updateStatesRotate(const sf::Time& dt);
+   /// \brief updates one active spike at a time and rotates active side after each cycle.
+   /// \param dt elapsed frame time.
+   void updateStatesRotate(const sf::Time& dt);
 
    //     +---+
    //     | 0 |
@@ -165,7 +164,7 @@ private:
    //     | 2 |
    //     +---+
 
-   sf::Vector2f _pixel_positions;
+   sf::Vector2f _positions_px;
    sf::FloatRect _rect;
    b2Body* _body = nullptr;
    std::vector<b2Vec2> _path;

--- a/src/game/mechanisms/dialogue.cpp
+++ b/src/game/mechanisms/dialogue.cpp
@@ -162,7 +162,7 @@ std::shared_ptr<Dialogue> Dialogue::deserialize(GameNode* parent, const GameDese
       dialogue->_show_delay_ms = std::chrono::milliseconds{show_delay.value()};
    }
 
-   dialogue->_pixel_rect =
+   dialogue->_rect_px =
       sf::FloatRect{{data._tmx_object->_x_px, data._tmx_object->_y_px}, {data._tmx_object->_width_px, data._tmx_object->_height_px}};
 
    return dialogue;
@@ -203,7 +203,7 @@ void Dialogue::update(const sf::Time& /*dt*/)
    }
 
    const auto& player_rect = PlayerRegistry::getFirst()->getPixelRectFloat();
-   if (_open_on_intersect && sfcompat::findIntersection(player_rect, _pixel_rect).has_value())
+   if (_open_on_intersect && sfcompat::findIntersection(player_rect, _rect_px).has_value())
    {
       // message boxes might already be marked as inactive, however
       // they might still be fading out. the display mode 'modal', however
@@ -237,7 +237,7 @@ void Dialogue::update(const sf::Time& /*dt*/)
 
 std::optional<sf::FloatRect> Dialogue::getBoundingBoxPx()
 {
-   return _pixel_rect;
+   return _rect_px;
 }
 
 bool Dialogue::isActive() const

--- a/src/game/mechanisms/dialogue.h
+++ b/src/game/mechanisms/dialogue.h
@@ -85,7 +85,7 @@ private:
    std::vector<DialogueItem> _dialogue_items;
    uint32_t _index = 0;
 
-   sf::FloatRect _pixel_rect;
+   sf::FloatRect _rect_px;
    bool _active{false};
    bool _button_required{true};
    bool _pause_game{true};

--- a/src/game/mechanisms/door.cpp
+++ b/src/game/mechanisms/door.cpp
@@ -270,7 +270,7 @@ void Door::setEnabled(bool enabled)
 
 std::optional<sf::FloatRect> Door::getBoundingBoxPx()
 {
-   return _pixel_rect;
+   return _rect_px;
 }
 
 void Door::updateTransform()
@@ -318,7 +318,7 @@ bool Door::checkPlayerAtDoor() const
 
 const sf::FloatRect& Door::getPixelRect() const
 {
-   return _pixel_rect;
+   return _rect_px;
 }
 
 void Door::open()
@@ -555,7 +555,7 @@ bool Door::setup(const GameDeserializeData& data)
       _door_quad[2].position = {x_px + 3 * PIXELS_PER_TILE - PIXELS_PER_TILE, y_px};                        // bottom-right
       _door_quad[3].position = {x_px + 3 * PIXELS_PER_TILE - PIXELS_PER_TILE, y_px + 3 * PIXELS_PER_TILE};  // top-right
 
-      _pixel_rect = sf::FloatRect({x_px, y_px}, {PIXELS_PER_TILE, PIXELS_PER_TILE * 3});
+      _rect_px = sf::FloatRect({x_px, y_px}, {PIXELS_PER_TILE, PIXELS_PER_TILE * 3});
    }
    else
    {

--- a/src/game/mechanisms/door.h
+++ b/src/game/mechanisms/door.h
@@ -131,7 +131,7 @@ private:
    // for 'version 1'
    sf::VertexArray _door_quad{sf::PrimitiveType::Triangles, 4};
    sf::Vector2i _tile_position_tl;
-   sf::FloatRect _pixel_rect;
+   sf::FloatRect _rect_px;
    float _bar_offset = 0.0f;
 
    std::optional<std::string> _required_item;

--- a/src/game/mechanisms/fan.cpp
+++ b/src/game/mechanisms/fan.cpp
@@ -65,12 +65,12 @@ void Fan::setEnabled(bool enabled)
 
 const sf::FloatRect& Fan::getPixelRect() const
 {
-   return _pixel_rect;
+   return _rect_px;
 }
 
 std::optional<sf::FloatRect> Fan::getBoundingBoxPx()
 {
-   return _pixel_rect;
+   return _rect_px;
 }
 
 std::shared_ptr<Fan> Fan::deserialize(GameNode* parent, const GameDeserializeData& data)
@@ -80,7 +80,7 @@ std::shared_ptr<Fan> Fan::deserialize(GameNode* parent, const GameDeserializeDat
    const auto& obj = data._tmx_object;
    fan->_texture = TexturePool::getInstance().get("data/sprites/fan.png");
 
-   fan->_pixel_rect = {{obj->_x_px, obj->_y_px}, {obj->_width_px, obj->_height_px}};
+   fan->_rect_px = {{obj->_x_px, obj->_y_px}, {obj->_width_px, obj->_height_px}};
 
    std::string dir_str = std::string(default_fan_direction);
    if (obj->_properties)
@@ -106,8 +106,8 @@ std::shared_ptr<Fan> Fan::deserialize(GameNode* parent, const GameDeserializeDat
 
    fan->_direction_string = dir_str;  // Store the string form too
 
-   const auto tiles_x = static_cast<int>(fan->_pixel_rect.size.x) / PIXELS_PER_TILE;
-   const auto tiles_y = static_cast<int>(fan->_pixel_rect.size.y) / PIXELS_PER_TILE;
+   const auto tiles_x = static_cast<int>(fan->_rect_px.size.x) / PIXELS_PER_TILE;
+   const auto tiles_y = static_cast<int>(fan->_rect_px.size.y) / PIXELS_PER_TILE;
 
    if (dir_str == "up")
    {
@@ -163,8 +163,8 @@ void Fan::insertInstance(const std::shared_ptr<Fan>& fan, const GameDeserializeD
 
    instance.sprite_offset = std::rand() % 8;
    instance.tile_position_px = {
-      static_cast<int>(fan->_pixel_rect.position.x) + (x_tl * PIXELS_PER_TILE),
-      static_cast<int>(fan->_pixel_rect.position.y) + (y_tl * PIXELS_PER_TILE)
+      static_cast<int>(fan->_rect_px.position.x) + (x_tl * PIXELS_PER_TILE),
+      static_cast<int>(fan->_rect_px.position.y) + (y_tl * PIXELS_PER_TILE)
    };
 
    instance.direction = fan->_direction;
@@ -281,7 +281,7 @@ void Fan::collide()
    }
 
    const auto& player_rect = PlayerRegistry::getFirst()->getPixelRectFloat();
-   if (sfcompat::findIntersection(player_rect, _pixel_rect).has_value())
+   if (sfcompat::findIntersection(player_rect, _rect_px).has_value())
    {
       PlayerRegistry::getFirst()->getBody()->ApplyForceToCenter(b2Vec2(2.0F * _direction.x, _direction.y), true);
    }

--- a/src/game/mechanisms/fan.h
+++ b/src/game/mechanisms/fan.h
@@ -80,8 +80,7 @@ private:
 
       /// \brief creates a fan tile sprite from a shared texture atlas.
       /// \param tex shared texture used for this tile sprite.
-      FanInstance(const std::shared_ptr<sf::Texture>& tex)
-         : texture(tex), sprite(std::make_unique<sf::Sprite>())
+      FanInstance(const std::shared_ptr<sf::Texture>& tex) : texture(tex), sprite(std::make_unique<sf::Sprite>())
       {
       }
 #else
@@ -112,7 +111,7 @@ private:
    sf::Vector2f _direction;
    std::string _direction_string;
    TileDirection _direction_enum{TileDirection::Up};
-   sf::FloatRect _pixel_rect;
+   sf::FloatRect _rect_px;
    float _speed = 1.0f;
    float _lever_lag = 1.0f;
    int32_t _y_offset_tl{0};

--- a/src/game/mechanisms/gateway.cpp
+++ b/src/game/mechanisms/gateway.cpp
@@ -893,7 +893,7 @@ void Gateway::use()
       {
          const auto y_tl_to_px = static_cast<int32_t>(target_pos_px.y / PIXELS_PER_TILE) * PIXELS_PER_TILE;
          PlayerRegistry::getFirst()->setBodyViaPixelPosition(
-            target_pos_px.x + PLAYER_ACTUAL_WIDTH / 2, y_tl_to_px + PIXELS_PER_TILE * 3 - 8
+            target_pos_px.x + PLAYER_ACTUAL_WIDTH_PX / 2, y_tl_to_px + PIXELS_PER_TILE * 3 - 8
          );
 
          // update the camera system to point to the player position immediately
@@ -1048,7 +1048,7 @@ void Gateway::Eye::update(const sf::Time& dt, State state)
       _eye_iris_idle_ref->update(dt);
    }
 
-   const auto error_gaze_px = sf::Vector2f(-PLAYER_ACTUAL_WIDTH / 2, 0);
+   const auto error_gaze_px = sf::Vector2f(-PLAYER_ACTUAL_WIDTH_PX / 2, 0);
    const auto player_pos_px = PlayerRegistry::getFirst()->getPixelPositionFloat() + error_gaze_px;
    const auto dir_to_player = player_pos_px - _center_pos_px;
    const auto dir_to_player_normalized = dir_to_player.normalized();

--- a/src/game/mechanisms/laser.cpp
+++ b/src/game/mechanisms/laser.cpp
@@ -82,7 +82,7 @@ void Laser::setEnabled(bool enabled)
 
 const sf::FloatRect& Laser::getPixelRect() const
 {
-   return _pixel_rect;
+   return _rect_px;
 }
 
 void Laser::update(const sf::Time& dt)
@@ -222,7 +222,7 @@ void Laser::update(const sf::Time& dt)
 
 std::optional<sf::FloatRect> Laser::getBoundingBoxPx()
 {
-   return _pixel_rect;
+   return _rect_px;
 }
 
 void Laser::reset()
@@ -244,7 +244,7 @@ void Laser::resetAll()
 
 const sf::Vector2f& Laser::getTilePosition() const
 {
-   return _tile_position;
+   return _position_tl;
 }
 
 const sf::Vector2f& Laser::getPixelPosition() const
@@ -305,17 +305,17 @@ std::vector<std::shared_ptr<GameMechanism>> Laser::load(GameNode* parent, const 
 
          laser->_version = version;
 
-         laser->_tile_position.x = static_cast<float>(i);
-         laser->_tile_position.y = static_cast<float>(j);
+         laser->_position_tl.x = static_cast<float>(i);
+         laser->_position_tl.y = static_cast<float>(j);
 
-         laser->_position_px.x = laser->_tile_position.x * PIXELS_PER_TILE;
-         laser->_position_px.y = laser->_tile_position.y * PIXELS_PER_TILE;
+         laser->_position_px.x = laser->_position_tl.x * PIXELS_PER_TILE;
+         laser->_position_px.y = laser->_position_tl.y * PIXELS_PER_TILE;
 
-         laser->_pixel_rect.position.x = laser->_position_px.x;
-         laser->_pixel_rect.position.y = laser->_position_px.y;
+         laser->_rect_px.position.x = laser->_position_px.x;
+         laser->_rect_px.position.y = laser->_position_px.y;
 
-         laser->_pixel_rect.size.x = PIXELS_PER_TILE;
-         laser->_pixel_rect.size.y = PIXELS_PER_TILE;
+         laser->_rect_px.size.x = PIXELS_PER_TILE;
+         laser->_rect_px.size.y = PIXELS_PER_TILE;
 
          laser->_texture = TexturePool::getInstance().get(data._base_path / data._tmx_tileset->_image->_source);
 
@@ -399,15 +399,15 @@ void Laser::collide()
    auto checkCollision = [this]()
    {
       const sf::FloatRect& player_rect = PlayerRegistry::getFirst()->getPixelRectFloat();
-      auto pixel_rect = _pixel_rect;
+      auto rect_px = _rect_px;
 
       if (_path.has_value())
       {
-         pixel_rect.position.x += static_cast<int32_t>(_move_offset_px.x);
-         pixel_rect.position.y += static_cast<int32_t>(_move_offset_px.y);
+         rect_px.position.x += static_cast<int32_t>(_move_offset_px.x);
+         rect_px.position.y += static_cast<int32_t>(_move_offset_px.y);
       }
 
-      const auto rough_intersection = sfcompat::findIntersection(player_rect, pixel_rect).has_value();
+      const auto rough_intersection = sfcompat::findIntersection(player_rect, rect_px).has_value();
 
       auto active = false;
 
@@ -535,7 +535,7 @@ void Laser::merge()
             {
                for (auto& laser : __lasers)
                {
-                  if (static_cast<int32_t>(laser->_tile_position.x) == xi && static_cast<int32_t>(laser->_tile_position.y) == yi)
+                  if (static_cast<int32_t>(laser->_position_tl.x) == xi && static_cast<int32_t>(laser->_position_tl.y) == yi)
                   {
                      if (on_signal.has_value())
                      {

--- a/src/game/mechanisms/laser.h
+++ b/src/game/mechanisms/laser.h
@@ -119,9 +119,9 @@ protected:
    std::shared_ptr<sf::Texture> _texture;
    std::unique_ptr<sf::Sprite> _sprite;
 
-   sf::Vector2f _tile_position;
+   sf::Vector2f _position_tl;
    sf::Vector2f _position_px;
-   sf::FloatRect _pixel_rect;
+   sf::FloatRect _rect_px;
 
    std::optional<std::vector<sf::Vector2f>> _path;
    sf::Vector2f _move_offset_px;

--- a/src/game/mechanisms/movingplatform.cpp
+++ b/src/game/mechanisms/movingplatform.cpp
@@ -119,12 +119,12 @@ void MovingPlatform::draw(sf::RenderTarget& color, sf::RenderTarget& normal, con
 
 const std::vector<sf::Vector2f>& MovingPlatform::getPixelPath() const
 {
-   return _pixel_path;
+   return _path_px;
 }
 
 float MovingPlatform::getDx() const
 {
-   return _pos.x - _pos_prev.x;
+   return _pos_m.x - _pos_prev_m.x;
 }
 
 b2Body* MovingPlatform::getBody()
@@ -148,8 +148,8 @@ void MovingPlatform::setEnabled(bool enabled)
 
 void MovingPlatform::setupTransform()
 {
-   auto pos_x_m = static_cast<float>(_tile_positions.x) * PIXELS_PER_TILE / PPM;
-   auto pos_y_m = static_cast<float>(_tile_positions.y) * PIXELS_PER_TILE / PPM;
+   auto pos_x_m = static_cast<float>(_positions_tl.x) * PIXELS_PER_TILE / PPM;
+   auto pos_y_m = static_cast<float>(_positions_tl.y) * PIXELS_PER_TILE / PPM;
    _body->SetTransform(b2Vec2(pos_x_m, pos_y_m), 0);
 }
 
@@ -315,7 +315,7 @@ void MovingPlatform::setup(const GameDeserializeData& data)
       platform_pos_m.y = y_px * MPP;
 
       _interpolation.addKey(platform_pos_m, time);
-      _pixel_path.emplace_back((data._tmx_object->_x_px + poly_pos_px.x), (data._tmx_object->_y_px + poly_pos_px.y));
+      _path_px.emplace_back((data._tmx_object->_x_px + poly_pos_px.x), (data._tmx_object->_y_px + poly_pos_px.y));
 
       platform_x_min_m = std::min(platform_pos_m.x, platform_x_min_m);
       platform_y_min_m = std::min(platform_pos_m.y, platform_y_min_m);
@@ -402,9 +402,9 @@ void MovingPlatform::update(const sf::Time& delta_time)
    }
 
    _body->SetLinearVelocity(_velocity);
-   _pos_prev = _pos;
-   _pos.x = _body->GetPosition().x;
-   _pos.y = _body->GetPosition().y;
+   _pos_prev_m = _pos_m;
+   _pos_m.x = _body->GetPosition().x;
+   _pos_m.y = _body->GetPosition().y;
 
    auto& platform = PlayerRegistry::getFirst()->getPlatform();
    if (platform.getPlatformBody() == _body)

--- a/src/game/mechanisms/movingplatform.h
+++ b/src/game/mechanisms/movingplatform.h
@@ -5,11 +5,11 @@
 #include "game/level/gamenode.h"
 #include "game/mechanisms/gamemechanism.h"
 
-#include "box2d/box2d.h"
 #include <SFML/Graphics/RenderWindow.hpp>
 #include <SFML/Graphics/Sprite.hpp>
 #include <SFML/Graphics/Texture.hpp>
 #include <filesystem>
+#include "box2d/box2d.h"
 
 struct TmxLayer;
 struct TmxObject;
@@ -95,14 +95,14 @@ private:
    int32_t _animated_tile_index_1 = 0;
    float _animation_elapsed = 0.0f;
    b2Body* _body = nullptr;
-   sf::Vector2i _tile_positions;
+   sf::Vector2i _positions_tl;
    int32_t _platform_width_tl = 0;
    float _lever_lag = 0.0f;
    bool _initialized = false;
    PathInterpolation<b2Vec2> _interpolation;
    b2Vec2 _velocity{};
-   std::vector<sf::Vector2f> _pixel_path;
+   std::vector<sf::Vector2f> _path_px;
    sf::FloatRect _rect;
-   sf::Vector2f _pos;
-   sf::Vector2f _pos_prev;
+   sf::Vector2f _pos_m;
+   sf::Vector2f _pos_prev_m;
 };

--- a/src/game/mechanisms/portal.cpp
+++ b/src/game/mechanisms/portal.cpp
@@ -58,7 +58,7 @@ sf::Vector2f Portal::getPortalPosition()
 
 const sf::Vector2f& Portal::getTilePosition() const
 {
-   return _tile_positions;
+   return _positions_tl;
 }
 
 void Portal::lock()
@@ -184,8 +184,8 @@ void Portal::update(const sf::Time& /*dt*/)
          )
       );
 
-      const auto x = static_cast<int32_t>(_tile_positions.x);
-      const auto y = static_cast<int32_t>(_tile_positions.y);
+      const auto x = static_cast<int32_t>(_positions_tl.x);
+      const auto y = static_cast<int32_t>(_positions_tl.y);
 
       sfcompat::setPosition(sprite, sf::Vector2f(static_cast<float>(x * PIXELS_PER_TILE), static_cast<float>((i + y) * PIXELS_PER_TILE)));
 
@@ -301,7 +301,7 @@ std::vector<std::shared_ptr<GameMechanism>> Portal::load(GameNode* parent, const
             for (auto& p : portals)
             {
                auto tmp = std::dynamic_pointer_cast<Portal>(p);
-               if (static_cast<uint32_t>(tmp->_tile_positions.x) == i && static_cast<uint32_t>(tmp->_tile_positions.y) + 1 == j)
+               if (static_cast<uint32_t>(tmp->_positions_tl.x) == i && static_cast<uint32_t>(tmp->_positions_tl.y) + 1 == j)
                {
                   portal = tmp;
                   break;
@@ -312,8 +312,8 @@ std::vector<std::shared_ptr<GameMechanism>> Portal::load(GameNode* parent, const
             {
                portal = std::make_shared<Portal>(parent);
                portals.push_back(portal);
-               portal->_tile_positions.x = static_cast<float>(i);
-               portal->_tile_positions.y = static_cast<float>(j);
+               portal->_positions_tl.x = static_cast<float>(i);
+               portal->_positions_tl.y = static_cast<float>(j);
                portal->_texture = TexturePool::getInstance().get((data._base_path / data._tmx_tileset->_image->_source).string());
                portal->_rect = sf::FloatRect{{static_cast<float>(i), static_cast<float>(j)}, {PIXELS_PER_TILE, PIXELS_PER_TILE * 2}};
 

--- a/src/game/mechanisms/portal.cpp
+++ b/src/game/mechanisms/portal.cpp
@@ -101,7 +101,7 @@ void goToPortal(auto portal)
    auto dst_position_px = portal->getDestination()->getPortalPosition();
 
    PlayerRegistry::getFirst()->setBodyViaPixelPosition(
-      dst_position_px.x + PLAYER_ACTUAL_WIDTH / 2, dst_position_px.y + DIFF_PLAYER_TILE_TO_PHYSICS
+      dst_position_px.x + PLAYER_ACTUAL_WIDTH_PX / 2, dst_position_px.y + DIFF_PLAYER_TILE_TO_PHYSICS_PX
    );
 
    // update the camera system to point to the player position immediately

--- a/src/game/mechanisms/portal.h
+++ b/src/game/mechanisms/portal.h
@@ -99,7 +99,7 @@ protected:
    sf::Vector2u _tile_size;
    std::shared_ptr<sf::Texture> _texture;
    std::vector<sf::Sprite> _sprites;
-   sf::Vector2f _tile_positions;
+   sf::Vector2f _positions_tl;
    int32_t _height = 0;
    bool _player_at_portal = false;
    std::shared_ptr<Portal> _destination;

--- a/src/game/mechanisms/rope.cpp
+++ b/src/game/mechanisms/rope.cpp
@@ -283,9 +283,9 @@ void Rope::setup(const GameDeserializeData& data)
    }
 
    // init segment length
-   std::vector<sf::Vector2f> pixel_path = data._tmx_object->_polyline->_path;
-   const auto path_0_px = pixel_path.at(0);
-   const auto path_1_px = pixel_path.at(1);
+   std::vector<sf::Vector2f> path_px = data._tmx_object->_polyline->_path;
+   const auto path_0_px = path_px.at(0);
+   const auto path_1_px = path_px.at(1);
    const auto rope_length_px = path_1_px - path_0_px;
    _segment_length_m = (SfmlMath::length(rope_length_px) * MPP) / static_cast<float>(_segment_count);
 
@@ -345,7 +345,7 @@ sf::Vector2i Rope::getPixelPosition() const
    return _position_px;
 }
 
-void Rope::setPixelPosition(const sf::Vector2i& pixel_position)
+void Rope::setPixelPosition(const sf::Vector2i& position_px)
 {
-   _position_px = pixel_position;
+   _position_px = position_px;
 }

--- a/src/game/mechanisms/rope.h
+++ b/src/game/mechanisms/rope.h
@@ -52,8 +52,8 @@ public:
    sf::Vector2i getPixelPosition() const;
 
    /// \brief sets the rope anchor position in pixels.
-   /// \param pixel_position anchor position used for box2d body creation.
-   void setPixelPosition(const sf::Vector2i& pixel_position);
+   /// \param position_px anchor position used for box2d body creation.
+   void setPixelPosition(const sf::Vector2i& position_px);
 
 protected:
    int32_t _segment_count = 7;

--- a/src/game/mechanisms/spikeball.cpp
+++ b/src/game/mechanisms/spikeball.cpp
@@ -421,7 +421,7 @@ void SpikeBall::setup(const GameDeserializeData& data)
       static_cast<int32_t>(data._tmx_object->_y_px) + PIXELS_PER_HALF_TILE
    });
 
-   const auto pos_m = b2Vec2{static_cast<float>(_pixel_position.x * MPP), static_cast<float>(_pixel_position.y * MPP)};
+   const auto pos_m = b2Vec2{static_cast<float>(_position_px.x * MPP), static_cast<float>(_position_px.y * MPP)};
 
    _anchor_body = data._world->CreateBody(&_anchor_def);
    _anchor_shape.SetTwoSided(b2Vec2(pos_m.x - 0.1f, pos_m.y), b2Vec2(pos_m.x + 0.1f, pos_m.y));
@@ -480,10 +480,10 @@ void SpikeBall::setup(const GameDeserializeData& data)
 
 sf::Vector2i SpikeBall::getPixelPosition() const
 {
-   return _pixel_position;
+   return _position_px;
 }
 
-void SpikeBall::setPixelPosition(const sf::Vector2i& pixel_position)
+void SpikeBall::setPixelPosition(const sf::Vector2i& position_px)
 {
-   _pixel_position = pixel_position;
+   _position_px = position_px;
 }

--- a/src/game/mechanisms/spikeball.h
+++ b/src/game/mechanisms/spikeball.h
@@ -73,8 +73,8 @@ public:
    sf::Vector2i getPixelPosition() const;
 
    /// \brief sets the anchor position in pixels.
-   /// \param pixel_position position in pixels.
-   void setPixelPosition(const sf::Vector2i& pixel_position);
+   /// \param position_px position in pixels.
+   void setPixelPosition(const sf::Vector2i& position_px);
 
 private:
 #ifdef __EMSCRIPTEN__
@@ -94,7 +94,7 @@ private:
    std::unique_ptr<sf::Sprite> _chain_element_a;
    std::unique_ptr<sf::Sprite> _chain_element_b;
 
-   sf::Vector2i _pixel_position;
+   sf::Vector2i _position_px;
    sf::FloatRect _rect;
 
    b2BodyDef _anchor_def;

--- a/src/game/mechanisms/spikes.cpp
+++ b/src/game/mechanisms/spikes.cpp
@@ -26,7 +26,7 @@ namespace
 //     |
 //     + unused
 constexpr auto SPRITES_PER_CYCLE = 15;
-constexpr auto TOLERANCE_PIXELS = 5;
+constexpr auto TOLERANCE_PX = 5;
 constexpr auto SPIKES_TILE_INDEX_TRAP_START = (SPRITES_PER_CYCLE - 1);
 constexpr auto SPIKES_TILE_INDEX_EXTRACT_START = 1;
 constexpr auto SPIKES_TILE_INDEX_EXTRACT_END = 5;
@@ -352,8 +352,8 @@ std::shared_ptr<Spikes> Spikes::deserialize(GameNode* parent, const GameDeserial
 
    // make the collision rectangle a bit smaller so it's a little more lax
    instance->_player_collision_rect_px = {
-      {data._tmx_object->_x_px + TOLERANCE_PIXELS, data._tmx_object->_y_px + TOLERANCE_PIXELS},
-      {data._tmx_object->_width_px - (2 * TOLERANCE_PIXELS), data._tmx_object->_height_px - (2 * TOLERANCE_PIXELS)}
+      {data._tmx_object->_x_px + TOLERANCE_PX, data._tmx_object->_y_px + TOLERANCE_PX},
+      {data._tmx_object->_width_px - (2 * TOLERANCE_PX), data._tmx_object->_height_px - (2 * TOLERANCE_PX)}
    };
 
    const auto rect =
@@ -546,8 +546,8 @@ std::vector<std::shared_ptr<Spikes>> Spikes::load(GameNode* parent, const GameDe
          }
 
          spikes->_player_collision_rect_px = {
-            {static_cast<float>(i * PIXELS_PER_TILE) + TOLERANCE_PIXELS, static_cast<float>(j * PIXELS_PER_TILE) + TOLERANCE_PIXELS},
-            {PIXELS_PER_TILE - (2 * TOLERANCE_PIXELS), PIXELS_PER_TILE - (2 * TOLERANCE_PIXELS)}
+            {static_cast<float>(i * PIXELS_PER_TILE) + TOLERANCE_PX, static_cast<float>(j * PIXELS_PER_TILE) + TOLERANCE_PX},
+            {PIXELS_PER_TILE - (2 * TOLERANCE_PX), PIXELS_PER_TILE - (2 * TOLERANCE_PX)}
          };
 
          const auto rect = sf::FloatRect{

--- a/src/game/mechanisms/spikes.cpp
+++ b/src/game/mechanisms/spikes.cpp
@@ -347,8 +347,8 @@ std::shared_ptr<Spikes> Spikes::deserialize(GameNode* parent, const GameDeserial
    auto instance = std::make_shared<Spikes>(parent);
 
    instance->setObjectId(data._tmx_object->_name);
-   instance->_pixel_position.x = data._tmx_object->_x_px;
-   instance->_pixel_position.y = data._tmx_object->_y_px;
+   instance->_position_px.x = data._tmx_object->_x_px;
+   instance->_position_px.y = data._tmx_object->_y_px;
 
    // make the collision rectangle a bit smaller so it's a little more lax
    instance->_player_collision_rect_px = {

--- a/src/game/mechanisms/spikes.h
+++ b/src/game/mechanisms/spikes.h
@@ -7,8 +7,8 @@
 
 #include "SFML/Graphics.hpp"
 
-#include "box2d/box2d.h"
 #include <filesystem>
+#include "box2d/box2d.h"
 
 struct TmxLayer;
 struct TmxTileSet;
@@ -137,7 +137,7 @@ private:
    int32_t _dt_ms{0};
    std::optional<int32_t> _elapsed_since_collision_ms;
 
-   sf::Vector2f _pixel_position;
+   sf::Vector2f _position_px;
    sf::FloatRect _player_collision_rect_px;
 
    bool _extracting{false};

--- a/src/game/player/player.cpp
+++ b/src/game/player/player.cpp
@@ -434,17 +434,17 @@ const sf::FloatRect& Player::getPixelRectFloat() const
 
 void Player::updatePixelRect()
 {
-   constexpr auto height_diff_px = PLAYER_TILES_HEIGHT - PLAYER_ACTUAL_HEIGHT;
+   constexpr auto height_diff_px = PLAYER_TILES_HEIGHT_PX - PLAYER_ACTUAL_HEIGHT_PX;
 
-   _rect_px_f.position.x = _position_px_f.x - PLAYER_ACTUAL_WIDTH * 0.5f;
+   _rect_px_f.position.x = _position_px_f.x - PLAYER_ACTUAL_WIDTH_PX * 0.5f;
    _rect_px_f.position.y = _position_px_f.y - height_diff_px - (height_diff_px * 0.5f);
-   _rect_px_f.size.x = PLAYER_ACTUAL_WIDTH;
-   _rect_px_f.size.y = PLAYER_ACTUAL_HEIGHT;
+   _rect_px_f.size.x = PLAYER_ACTUAL_WIDTH_PX;
+   _rect_px_f.size.y = PLAYER_ACTUAL_HEIGHT_PX;
 
    _rect_px_i.position.x = static_cast<int32_t>(_rect_px_f.position.x);
    _rect_px_i.position.y = static_cast<int32_t>(_rect_px_f.position.y);
-   _rect_px_i.size.x = PLAYER_ACTUAL_WIDTH;
-   _rect_px_i.size.y = PLAYER_ACTUAL_HEIGHT;
+   _rect_px_i.size.x = PLAYER_ACTUAL_WIDTH_PX;
+   _rect_px_i.size.y = PLAYER_ACTUAL_HEIGHT_PX;
 }
 
 void Player::updateChunk()
@@ -482,8 +482,8 @@ void Player::createFeet()
    //  ^                        ^
    //  count * (dist + radius)
 
-   const auto width_px = PLAYER_ACTUAL_WIDTH;
-   const auto height_px = PLAYER_ACTUAL_HEIGHT;
+   const auto width_px = PLAYER_ACTUAL_WIDTH_PX;
+   const auto height_px = PLAYER_ACTUAL_HEIGHT_PX;
    const auto feet_radius_m = 0.16f / static_cast<float>(__foot_count);
    const auto feet_distance_m = 0.0f;
    const auto feet_offset_m = static_cast<float>(__foot_count) * (feet_radius_m * 2.0f + feet_distance_m) * 0.5f - feet_radius_m;

--- a/src/game/player/player.cpp
+++ b/src/game/player/player.cpp
@@ -142,13 +142,13 @@ void Player::initialize()
       {
          case PlayerJump::DustAnimationType::Ground:
          {
-            _animation_pool.create(_points_to_left ? "player_jump_dust_l" : "player_jump_dust_r", _pixel_position_f.x, _pixel_position_f.y);
+            _animation_pool.create(_points_to_left ? "player_jump_dust_l" : "player_jump_dust_r", _position_px_f.x, _position_px_f.y);
             break;
          }
          case PlayerJump::DustAnimationType::InAir:
          {
             _animation_pool.create(
-               _points_to_left ? "player_jump_dust_inair_l" : "player_jump_dust_inair_r", _pixel_position_f.x, _pixel_position_f.y
+               _points_to_left ? "player_jump_dust_inair_l" : "player_jump_dust_inair_r", _position_px_f.x, _position_px_f.y
             );
             break;
          }
@@ -329,7 +329,7 @@ void Player::draw(sf::RenderTarget& color, sf::RenderTarget& normal, const sf::R
    }
 
    // that y offset is to compensate the wonky box2d origin
-   const auto draw_position_px = _pixel_position_f + sf::Vector2f(0, 8);
+   const auto draw_position_px = _position_px_f + sf::Vector2f(0, 8);
 
    const auto& current_cycle = _player_animation->getCurrentCycle();
    if (current_cycle)
@@ -371,7 +371,7 @@ void Player::draw(sf::RenderTarget& color, sf::RenderTarget& normal, const sf::R
 void Player::drawStencil(sf::RenderTarget& color, const sf::RenderStates& states)
 {
    const auto stencil_color = sf::Color{255, 255, 255, 25};
-   const auto draw_position_px = _pixel_position_f + sf::Vector2f(0, 8);
+   const auto draw_position_px = _position_px_f + sf::Vector2f(0, 8);
 
    // the silhouette shader forces the occluded player to transparent white (its rgb comes from the
    // shader, its alpha from the sprite shape scaled by u_alpha) instead of the dimmed sprite colors
@@ -410,51 +410,51 @@ void Player::drawStencil(sf::RenderTarget& color, const sf::RenderStates& states
 
 const sf::Vector2f& Player::getPixelPositionFloat() const
 {
-   return _pixel_position_f;
+   return _position_px_f;
 }
 
 const sf::Vector2i& Player::getPixelPositionInt() const
 {
-   return _pixel_position_i;
+   return _position_px_i;
 }
 
 void Player::setPixelPosition(float x, float y)
 {
-   _pixel_position_f.x = x;
-   _pixel_position_f.y = y;
+   _position_px_f.x = x;
+   _position_px_f.y = y;
 
-   _pixel_position_i.x = static_cast<int32_t>(x);
-   _pixel_position_i.y = static_cast<int32_t>(y);
+   _position_px_i.x = static_cast<int32_t>(x);
+   _position_px_i.y = static_cast<int32_t>(y);
 }
 
 const sf::FloatRect& Player::getPixelRectFloat() const
 {
-   return _pixel_rect_f;
+   return _rect_px_f;
 }
 
 void Player::updatePixelRect()
 {
    constexpr auto height_diff_px = PLAYER_TILES_HEIGHT - PLAYER_ACTUAL_HEIGHT;
 
-   _pixel_rect_f.position.x = _pixel_position_f.x - PLAYER_ACTUAL_WIDTH * 0.5f;
-   _pixel_rect_f.position.y = _pixel_position_f.y - height_diff_px - (height_diff_px * 0.5f);
-   _pixel_rect_f.size.x = PLAYER_ACTUAL_WIDTH;
-   _pixel_rect_f.size.y = PLAYER_ACTUAL_HEIGHT;
+   _rect_px_f.position.x = _position_px_f.x - PLAYER_ACTUAL_WIDTH * 0.5f;
+   _rect_px_f.position.y = _position_px_f.y - height_diff_px - (height_diff_px * 0.5f);
+   _rect_px_f.size.x = PLAYER_ACTUAL_WIDTH;
+   _rect_px_f.size.y = PLAYER_ACTUAL_HEIGHT;
 
-   _pixel_rect_i.position.x = static_cast<int32_t>(_pixel_rect_f.position.x);
-   _pixel_rect_i.position.y = static_cast<int32_t>(_pixel_rect_f.position.y);
-   _pixel_rect_i.size.x = PLAYER_ACTUAL_WIDTH;
-   _pixel_rect_i.size.y = PLAYER_ACTUAL_HEIGHT;
+   _rect_px_i.position.x = static_cast<int32_t>(_rect_px_f.position.x);
+   _rect_px_i.position.y = static_cast<int32_t>(_rect_px_f.position.y);
+   _rect_px_i.size.x = PLAYER_ACTUAL_WIDTH;
+   _rect_px_i.size.y = PLAYER_ACTUAL_HEIGHT;
 }
 
 void Player::updateChunk()
 {
-   _chunk.update(_pixel_position_i.x, _pixel_position_i.y);
+   _chunk.update(_position_px_i.x, _position_px_i.y);
 }
 
 const sf::IntRect& Player::getPixelRectInt() const
 {
-   return _pixel_rect_i;
+   return _rect_px_i;
 }
 
 void Player::setMaskBitsCrouching(bool enabled)
@@ -1268,7 +1268,7 @@ void Player::updateAttack()
    // require a fresh button press each time the sword should be swung
    if (_attack._attack_button_pressed)
    {
-      const auto result = _attack.attack(_world, _controls, _player_animation, _pixel_position_f, _points_to_left, isInAir());
+      const auto result = _attack.attack(_world, _controls, _player_animation, _position_px_f, _points_to_left, isInAir());
 
       // sword attack is combined with a small impulse move forward
       auto uses_sword = []()
@@ -1517,9 +1517,9 @@ void Player::updateWallslide(const sf::Time& dt)
    const auto wallslide_animation = _player_animation->getWallslideAnimation();
    const auto offset_x_px = isPointingLeft() ? -5.0f : 5.0f;
 #ifdef __EMSCRIPTEN__
-   wallslide_animation->position = {_pixel_position_f.x + offset_x_px, _pixel_position_f.y};
+   wallslide_animation->position = {_position_px_f.x + offset_x_px, _position_px_f.y};
 #else
-   wallslide_animation->setPosition({_pixel_position_f.x + offset_x_px, _pixel_position_f.y});
+   wallslide_animation->setPosition({_position_px_f.x + offset_x_px, _position_px_f.y});
 #endif
    wallslide_animation->play();
    wallslide_animation->update(dt);
@@ -1601,7 +1601,7 @@ void Player::update(const sf::Time& dt)
    _climb.update(_body, isInAir());
    _dive.update(dt, isInWater());
    _platform.update(_body, _jump.isJumping());
-   PlayerAudio::updateListenerPosition(_pixel_position_f);
+   PlayerAudio::updateListenerPosition(_position_px_f);
    updateFootsteps();
    updatePreviousBodyState();
    updateWeapons(dt);
@@ -1648,14 +1648,14 @@ void Player::updateAtmosphere()
       _body->SetTransform(_body->GetPosition() + b2Vec2{0.0, 0.4f}, 0.0f);
       _water_entered_time = StopWatch::getInstance().now();
       Audio::getInstance().playSample({"splash.wav"});
-      _animation_pool.create("player_water_splash", _pixel_position_f.x, _pixel_position_f.y);
+      _animation_pool.create("player_water_splash", _position_px_f.x, _position_px_f.y);
    }
 
    // leaving water
    if (!inside_water && was_inside_water)
    {
       _body->SetGravityScale(PhysicsConfiguration::getInstance()._gravity_scale_default);
-      _animation_pool.create("player_water_splash", _pixel_position_f.x, _pixel_position_f.y);
+      _animation_pool.create("player_water_splash", _position_px_f.x, _position_px_f.y);
    }
 
    // not sure if this is just another ugly hack
@@ -1901,6 +1901,6 @@ void Player::updatePixelPosition()
 
 void Player::updatePreviousBodyState()
 {
-   _position_previous = _body->GetPosition();
+   _position_previous_m = _body->GetPosition();
    _velocity_previous = _body->GetLinearVelocity();
 }

--- a/src/game/player/player.h
+++ b/src/game/player/player.h
@@ -450,14 +450,14 @@ private:
    b2Fixture* _foot_sensor_fixture = nullptr;
    b2Body* _ground_body = nullptr;
    b2Vec2 _ground_normal;
-   b2Vec2 _position_previous;
+   b2Vec2 _position_previous_m;
    b2Vec2 _velocity_previous;
    float _impulse{0.0f};
 
-   sf::Vector2f _pixel_position_f;
-   sf::Vector2i _pixel_position_i;
-   sf::FloatRect _pixel_rect_f;
-   sf::IntRect _pixel_rect_i;
+   sf::Vector2f _position_px_f;
+   sf::Vector2i _position_px_i;
+   sf::FloatRect _rect_px_f;
+   sf::IntRect _rect_px_i;
 
    sf::Time _time;
    sf::Clock _clock;

--- a/src/menus/menuscreen.cpp
+++ b/src/menus/menuscreen.cpp
@@ -19,30 +19,30 @@ MenuScreen::MenuScreen() : _font(getFont())
 void MenuScreen::placeTextCentered(sf::Text& text, const sf::FloatRect& reference_rect)
 {
    const auto text_bounds = text.getLocalBounds();
-   const auto pixel_x =
+   const auto x_px =
       static_cast<int32_t>(reference_rect.position.x + (reference_rect.size.x - text_bounds.size.x) / 2.0f - text_bounds.position.x);
-   const auto pixel_y =
+   const auto y_px =
       static_cast<int32_t>(reference_rect.position.y + (reference_rect.size.y - text_bounds.size.y) / 2.0f - text_bounds.position.y);
-   sfcompat::setPosition(text, {static_cast<float>(pixel_x), static_cast<float>(pixel_y)});
+   sfcompat::setPosition(text, {static_cast<float>(x_px), static_cast<float>(y_px)});
 }
 
 void MenuScreen::placeTextLeft(sf::Text& text, const sf::FloatRect& reference_rect)
 {
    const auto text_bounds = text.getLocalBounds();
-   const auto pixel_x = static_cast<int32_t>(reference_rect.position.x - text_bounds.position.x);
-   const auto pixel_y =
+   const auto x_px = static_cast<int32_t>(reference_rect.position.x - text_bounds.position.x);
+   const auto y_px =
       static_cast<int32_t>(reference_rect.position.y + (reference_rect.size.y - text_bounds.size.y) / 2.0f - text_bounds.position.y);
-   sfcompat::setPosition(text, {static_cast<float>(pixel_x), static_cast<float>(pixel_y)});
+   sfcompat::setPosition(text, {static_cast<float>(x_px), static_cast<float>(y_px)});
 }
 
 void MenuScreen::placeTextRightOf(sf::Text& text, const sf::FloatRect& reference_rect)
 {
    const auto text_bounds = text.getLocalBounds();
-   const auto pixel_x =
+   const auto x_px =
       static_cast<int32_t>(reference_rect.position.x + reference_rect.size.x + button_text_x_offset - text_bounds.position.x);
-   const auto pixel_y =
+   const auto y_px =
       static_cast<int32_t>(reference_rect.position.y + (reference_rect.size.y - text_bounds.size.y) / 2.0f - text_bounds.position.y);
-   sfcompat::setPosition(text, {static_cast<float>(pixel_x), static_cast<float>(pixel_y)});
+   sfcompat::setPosition(text, {static_cast<float>(x_px), static_cast<float>(y_px)});
 }
 
 void MenuScreen::placeDecorators(sf::Sprite& deco_left, sf::Sprite& deco_right, const sf::FloatRect& reference_rect)


### PR DESCRIPTION
Applies the existing `_px` (pixels) / `_tl` (tiles) / `_m` (meters) suffix convention to names that clearly violated it. The convention was already used in ~1,000 places; this cleans up the holdouts.

Scope: first-party only (`src/game`, `src/menus`, `src/framework`, `data/scripts`). `src/opengl`, `src/wasm/SDL3`, `src/wasm/SFML` and `src/wasm/opengl` are untouched.

Two commits: variables/members first, then constants.

## Commit 1 — variables and members

**Unit encoded as a prefix instead of a suffix**
- `_pixel_position` / `_pixel_rect` / `_pixel_path` / `_pixel_positions` → `_position_px` / `_rect_px` / `_path_px` / `_positions_px`
- `_pixel_offset_{mount,pusher,spike}` → `_offset_{mount,pusher,spike}_px`
- `_belt_pixel_rect` / `_arrow_pixel_rect` → `_belt_rect_px` / `_arrow_rect_px`
- player's `_pixel_position_f/_i`, `_pixel_rect_f/_i` → `_position_px_f/_i`, `_rect_px_f/_i`

**Unit encoded as a framework tag**
- conveyorbelt `_position_b2d` → `_position_m` (assigned via `* MPP`), `_position_sfml` → `_position_px`

**Tile units**
- laser `_tile_position` → `_position_tl` (multiplied by `PIXELS_PER_TILE` to produce `_position_px`)
- portal / movingplatform `_tile_positions` → `_positions_tl`
- tilemap `_tile_x` / `_tile_y` → `_x_tl` / `_y_tl`, `_tile_size` → `_tile_size_px`

**Missing suffix entirely**
- box2d-derived positions: player `_position_previous` → `_position_previous_m`, movingplatform `_pos` / `_pos_prev` → `_pos_m` / `_pos_prev_m`
- `_start_position` existed on four unrelated classes with different units, so it was split: `Level` and `Room::Area` are pixels → `_start_position_px`; `LevelDescription` is tiles → `_start_position_tl`. The JSON key stays the literal `"startposition"`, so serialization is unaffected.

**Lua enemy scripts** — `_position`, `_player_position`, `_start_position`, `_pos`, `_pos_player` and the arrowtrap offsets gain `_px`. These receive pixel values from `movedTo` / `setStartPosition` / `playerMovedTo`. Brings 10 scripts in line with `bat_2.lua` and `bat_guard.lua`, already converted. Safe because the engine only looks up Lua *functions* by name, never variables.

## Commit 2 — constants

**C++**
- `constants.h`: `PLAYER_ACTUAL_{WIDTH,HEIGHT}`, `PLAYER_TILES_{WIDTH,HEIGHT}`, `DIFF_PLAYER_TILE_TO_PHYSICS` → `*_PX`
- spikes `TOLERANCE_PIXELS` → `TOLERANCE_PX` (unit was spelled out as a word)
- conveyorbelt `Y_OFFSET`, bouncer `SPRITE_{WIDTH,HEIGHT}` → `*_PX`
- crusher `BLADE_SIZE_{X,Y}`, `BLADE_TOLERANCE`, `BLADE_SHARPNESS` → `*_M` (they live in box2d vertex space)

**Lua**
- `SPRITE_{WIDTH,HEIGHT,SIZE,W,H}` and the `_DYING` variants → `*_PX`
- frog_blue fireball geometry, including `FIREBALL_VISUAL_CENTER_{X,Y}` (the visible dot at (36, 60) inside the 120×120 frame)
- bat_guard hover/orbit/return offsets — two already documented their unit as `(px)` in a trailing comment
- `COLLISION_THRESHOLD`, `DEBUG_ATTACK_OFFSET`, `BUBBLE_SPAWN_SPREAD_{X,Y}`
- `HIT_RADIUS` → `HIT_RADIUS_M` (passed to `addShapeCircle`)
- script state: `_sprite_{width,height}`, `_sprite_offset_{x,y}`, `_muzzle_{width,height}`, `_transform_y`, `_wave_strength`, `_orb_collision_size`, `_fireball_distance` → `*_px`

TMX property keys and the string literals in `writeProperty` are unchanged, so level data keeps working.

## Deliberately left alone

- `*_TILES` / `*_tiles` (`LEASH_X_TILES`, `BLADE_HORIZONTAL_TILES`, `dx_tiles`, …) — tile **counts**, not quantities expressed in tile units
- `EnemyDescription::_start_position` and `::_path` — units are conditional on `_position_in_tiles`, so no single suffix is correct
- `crusher::_blade_offset` — used both as a pixel offset and as a sprite scale factor; a unit suffix would be wrong for one of the two
- `ringshaderlayer::_pixel_size` — mirrors the `u_pixel_size` shader uniform and the `"pixel_size"` TMX property
- `portal::_tile_size` — declared but never used, so its unit cannot be verified
- Counts and indices (`FIREBALL_FRAME_COUNT`, `SPRITE_COUNT_*`, `ROW_*`, `CYCLE_*`, `TILE_COUNT_*`), durations, speeds and z-indexes — none are lengths
- Method names (`setPixelPosition`, `getPixelRectFloat`) — camelCase API surface, out of scope

## Verification

- Builds clean (`build_rel`, MSVC/Ninja, links `deceptus.exe`)
- `clang-format -i` run on the modified C++ files
- C++ verified rename-only: per file, the sorted token multiset matches the base after applying the rename map. The one expected exception is the intentional 2-token `_start_position` tiles/pixels split in `level.cpp`.
- Lua verified rename-only **line-for-line**, plus line counts and comment-line counts identical to the pre-refactor base for every Lua file in the repo. Note: no Lua interpreter was available, so the scripts are not parse-checked.
- Side effect worth knowing: clang-format re-sorted `#include` blocks in four headers it touched.