### PR TITLE
feat(mechanisms): add SkillGate mechanism

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,6 +430,8 @@ set(GAME_FILES
     src/game/mechanisms/sensorrect.h
     src/game/mechanisms/shaderlayer.cpp
     src/game/mechanisms/shaderlayer.h
+    src/game/mechanisms/skillgate.cpp
+    src/game/mechanisms/skillgate.h
     src/game/mechanisms/smokeeffect.cpp
     src/game/mechanisms/soundemitter.cpp
     src/game/mechanisms/soundemitter.h

--- a/doc/level_design/mechanisms.md
+++ b/doc/level_design/mechanisms.md
@@ -1207,6 +1207,73 @@ end
 ---
 
 
+## Skill Gates
+
+Skill Gates are solid rectangles that only let Adam pass once he has unlocked a particular skill. They are the tool to
+express 'you need the double jump to get in here' without writing a single line of Lua: place the rectangle, name the
+skill, done.
+
+The gate keeps checking the player's skill set every frame, so it does not matter how the skill is acquired - a level
+script calling `addPlayerSkill`, an Extra that grants it, or the debug console. The moment the skill is there, the
+collider disappears and the gate's texture dissolves.
+
+Since unlocked skills are already part of the save state, the gate needs no state of its own; it will be closed or open
+again automatically after loading a save game.
+
+To create a Skill Gate, create a rectangle object covering the area that should be blocked.
+
+### Object Type / Object Group
+
+|Method|Value|
+|-|-|
+|Object Type|`SkillGate`|
+|Object Group|`skill_gates`|
+
+### Object Properties
+
+|Property|Type|Description|
+|-|-|-|
+|skill|string|The skill that opens this gate (see the table below). This property is required; if it is missing or misspelled, the gate stays closed and a warning is written to the log|
+|inverted|bool|If set to `true`, the gate blocks *while* the skill is unlocked instead of while it is missing (default is `false`)|
+|fade_speed|float|Alpha change per second while the gate fades in or out (default is `2.0`, i.e. half a second for a full fade)|
+|enabled|bool|The default enabled state; a disabled gate never blocks and can be switched on from Lua (default is `true`)|
+|texture|string|Optional texture drawn across the gate rectangle|
+|normal|string|Optional normal map for the texture above|
+|z|int|The layer's z index|
+
+### Valid Skill Names
+
+|Value|Skill|
+|-|-|
+|`wall_climb`|Climbing up walls|
+|`dash`|Dashing|
+|`invulnerable`|Invulnerability|
+|`wall_slide`|Sliding down walls in a controlled manner|
+|`wall_jump`|Jumping off walls|
+|`double_jump`|The second jump in mid-air|
+|`crouch`|Crouching, and therefore moving through low passages|
+|`swim`|Swimming instead of drowning|
+
+### Notes
+
+- The collider is removed as soon as the skill condition is satisfied, while the texture is still fading out. That is
+  intentional - it makes sure Adam is never trapped inside a gate that is in the middle of dissolving.
+- A Skill Gate without a `texture` is invisible and acts as a pure collider. That is useful when the level's tile layers
+  already draw something at that position.
+- Skill Gates are silent by design. If you want to tell the player *why* they cannot pass, place an
+  [Interaction Help](#interaction-help) or a [Dialogue](#dialogues) in front of the gate.
+- Since the gate can also be toggled from Lua via its object id, the `inverted` property is mostly useful for
+  'you were faster before you got heavy' style puzzles.
+
+---
+
+&nbsp;
+
+&nbsp;
+
+---
+
+
 ## Spike Balls
 
 Spike Balls are nasty. They're heavy balls with spikes connected to a chain which move from left to right and back. Adam can either duck or jump to make his way past them, however it requires a little practice to master them.

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -42,6 +42,7 @@
     - [Ropes](level_design/mechanisms.md#ropes)<br>
     - [Rotating Blades](level_design/mechanisms.md#rotating-blades)<br>
     - [Sensor Rects](level_design/mechanisms.md#sensor-rects)<br>
+    - [Skill Gates](level_design/mechanisms.md#skill-gates)<br>
     - [Spike Balls](level_design/mechanisms.md#spike-balls)<br>
     - [Spike Blocks](level_design/mechanisms.md#spike-blocks)<br>
     - [Spikes](level_design/mechanisms.md#spikes)<br>

--- a/src/game/level/gamemechanismregistry.cpp
+++ b/src/game/level/gamemechanismregistry.cpp
@@ -43,6 +43,7 @@ GameMechanismRegistry::GameMechanismRegistry()
       &_mechanism_rotating_blades,
       &_mechanism_sensor_rects,
       &_mechanism_shader_layers,
+      &_mechanism_skill_gates,
       &_mechanism_sound_emitters,
       &_mechanism_smoke_effect,
       &_mechanism_spike_balls,
@@ -93,6 +94,7 @@ GameMechanismRegistry::GameMechanismRegistry()
    _mechanisms_map[std::string{layer_name_rotating_blades}] = &_mechanism_rotating_blades;
    _mechanisms_map[std::string{layer_name_sensor_rects}] = &_mechanism_sensor_rects;
    _mechanisms_map[std::string{layer_name_shader_quads}] = &_mechanism_shader_layers;
+   _mechanisms_map[std::string{layer_name_skill_gates}] = &_mechanism_skill_gates;
    _mechanisms_map[std::string{layer_name_smoke_effect}] = &_mechanism_smoke_effect;
    _mechanisms_map[std::string{layer_name_sound_emitters}] = &_mechanism_sound_emitters;
    _mechanisms_map[std::string{layer_name_spike_balls}] = &_mechanism_spike_balls;

--- a/src/game/level/gamemechanismregistry.h
+++ b/src/game/level/gamemechanismregistry.h
@@ -107,6 +107,7 @@ private:
    MechanismVector _mechanism_rotating_blades;
    MechanismVector _mechanism_sensor_rects;
    MechanismVector _mechanism_shader_layers;
+   MechanismVector _mechanism_skill_gates;
    MechanismVector _mechanism_smoke_effect;
    MechanismVector _mechanism_sound_emitters;
    MechanismVector _mechanism_spike_balls;

--- a/src/game/mechanisms/gamemechanismdeserializerconstants.h
+++ b/src/game/mechanisms/gamemechanismdeserializerconstants.h
@@ -122,6 +122,9 @@ constexpr std::string_view layer_name_shader_quads{"shader_quads"};
 /// \brief tmx layer name for spike ball mechanisms.
 constexpr std::string_view layer_name_spike_balls{"spike_balls"};
 
+/// \brief tmx layer name for skill gate mechanisms.
+constexpr std::string_view layer_name_skill_gates{"skill_gates"};
+
 /// \brief tmx layer name for smoke effects.
 constexpr std::string_view layer_name_smoke_effect{"smoke"};
 
@@ -271,6 +274,9 @@ constexpr std::string_view type_name_sensor_rect{"SensorRect"};
 
 /// \brief object template type name for shader quads.
 constexpr std::string_view type_name_shader_quad{"ShaderQuad"};
+
+/// \brief object template type name for skill gates.
+constexpr std::string_view type_name_skill_gate{"SkillGate"};
 
 /// \brief object template type name for smoke effects.
 constexpr std::string_view type_name_smoke_effect{"Smoke"};

--- a/src/game/mechanisms/skillgate.cpp
+++ b/src/game/mechanisms/skillgate.cpp
@@ -1,0 +1,280 @@
+#include "game/mechanisms/skillgate.h"
+
+#include <algorithm>
+#include <array>
+#include <string>
+#include <unordered_map>
+
+#include "framework/tmxparser/tmxobject.h"
+#include "framework/tmxparser/tmxproperties.h"
+#include "framework/tmxparser/tmxproperty.h"
+#include "framework/tools/log.h"
+#include "framework/tools/sfmlcompat.h"
+#include "game/io/texturepool.h"
+#include "game/io/valuereader.h"
+#include "game/mechanisms/gamemechanismdeserializerregistry.h"
+#include "game/state/savestate.h"
+
+namespace
+{
+static constexpr bool default_skill_gate_inverted = false;
+static constexpr float default_skill_gate_fade_speed = 2.0f;
+static constexpr auto default_skill_gate_skill = std::string_view{"double_jump"};
+
+static constexpr std::array skill_gate_properties{
+   PropertyInfo{.name = "skill", .type = "string", .default_value = default_skill_gate_skill, .required = true},
+   PropertyInfo{.name = "inverted", .type = "bool", .default_value = default_skill_gate_inverted},
+   PropertyInfo{.name = "fade_speed", .type = "float", .default_value = default_skill_gate_fade_speed},
+   PropertyInfo{.name = "enabled", .type = "bool", .default_value = true},
+   PropertyInfo{.name = "texture", .type = "string", .default_value = std::string_view{""}},
+   PropertyInfo{.name = "normal", .type = "string", .default_value = std::string_view{""}},
+   PropertyInfo{.name = "z", .type = "int", .default_value = int32_t{20}},
+};
+static constexpr MechanismSchema skill_gate_schema{
+   .type_name = "SkillGate",
+   .layer_name = "skill_gates",
+   .default_width = 48,
+   .default_height = 96,
+   .properties = skill_gate_properties,
+};
+const auto registered_skillgate = []
+{
+   auto& registry = GameMechanismDeserializerRegistry::instance();
+   registry.registerSchema(skill_gate_schema);
+
+   registry.mapGroupToLayer("SkillGate", "skill_gates");
+
+   registry.registerLayerName(
+      "skill_gates",
+      [](GameNode* parent, const GameDeserializeData& data, auto& mechanisms)
+      {
+         auto mechanism = std::make_shared<SkillGate>(parent);
+         mechanism->setup(data);
+         mechanisms["skill_gates"]->push_back(mechanism);
+      }
+   );
+
+   registry.registerObjectGroup(
+      "SkillGate",
+      [](GameNode* parent, const GameDeserializeData& data, auto& mechanisms)
+      {
+         auto mechanism = std::make_shared<SkillGate>(parent);
+         mechanism->setup(data);
+         mechanisms["skill_gates"]->push_back(mechanism);
+      }
+   );
+   return true;
+}();
+
+/// \brief resolves a tmx skill property to a skill flag.
+/// \param skill_name lower-case skill identifier as written in the tmx property.
+/// \return matching skill flag, or std::nullopt when the name is not known.
+std::optional<Skill::SkillType> skillFromName(const std::string& skill_name)
+{
+   static const std::unordered_map<std::string, Skill::SkillType> skill_names{
+      {"wall_climb", Skill::SkillType::WallClimb},
+      {"dash", Skill::SkillType::Dash},
+      {"invulnerable", Skill::SkillType::Invulnerable},
+      {"wall_slide", Skill::SkillType::WallSlide},
+      {"wall_jump", Skill::SkillType::WallJump},
+      {"double_jump", Skill::SkillType::DoubleJump},
+      {"crouch", Skill::SkillType::Crouch},
+      {"swim", Skill::SkillType::Swim},
+   };
+
+   const auto skill_name_it = skill_names.find(skill_name);
+   if (skill_name_it == skill_names.end())
+   {
+      return std::nullopt;
+   }
+
+   return skill_name_it->second;
+}
+
+}  // namespace
+
+SkillGate::SkillGate(GameNode* parent) : GameNode(parent)
+{
+   setClassName(typeid(SkillGate).name());
+}
+
+std::string_view SkillGate::objectName() const
+{
+   return "SkillGate";
+}
+
+void SkillGate::setup(const GameDeserializeData& data)
+{
+   setObjectId(data._tmx_object->_name);
+
+   _rectangle = {{data._tmx_object->_x_px, data._tmx_object->_y_px}, {data._tmx_object->_width_px, data._tmx_object->_height_px}};
+
+   setZ(static_cast<int32_t>(ZDepth::ForegroundMin) + 1);
+
+   if (data._tmx_object->_properties)
+   {
+      const auto& properties = data._tmx_object->_properties->_map;
+
+      const auto skill_name = ValueReader::readValue<std::string>("skill", properties);
+      if (!skill_name.has_value())
+      {
+         Log::Warning() << "skill gate '" << getObjectId() << "' has no skill property, it will stay closed";
+      }
+      else
+      {
+         _required_skill = skillFromName(skill_name.value());
+         if (!_required_skill.has_value())
+         {
+            Log::Warning() << "skill gate '" << getObjectId() << "' has unknown skill '" << skill_name.value() << "', it will stay closed";
+         }
+      }
+
+      _inverted = ValueReader::readValue<bool>("inverted", properties).value_or(default_skill_gate_inverted);
+      _fade_speed = ValueReader::readValue<float>("fade_speed", properties).value_or(default_skill_gate_fade_speed);
+      _enabled = ValueReader::readValue<bool>("enabled", properties).value_or(true);
+      setZ(ValueReader::readValue<int32_t>("z", properties).value_or(getZ()));
+
+      const auto texture = ValueReader::readValue<std::string>("texture", properties);
+      if (texture.has_value())
+      {
+         _texture_map = TexturePool::getInstance().get(texture.value());
+#ifdef __EMSCRIPTEN__
+         _sprite = std::make_unique<sf::Sprite>();
+#else
+         _sprite = std::make_unique<sf::Sprite>(*_texture_map);
+#endif
+         sfcompat::setPosition(*_sprite, {data._tmx_object->_x_px, data._tmx_object->_y_px});
+      }
+
+      const auto normal = ValueReader::readValue<std::string>("normal", properties);
+      if (normal.has_value())
+      {
+         _normal_map = TexturePool::getInstance().get(normal.value());
+      }
+   }
+
+   // create body
+   b2BodyDef body_definition;
+   body_definition.type = b2_staticBody;
+   body_definition.position = b2Vec2(data._tmx_object->_x_px * MPP, data._tmx_object->_y_px * MPP);
+
+   _body = data._world->CreateBody(&body_definition);
+
+   const auto half_physics_width = data._tmx_object->_width_px * MPP * 0.5f;
+   const auto half_physics_height = data._tmx_object->_height_px * MPP * 0.5f;
+
+   _shape_bounds.SetAsBox(half_physics_width, half_physics_height, b2Vec2(half_physics_width, half_physics_height), 0.0f);
+
+   b2FixtureDef boundary_fixture_definition;
+   boundary_fixture_definition.shape = &_shape_bounds;
+   boundary_fixture_definition.density = 1.0f;
+
+   _body->CreateFixture(&boundary_fixture_definition);
+
+   // snap to the initial state so gates the player already unlocked are not visible on level load
+   const auto blocking = isBlocking();
+   _alpha = blocking ? 1.0f : 0.0f;
+   applyBlockingState(blocking);
+
+   addChunks(_rectangle);
+}
+
+bool SkillGate::isPassable() const
+{
+   if (!_required_skill.has_value())
+   {
+      return false;
+   }
+
+   const auto skills = SaveState::getPlayerInfo()._extra_table._skills._skills;
+   const auto has_skill = (skills & static_cast<int32_t>(_required_skill.value())) != 0;
+
+   return _inverted ? !has_skill : has_skill;
+}
+
+bool SkillGate::isBlocking() const
+{
+   return isEnabled() && !isPassable();
+}
+
+void SkillGate::applyBlockingState(bool blocking)
+{
+   if (_body->IsEnabled() != blocking)
+   {
+      _body->SetEnabled(blocking);
+   }
+}
+
+void SkillGate::update(const sf::Time& dt)
+{
+   const auto blocking = isBlocking();
+
+   // the collider follows the skill condition immediately while the sprite fades, so acquiring a skill never traps
+   // the player inside a gate that is still dissolving
+   applyBlockingState(blocking);
+
+   const auto target_alpha = blocking ? 1.0f : 0.0f;
+   const auto alpha_step = _fade_speed * dt.asSeconds();
+
+   if (_alpha < target_alpha)
+   {
+      _alpha = std::min(_alpha + alpha_step, target_alpha);
+   }
+   else if (_alpha > target_alpha)
+   {
+      _alpha = std::max(_alpha - alpha_step, target_alpha);
+   }
+}
+
+const sf::FloatRect& SkillGate::getPixelRect() const
+{
+   return _rectangle;
+}
+
+void SkillGate::draw(sf::RenderTarget& target, sf::RenderTarget& normal)
+{
+   draw(target, normal, {});
+}
+
+void SkillGate::draw(sf::RenderTarget& target, sf::RenderTarget& normal, const sf::RenderStates& states)
+{
+   // nothing to paint
+   if (_sprite == nullptr)
+   {
+      return;
+   }
+
+   if (_alpha <= 0.0f)
+   {
+      return;
+   }
+
+   sfcompat::setColor(*_sprite, sf::Color(255, 255, 255, static_cast<uint8_t>(_alpha * 255.0f)));
+
+#ifdef __EMSCRIPTEN__
+   sf::RenderStates color_states = states;
+   color_states.texture = _texture_map.get();
+   target.draw(*_sprite, color_states);
+
+   if (_normal_map)
+   {
+      sf::RenderStates normal_states = states;
+      normal_states.texture = _normal_map.get();
+      normal.draw(*_sprite, normal_states);
+   }
+#else
+   target.draw(*_sprite, states);
+
+   if (_normal_map)
+   {
+      _sprite->setTexture(*_normal_map);
+      normal.draw(*_sprite, states);
+      _sprite->setTexture(*_texture_map);
+   }
+#endif
+}
+
+std::optional<sf::FloatRect> SkillGate::getBoundingBoxPx()
+{
+   return _rectangle;
+}

--- a/src/game/mechanisms/skillgate.h
+++ b/src/game/mechanisms/skillgate.h
@@ -1,0 +1,84 @@
+#ifndef SKILLGATE_H
+#define SKILLGATE_H
+
+#include <memory>
+#include <optional>
+
+#include "game/io/gamedeserializedata.h"
+#include "game/level/gamenode.h"
+#include "game/mechanisms/gamemechanism.h"
+#include "game/player/skill.h"
+
+/// \brief represents a solid rectangle that only lets the player pass once a given player skill is unlocked.
+/// the gate reads its condition from the player skill bitmask every frame, so it opens as soon as the skill is
+/// granted by a level script, an extra, or the debug console. no state is serialized because the unlocked skills
+/// are already part of the save state.
+class SkillGate : public GameMechanism, public GameNode
+{
+public:
+   /// \brief creates a skill gate node.
+   /// \param parent parent node in the scene graph.
+   SkillGate(GameNode* parent = nullptr);
+
+   /// \brief returns the mechanism type identifier.
+   /// \return non-owning string view with value "SkillGate".
+   std::string_view objectName() const override;
+
+   /// \brief initializes rectangle geometry, required skill, optional textures, and a static box2d collider from tmx data.
+   /// \param data deserialize context containing object properties and physics world.
+   void setup(const GameDeserializeData& data);
+
+   /// \brief draws the configured texture and normal map with the current fade alpha applied.
+   /// \param target color render target.
+   /// \param normal normal-map render target.
+   void draw(sf::RenderTarget& target, sf::RenderTarget& normal) override;
+
+   /// \brief draws the configured texture and normal map with explicit render states (used in WASM to carry the level view).
+   /// \param target color render target.
+   /// \param normal normal-map render target.
+   /// \param states render states to apply.
+   void draw(sf::RenderTarget& target, sf::RenderTarget& normal, const sf::RenderStates& states) override;
+   using GameMechanism::draw;
+
+   /// \brief reconciles collider state with the player skill set and advances the fade animation.
+   /// \param dt elapsed frame time.
+   void update(const sf::Time& dt) override;
+
+   /// \brief returns the gate rectangle in pixel coordinates.
+   /// \return rectangle bounds used for culling and overlap checks.
+   std::optional<sf::FloatRect> getBoundingBoxPx() override;
+
+   /// \brief returns the configured pixel rectangle.
+   /// \return rectangle occupied by this gate.
+   const sf::FloatRect& getPixelRect() const;
+
+   /// \brief checks whether the player may currently pass this gate.
+   /// \return true when the skill condition is satisfied.
+   bool isPassable() const;
+
+private:
+   /// \brief checks whether the gate should currently be solid.
+   /// \return true when the mechanism is enabled and the skill condition is not satisfied.
+   bool isBlocking() const;
+
+   /// \brief applies the blocking state to the box2d body.
+   /// \param blocking true to make the gate collidable.
+   void applyBlockingState(bool blocking);
+
+   std::optional<Skill::SkillType> _required_skill;  //!< skill that opens this gate, unset when the tmx property was invalid
+   bool _inverted{false};    //!< when true the gate blocks while the skill is unlocked instead of while it is missing
+   float _alpha{1.0f};       //!< current fade value, 1 when fully solid and 0 when fully dissolved
+   float _fade_speed{2.0f};  //!< alpha change per second while fading in or out
+
+   // rendering
+   std::shared_ptr<sf::Texture> _texture_map;
+   std::shared_ptr<sf::Texture> _normal_map;
+   std::unique_ptr<sf::Sprite> _sprite;
+   sf::FloatRect _rectangle;
+
+   // physics
+   b2Body* _body = nullptr;
+   b2PolygonShape _shape_bounds;
+};
+
+#endif  // SKILLGATE_H


### PR DESCRIPTION
## What

Adds a `SkillGate` mechanism: a solid rectangle that only lets Adam pass once a given player skill is unlocked. This makes ability gating authorable in Tiled instead of requiring Lua.

`Skill::SkillType` already defined eight unlockable abilities, but no mechanism gated on them — this closes that gap.

## How it works

- Evaluates `SaveState::getPlayerInfo()._extra_table._skills` every frame, so the gate opens regardless of how the skill arrived: `addPlayerSkill` from a level script, an `Extra`, or the debug console.
- The collider is dropped as soon as the condition is satisfied, while the optional texture fades out over `fade_speed`. That ordering is deliberate: the player can never be trapped inside a gate that is still dissolving.
- `setup` snaps to the final state, so gates whose skill is already unlocked are simply absent after loading a save.
- Nothing is serialized — the unlocked skills are already part of the save state, so `serializeState`/`deserializeState` would be redundant.

## Properties

| Property | Type | Description |
|-|-|-|
| `skill` | string | Required. One of `wall_climb`, `dash`, `invulnerable`, `wall_slide`, `wall_jump`, `double_jump`, `crouch`, `swim`. A missing or misspelled name logs a warning and leaves the gate closed |
| `inverted` | bool | Block *while* the skill is held instead of while it is missing (default `false`) |
| `fade_speed` | float | Alpha change per second (default `2.0`) |
| `enabled` | bool | Master switch, toggleable from Lua (default `true`) |
| `texture` / `normal` | string | Optional visuals; without a texture the gate is a pure collider |
| `z` | int | Layer z index |

Object type `SkillGate`, object group `skill_gates`.

## Verification

- Builds and links clean (MSVC / Ninja, Release).
- `SkillGate` appears in the runtime schema dump written to `data/schemas/mechanisms.json` on startup, confirming registration works end-to-end rather than just compiling.
- Not yet placed in a level and played — no TMX content was modified in this PR.

## Docs

`doc/level_design/mechanisms.md` gains a `Skill Gates` section (object type/group, property table, valid skill names, notes), with a TOC entry in `doc/readme.md`.
