### PR TITLE
refactor(gateway): drop the texture pre-rotation for the side elements

### DIFF
--- a/src/game/mechanisms/gateway.cpp
+++ b/src/game/mechanisms/gateway.cpp
@@ -745,6 +745,9 @@ void Gateway::setup(const GameDeserializeData& data)
 
          if (layer.getName().starts_with("pa_") || layer.getName().starts_with("pi_"))
          {
+            // sampled bilinearly so the sub-pixel movement of the side elements stays smooth
+            texture->setSmooth(true);
+
             const auto origin = sf::Vector2f{texture->getSize().x * 0.5f, texture->getSize().y * 0.5f};
             sfcompat::setOrigin(*sprite, origin);
             sfcompat::setPosition(*sprite, origin + pos + sf::Vector2f{0, 0});

--- a/src/game/mechanisms/gateway.cpp
+++ b/src/game/mechanisms/gateway.cpp
@@ -129,46 +129,6 @@ const auto registered_gateway = []
 }();
 }  // namespace
 
-namespace
-{
-
-std::shared_ptr<sf::Texture> createRotatedTexture(const sf::Texture& original, const sf::Angle& angle)
-{
-   const auto size_px = original.getSize();
-   const auto width_px = static_cast<float>(size_px.x);
-   const auto height_px = static_cast<float>(size_px.y);
-
-#ifdef __EMSCRIPTEN__
-   auto render_texture = std::move(*sf::RenderTexture::create(size_px));
-   render_texture.clear(sf::Color::Transparent);
-
-   sf::Sprite sprite;
-   sprite.textureRect = sf::FloatRect{{0.0f, 0.0f}, {width_px, height_px}};
-   sprite.origin = {width_px / 2.0f, height_px / 2.0f};
-   sprite.rotation = angle;
-   sprite.position = {width_px / 2.0f, height_px / 2.0f};
-
-   render_texture.draw(sprite, sf::RenderStates{.texture = &original});
-   render_texture.display();
-#else
-   sf::RenderTexture render_texture(size_px);
-   render_texture.clear(sf::Color::Transparent);
-
-   sf::Sprite sprite(original);
-   sprite.setOrigin({width_px / 2.0f, height_px / 2.0f});
-   sprite.setRotation(angle);
-   sprite.setPosition({width_px / 2.0f, height_px / 2.0f});
-
-   render_texture.draw(sprite);
-   render_texture.display();
-#endif
-
-   auto rotated = std::make_shared<sf::Texture>(render_texture.getTexture());
-   return rotated;
-}
-
-}  // namespace
-
 Gateway::Gateway(GameNode* parent) : GameNode(parent)
 {
    _filename = "data/sprites/gateway.psd";
@@ -760,13 +720,6 @@ void Gateway::setup(const GameDeserializeData& data)
 
          std::shared_ptr<sf::Sprite> sprite;
 
-         // rotate texture if this is a pa_ or pi_ layer
-         if (layer.getName().starts_with("pa_") || layer.getName().starts_with("pi_"))
-         {
-            texture->setSmooth(true);
-            texture = createRotatedTexture(*texture, -_base_angle);  // rotate ccw
-         }
-
 #ifdef __EMSCRIPTEN__
          sprite = std::make_shared<sf::Sprite>();
 #else
@@ -777,9 +730,7 @@ void Gateway::setup(const GameDeserializeData& data)
 #ifdef __EMSCRIPTEN__
          sprite->position = pos;
          sprite->color = sf::Color(255u, 255u, 255u, static_cast<uint8_t>(opacity));
-         const auto rotated_texture_size = texture->getSize();
-         sprite->textureRect =
-            sf::FloatRect{{0.0f, 0.0f}, {static_cast<float>(rotated_texture_size.x), static_cast<float>(rotated_texture_size.y)}};
+         sprite->textureRect = sf::FloatRect{{0.0f, 0.0f}, {static_cast<float>(texture_size.x), static_cast<float>(texture_size.y)}};
 #else
          sprite->setPosition(pos);
          sprite->setColor(sf::Color(255u, 255u, 255u, static_cast<uint8_t>(opacity)));
@@ -924,7 +875,8 @@ void Gateway::Side::update()
    sf::Vector2f pos_from_angle_and_distance_px;
    pos_from_angle_and_distance_px.x = std::cos(full_angle_sf.asRadians()) * _distance_factor;
    pos_from_angle_and_distance_px.y = std::sin(full_angle_sf.asRadians()) * _distance_factor;
-   sfcompat::setRotation(*_layer->_sprite, full_angle_sf);
+   // the pa_/pi_ artwork is authored at the base angle, compensate for it instead of pre-rotating the texture
+   sfcompat::setRotation(*_layer->_sprite, full_angle_sf - _base_angle);
    sfcompat::setPosition(*_layer->_sprite, _pos_px + pos_from_angle_and_distance_px + _offset_px - sf::Vector2f{1.0f, 1.0f});
 }
 


### PR DESCRIPTION
## What

The `pa_`/`pi_` side artwork in `gateway.psd` is authored at the base angle of 45°. Until now `setup()` compensated for that by baking a −45° rotation into the texture: `createRotatedTexture()` spun up an `sf::RenderTexture` per layer, drew the layer into it, and copied the result back into a fresh `sf::Texture`.

That rotation happened about the centre of the 140×140 layer canvas — which is exactly the point `setup()` already uses as the sprite origin. Two rotations about the same pivot compose into a single rotation by the sum, so the whole step collapses into one angle subtraction in `Side::update()`:

```cpp
sfcompat::setRotation(*_layer->_sprite, full_angle_sf - _base_angle);
```

`full_angle_sf` is still used unchanged for the outward direction vector, so the travel of the elements is unaffected. Origin and position maths are untouched.

## Why

- Removes 8 `sf::RenderTexture` creations plus 8 texture copies from level load.
- No longer resamples the artwork twice (once at load, once per frame). At rest the net rotation is an exact multiple of 90°, so nothing is resampled at all.

## Second commit: bilinear sampling

Dropping the pre-rotation also dropped the `setSmooth(true)` that fed it, which left the sides sampled nearest-neighbour at an axis-aligned rotation instead of nearest-neighbour at 45°. That regressed the "breathing" oscillation in `State::Enabled` to whole-pixel snapping.

At 45° the texel grid is incommensurate with the screen grid, so parts of a sprite cross their sampling thresholds at different moments and sub-pixel movement reads as continuous — the old smoothness was the 45° rotation accidentally dithering the snap, not sub-pixel filtering. Axis-aligned, every texel column shares the same threshold and flips at once.

The second commit enables smoothing on the textures that are actually sampled at runtime, so fractional positions genuinely interpolate at any rotation.

## Verification

- Builds clean with MSVC (Release, ninja).
- Geometry proven identical: rendering the real `pi_0` layer through both the old and the new path at the three configurations that matter (home, mid-lift, fully lifted) produces an **empty silhouette diff** — same positions, same shapes. Only interior texels differ, because the old path resampled twice and the new one resamples once.
- Confirmed in-game: the breathing oscillation is smooth again.

## Unrelated bugs spotted while reading this file, not addressed here

- The inactive ring is reset to alpha 255 while still flagged visible on the last frame of the cross-fade step, one frame before `State::Enabled` hides it — a 1-frame flicker of the "off" artwork on top of the active ring.
- Both backgrounds are hidden for the entire `State::Enabling` sequence (~8 s), reappearing only at the cross-fade step.
- `gateway_1` in `catacombs.tmx` targets `gateway_2`, which does not exist in the map.
