### PR TITLE
perf(mechanisms): enable chunk culling where it is safe, document where it is not

### DIFF
--- a/src/game/mechanisms/blockingrect.cpp
+++ b/src/game/mechanisms/blockingrect.cpp
@@ -127,6 +127,8 @@ void BlockingRect::setup(const GameDeserializeData& data)
    boundaryFixtureDef.density = 1.0f;
 
    _body->CreateFixture(&boundaryFixtureDef);
+
+   addChunks(_rectangle);
 }
 
 const sf::FloatRect& BlockingRect::getPixelRect() const

--- a/src/game/mechanisms/bouncer.cpp
+++ b/src/game/mechanisms/bouncer.cpp
@@ -140,6 +140,8 @@ Bouncer::Bouncer(GameNode* parent, const GameDeserializeData& data) : FixtureNod
    _sprite = std::make_unique<sf::Sprite>(*_texture);
    _sprite->setPosition(_position_sfml - sf::Vector2f(0.0f, static_cast<float>(SPRITE_HEIGHT_PX)));
 #endif
+
+   addChunks(_rect);
 }
 
 std::string_view Bouncer::objectName() const

--- a/src/game/mechanisms/bubblecube.cpp
+++ b/src/game/mechanisms/bubblecube.cpp
@@ -212,6 +212,8 @@ BubbleCube::BubbleCube(GameNode* parent, const GameDeserializeData& data) : Fixt
 
    _original_rect_px = {{data._tmx_object->_x_px, data._tmx_object->_y_px}, {width_px, height_px}};
    _translated_rect_px = _original_rect_px;
+
+   addChunks(_original_rect_px);
 }
 
 std::string_view BubbleCube::objectName() const

--- a/src/game/mechanisms/controllerhelp.cpp
+++ b/src/game/mechanisms/controllerhelp.cpp
@@ -234,6 +234,8 @@ void ControllerHelp::deserialize(const GameDeserializeData& data)
          *_background, sf::IntRect{{9 * PIXELS_PER_TILE, 10 * PIXELS_PER_TILE}, {PIXELS_PER_TILE * 3, PIXELS_PER_TILE * 3}}
       );
    }
+
+   addChunks(_rect_px);
 }
 
 std::optional<sf::FloatRect> ControllerHelp::getBoundingBoxPx()

--- a/src/game/mechanisms/conveyorbelt.h
+++ b/src/game/mechanisms/conveyorbelt.h
@@ -12,6 +12,9 @@
 struct TmxObject;
 
 /// \brief moving belt mechanism that pushes colliding bodies horizontally.
+/// \note deliberately does not call addChunks: the belt accumulates _elapsed in update to drive its scrolling texture
+///       and its lever ramp. chunk culling would freeze both, so a belt would resume with a stale surface offset and a
+///       stale ramp value once the player returns.
 class ConveyorBelt : public FixtureNode, public GameMechanism
 {
 public:

--- a/src/game/mechanisms/damagerect.cpp
+++ b/src/game/mechanisms/damagerect.cpp
@@ -89,4 +89,6 @@ void DamageRect::setup(const GameDeserializeData& data)
          _damage = damage_it->second->_value_int.value();
       }
    }
+
+   addChunks(_rect);
 }

--- a/src/game/mechanisms/deathblock.h
+++ b/src/game/mechanisms/deathblock.h
@@ -16,6 +16,9 @@ struct TmxObject;
 struct TmxTileSet;
 
 /// \brief moving spike block trap with animated spike states and optional patrol path.
+/// \note deliberately does not call addChunks: the extract and retract intervals are driven by elapsed time in update,
+///       and the block travels along a patrol path. chunk culling would both freeze the interval phase and stop the
+///       movement, so groups of blocks timed against each other would desynchronize.
 class DeathBlock : public GameMechanism, public GameNode
 {
 public:

--- a/src/game/mechanisms/dialogue.cpp
+++ b/src/game/mechanisms/dialogue.cpp
@@ -165,6 +165,8 @@ std::shared_ptr<Dialogue> Dialogue::deserialize(GameNode* parent, const GameDese
    dialogue->_rect_px =
       sf::FloatRect{{data._tmx_object->_x_px, data._tmx_object->_y_px}, {data._tmx_object->_width_px, data._tmx_object->_height_px}};
 
+   dialogue->addChunks(dialogue->_rect_px);
+
    return dialogue;
 }
 

--- a/src/game/mechanisms/door.h
+++ b/src/game/mechanisms/door.h
@@ -16,6 +16,9 @@ struct TmxLayer;
 struct TmxTileSet;
 
 /// \brief controls an interactable door that can block or allow passage.
+/// \note deliberately does not call addChunks: the open and close animation advances _bar_offset from update, and a door
+///       can be triggered remotely by a lever. chunk culling would stop those updates while the player is away, so a
+///       door opened from a distance would never finish opening.
 class Door : public GameMechanism, public GameNode
 {
 public:

--- a/src/game/mechanisms/enemywall.cpp
+++ b/src/game/mechanisms/enemywall.cpp
@@ -107,6 +107,8 @@ void EnemyWall::setup(const GameDeserializeData& data)
    boundary_fixture_def.filter.categoryBits = category_bits;
 
    _body->CreateFixture(&boundary_fixture_def);
+
+   addChunks(_rectangle);
 }
 
 const sf::FloatRect& EnemyWall::getPixelRect() const

--- a/src/game/mechanisms/extra.cpp
+++ b/src/game/mechanisms/extra.cpp
@@ -193,6 +193,8 @@ bool Extra::deserialize(const GameDeserializeData& data)
    // - enable/disable mechanism function to level
    // - add enable/disable mechanism code to levelscript
 
+   addChunks(_rect);
+
    return true;
 }
 

--- a/src/game/mechanisms/fan.cpp
+++ b/src/game/mechanisms/fan.cpp
@@ -154,6 +154,8 @@ std::shared_ptr<Fan> Fan::deserialize(GameNode* parent, const GameDeserializeDat
       std::cerr << "Warning: Fan direction '" << dir_str << "' not recognized. No tiles placed.\n";
    }
 
+   fan->addChunks(fan->_rect_px);
+
    return fan;
 }
 

--- a/src/game/mechanisms/interactionhelp.cpp
+++ b/src/game/mechanisms/interactionhelp.cpp
@@ -372,6 +372,8 @@ void InteractionHelp::deserialize(const GameDeserializeData& data)
 
       _help_elements.push_back(std::move(help));
    }
+
+   addChunks(_rect_px);
 }
 
 std::optional<sf::FloatRect> InteractionHelp::getBoundingBoxPx()

--- a/src/game/mechanisms/laser.h
+++ b/src/game/mechanisms/laser.h
@@ -22,6 +22,9 @@ struct TmxObject;
 struct TmxTileSet;
 
 /// \brief controls laser hazard tiles with timed signals and optional path movement.
+/// \note deliberately does not call addChunks: the signal schedule accumulates elapsed time in update. chunk culling
+///       would freeze that clock while the player is away, so lasers meant to fire in unison would drift out of phase
+///       relative to each other as the player moves through the level.
 class Laser : public GameMechanism, public GameNode
 {
 public:

--- a/src/game/mechanisms/leveltransition.cpp
+++ b/src/game/mechanisms/leveltransition.cpp
@@ -93,6 +93,8 @@ void LevelTransition::setup(const GameDeserializeData& data)
    {
       Log::Error() << "level transition '" << getObjectId() << "' has no 'level' property, it will not do anything";
    }
+
+   addChunks(_rect_px);
 }
 
 void LevelTransition::update(const sf::Time& /*dt*/)

--- a/src/game/mechanisms/portal.h
+++ b/src/game/mechanisms/portal.h
@@ -18,6 +18,9 @@ struct TmxObject;
 struct TmxTileSet;
 
 /// \brief teleports the player to a linked destination portal when activated.
+/// \note deliberately does not call addChunks: _rect mixes units, its position is assigned in tile coordinates while
+///       its size is in pixels, and getBoundingBoxPx returns it unchanged. chunks derive from pixel positions, so
+///       culling against this rect would place the portal near the level origin. the rect needs fixing first.
 class Portal : public GameMechanism, public GameNode
 {
 public:

--- a/src/game/mechanisms/rotatingblade.h
+++ b/src/game/mechanisms/rotatingblade.h
@@ -9,6 +9,9 @@
 #include "SFML/Graphics.hpp"
 
 /// \brief moves and spins a circular blade that damages the player on contact.
+/// \note deliberately does not call addChunks: _rectangle is a fixed 64x64 box at the tmx object position and does not
+///       cover the movement path the blade travels along. culling against it would freeze the blade whenever the player
+///       is near the far end of its path. adding chunks here first requires a bounding box spanning the whole path.
 class RotatingBlade : public GameMechanism, public GameNode
 {
 public:

--- a/src/game/mechanisms/sensorrect.cpp
+++ b/src/game/mechanisms/sensorrect.cpp
@@ -153,6 +153,8 @@ void SensorRect::setup(const GameDeserializeData& data)
 
       _observed = ValueReader::readValue<bool>("observed", data._tmx_object->_properties->_map).value_or(default_sensor_rect_observed);
    }
+
+   addChunks(_rect);
 }
 
 void SensorRect::findReference(const std::vector<std::shared_ptr<GameMechanism>>& mechanisms)

--- a/src/game/mechanisms/soundemitter.h
+++ b/src/game/mechanisms/soundemitter.h
@@ -6,6 +6,9 @@
 #include "game/mechanisms/gamemechanism.h"
 
 /// \brief plays positional ambient audio configured from a map object.
+/// \note deliberately does not call addChunks: this mechanism has no update override at all, it is driven by
+///       VolumeUpdater. distance attenuation is precisely what has to keep working while the player is far away, which
+///       is the opposite of what chunk culling provides.
 class SoundEmitter : public GameMechanism, public GameNode
 {
 public:

--- a/src/game/mechanisms/treasurechest.cpp
+++ b/src/game/mechanisms/treasurechest.cpp
@@ -158,6 +158,8 @@ void TreasureChest::deserialize(const GameDeserializeData& data)
 
    _spawn_effect = std::make_unique<SpawnEffect>(sf::Vector2f{_rect.position.x + _rect.size.x / 2, _rect.position.y - _rect.size.y / 2});
    _spawn_effect->deserialize(data);
+
+   addChunks(_rect);
 }
 
 void TreasureChest::draw(sf::RenderTarget& target, sf::RenderTarget& normal)

--- a/src/game/mechanisms/waterdamage.h
+++ b/src/game/mechanisms/waterdamage.h
@@ -9,6 +9,9 @@
 #include <optional>
 
 /// \brief applies periodic damage while the player is submerged in water.
+/// \note deliberately does not call addChunks: this mechanism has no position of its own, which is why
+///       getBoundingBoxPx returns std::nullopt. it is a level-wide rule that reacts to the player being submerged
+///       anywhere, so there is no meaningful chunk to attach it to.
 class WaterDamage : public GameNode, public GameMechanism
 {
 public:

--- a/src/game/mechanisms/watersurface.h
+++ b/src/game/mechanisms/watersurface.h
@@ -6,6 +6,9 @@
 #include "game/mechanisms/gamemechanism.h"
 
 /// \brief simulates and renders a deformable water surface with splash propagation.
+/// \note deliberately does not call addChunks: update runs a spring simulation across all segments and needs to keep
+///       running so the surface can settle. chunk culling would freeze the wave mid-oscillation and the player would
+///       come back to a stale deformation instead of calm water.
 class WaterSurface : public GameMechanism, public GameNode
 {
 public:
@@ -14,13 +17,13 @@ public:
    {
       Segment() = default;
 
-       /// \brief integrates this segment toward its target height.
-       /// \param dampening velocity dampening factor.
-       /// \param tension spring tension factor.
-       void update(float dampening, float tension);
+      /// \brief integrates this segment toward its target height.
+      /// \param dampening velocity dampening factor.
+      /// \param tension spring tension factor.
+      void update(float dampening, float tension);
 
-       /// \brief clears per-step neighbor transfer deltas.
-       void resetDeltas();
+      /// \brief clears per-step neighbor transfer deltas.
+      void resetDeltas();
 
       float _height{0.0f};
       float _target_height{0.0f};

--- a/src/game/mechanisms/weather.h
+++ b/src/game/mechanisms/weather.h
@@ -12,6 +12,9 @@
 struct TmxObject;
 
 /// \brief drives area-based weather overlays such as rain and thunderstorms.
+/// \note deliberately does not call addChunks: the overlay is a screen-space effect with its own start delay and
+///       intersection tracking rather than something anchored to one spot in the level, so a chunk box around it would
+///       not describe where it is actually relevant.
 class Weather : public GameMechanism, public GameNode
 {
 public:

--- a/src/game/mechanisms/zoomrect.cpp
+++ b/src/game/mechanisms/zoomrect.cpp
@@ -186,6 +186,8 @@ void ZoomRect::setup(const GameDeserializeData& data)
    {
       _zoom_factors = {{0.0f, 1.0f}, {1.0, 1.0}};
    }
+
+   addChunks(_rect_px);
 }
 
 std::optional<sf::FloatRect> ZoomRect::getBoundingBoxPx()


### PR DESCRIPTION
## Why

`hasChunks()` gates **both update and draw** (`level.cpp:1001, 1036, 1148` via `checkUpdateMechanism`), but only about half the mechanisms registered chunks — and nothing in the code recorded whether the rest were oversights or deliberate. This PR closes that: every mechanism now either registers chunks or carries a `\note` saying why it must not.

Chunks are 512×512 px (`CHUNK_SHIFT_X/Y = 9`) with `CHUNK_ALLOWED_DELTA = 3`, so the active window is roughly 1000–1500 px against a 640×360 view. That margin is what makes the additions below safe.

## Chunks added (13)

All are driven by player proximity, so culling cannot change *when* they trigger:

`blockingrect`, `bouncer`, `bubblecube`, `controllerhelp`, `damagerect`, `dialogue`, `extra`, `fan`, `interactionhelp`, `leveltransition`, `sensorrect`, `treasurechest`, `zoomrect`

Two notes on the less obvious ones:
- `bouncer` recomputes its animation frame from `GlobalClock` **absolute** time, so it self-corrects on resume rather than drifting.
- `bubblecube`'s respawn is also on the absolute clock; only its motor/contact timers accumulate, and those matter solely while the player is standing on it.

## Documented as intentionally unculled (10)

| Mechanism | Reason |
|-|-|
| `door` | animates `_bar_offset` from `update` **and** can be triggered remotely by a lever — culling leaves a door opened from a distance stuck shut |
| `laser` | `_time += dt` drives the signal schedule; lasers meant to fire in unison would drift out of phase |
| `deathblock` | interval timing plus patrol movement — groups timed against each other would desync |
| `conveyorbelt` | `_elapsed` drives the scrolling surface and lever ramp |
| `watersurface` | `update` runs a spring simulation that needs to settle; culling freezes the wave and returns stale deformation |
| `weather` | screen-space overlay, not anchored to one spot |
| `soundemitter` | has no `update` override at all (driven by `VolumeUpdater`); distance attenuation is exactly what must keep working when far away |
| `waterdamage` | no position of its own — `getBoundingBoxPx()` returns `std::nullopt`; level-wide rule |
| `portal` | `_rect` mixes units (position in tile coords, size in pixels) and `getBoundingBoxPx()` returns it as-is, so chunk coords would land near the level origin |
| `rotatingblade` | `_rectangle` is a fixed 64×64 at the spawn point and does not cover the movement path |

## Already covered via inheritance — no change needed

- `ropewithlight` → `Rope::setup` (`rope.cpp:309`)
- `ringshaderlayer` → `ShaderLayer::deserialize` (`shaderlayer.cpp:174`)

## Follow-ups this surfaced (not addressed here)

1. **`portal`'s mixed-unit `_rect`** looks like a genuine bug — player-intersection activation compares a pixel-space player rect against a tile-space position. Worth its own fix, after which portals can be chunked.
2. **`rotatingblade`** could be chunked once it has a path-spanning bounding box.
3. **`onoffblock` already has chunks and is lever-driven** — the same failure mode as `door`. Untested, but worth a look.
4. `watersurface.h:94` documents its bounding box as being used for "chunk registration", which was never true.

## Verification

Builds and links clean (MSVC / Ninja, Release). Not play-tested — the reasoning here is static analysis of update/draw paths, so the proximity-triggered additions deserve a pass in-game, particularly `dialogue`, `sensorrect`, and `leveltransition` where a missed enter/leave transition would be user-visible.
