### PR TITLE
music: loop tracks in the stream, and pick the level track from the reached checkpoint

### DIFF
--- a/data/level-catacombs/level.lua
+++ b/data/level-catacombs/level.lua
@@ -1,5 +1,6 @@
 require "data/level-catacombs/level_constants"
 local cutscene = require "data/scripts/cutscene"
+local music_zones = require "data/scripts/music_zones"
 
 ------------------------------------------------------------------------------------------------------------------------
 
@@ -21,7 +22,6 @@ _monk_hide = false
 _delay_to_show_dive_dialogue = 1.0
 _player_intersected_with_water_block_sensor = false
 _player_wont_dive_dialogue_shown = false
-_player_intersected_with_zone_rect = false
 
 _sword_ring_flash_color = {r = 1.0, g = 0.6, b = 0.2}
 
@@ -104,6 +104,19 @@ end
 function initialize()
    -- log("initialize catacombs level script")
    setInfoLayerVisible(true)
+
+   -- the sewers get their own track. checkpoint 1 sits behind the sewers entrance, so from there
+   -- on the sewers track is what the level starts with - also after dying or reloading the level.
+   music_zones.configure({
+      default_track = "data/music/level_test_track_muffler_awakening.ogg",
+      zones = {
+         {
+            sensor_rect = "zone_rect",
+            track = "data/music/level_test_track_muffler_ancestors.ogg",
+            from_checkpoint = 1
+         }
+      }
+   })
 end
 
 
@@ -266,7 +279,7 @@ function update(dt)
       addSensorRectCallback("water_block_sensor_01")
 
       -- change music on zone enter event
-      addSensorRectCallback("zone_rect")
+      music_zones.registerSensorRects()
 
       addSensorRectCallback("sword_ring_sensor")
 
@@ -416,17 +429,16 @@ end
 function playerCollidesWithSensorRect(rect_id)
    log(string.format("sensor rect collision: %s", rect_id))
    
+   if (music_zones.playerCollidesWithSensorRect(rect_id)) then
+      return
+   end
+
    if (rect_id == "monk_rect") then
       _player_intersected_with_monk_rect = true
    elseif (rect_id == "water_block_sensor_01") then
       _player_intersected_with_water_block_sensor = true
    elseif (rect_id == "sword_ring_sensor") then
       flashMechanism("sword_ring", _sword_ring_flash_color.r, _sword_ring_flash_color.g, _sword_ring_flash_color.b, 0.4)
-   elseif (rect_id == "zone_rect") then
-      if (not _player_intersected_with_zone_rect) then
-         _player_intersected_with_zone_rect = true
-         playMusic("data/music/level_test_track_muffler_ancestors.ogg", MusicTransitionType.Crossfade, 1000, MusicPostPlaybackAction.None)
-      end
    end
 end
 

--- a/data/scripts/cutscene.lua
+++ b/data/scripts/cutscene.lua
@@ -59,7 +59,7 @@ local function execute(entry)
          entry.file,
          _music_transition[entry.transition] or 0,
          entry.duration_ms or 0,
-         _music_post_action[entry.post_action] or 0
+         _music_post_action[entry.post_action] or 1
       )
    elseif action == "play_sound" then
       playSound(entry.id)

--- a/data/scripts/cutscene.md
+++ b/data/scripts/cutscene.md
@@ -213,7 +213,7 @@ Fires `<id>/dismissed` when the player closes it.
 | `file` | string | Path to the audio file |
 | `transition` | string | `let_current_finish`, `crossfade`, `immediate`, or `fade_out_then_new` |
 | `duration_ms` | number | Transition duration in milliseconds |
-| `post_action` | string | `none`, `loop`, or `play_next` |
+| `post_action` | string | `none`, `loop`, or `play_next`; defaults to `loop` when omitted |
 
 #### `play_sound`
 

--- a/data/scripts/music_zones.lua
+++ b/data/scripts/music_zones.lua
@@ -1,0 +1,106 @@
+-- shared level music handling
+-- keeps the level music in sync with the area the player is in: entering a zone's sensor rect
+-- crossfades to that zone's track, and once the player has reached the checkpoint a zone belongs
+-- to, that zone's track becomes the track the level starts with. require this from any level
+-- script that changes music while the level is running.
+--
+-- the level script has to hand over three things:
+--
+--    local music_zones = require "data/scripts/music_zones"
+--
+--    function initialize()
+--       music_zones.configure({
+--          default_track = "data/music/some_track.ogg",
+--          zones = {
+--             {sensor_rect = "zone_rect", track = "data/music/other_track.ogg", from_checkpoint = 1},
+--          }
+--       })
+--    end
+--
+--    function update(dt)
+--       if (not _initialized) then
+--          music_zones.registerSensorRects()
+--       end
+--    end
+--
+--    function playerCollidesWithSensorRect(rect_id)
+--       music_zones.playerCollidesWithSensorRect(rect_id)
+--    end
+--
+-- configure() must be called from the level script's initialize function: the engine starts the
+-- level music once loading has finished, which is after initialize but before the first update,
+-- so that is the only place where the starting track can still be selected without the default
+-- track being audible first. registerSensorRects() on the other hand has to wait for the first
+-- update tick, because the engine's mechanism lookup is not wired up yet while initialize runs.
+
+local MusicZones = {}
+
+-- numeric constants passed to the engine's playMusic binding
+local _transition_crossfade = 1
+local _post_action_loop = 1
+
+local _crossfade_duration_ms = 1000
+
+local _default_track = nil
+local _zones = {}         -- list of {sensor_rect, track, from_checkpoint}
+local _current_track = nil
+
+-- the track the level is supposed to start with: the track of the furthest zone the player has
+-- already checkpointed into, or the default track when no zone applies yet.
+local function trackForCheckpoint(checkpoint)
+   local track = _default_track
+   local best_checkpoint = nil
+
+   for _, zone in ipairs(_zones) do
+      if (zone.from_checkpoint and zone.from_checkpoint <= checkpoint) then
+         if (not best_checkpoint or zone.from_checkpoint >= best_checkpoint) then
+            best_checkpoint = zone.from_checkpoint
+            track = zone.track
+         end
+      end
+   end
+
+   return track
+end
+
+-- called by the level script from its initialize function.
+-- picks the track matching the reached checkpoint and hands it to the engine, which starts it
+-- when level loading has finished.
+function MusicZones.configure(config)
+   _default_track = config.default_track
+   _zones = config.zones or {}
+   _crossfade_duration_ms = config.crossfade_duration_ms or _crossfade_duration_ms
+
+   _current_track = trackForCheckpoint(getCheckpoint())
+
+   if (_current_track) then
+      setLevelMusic(_current_track)
+   end
+end
+
+-- called by the level script from its first update tick.
+-- subscribes to every configured zone's sensor rect.
+function MusicZones.registerSensorRects()
+   for _, zone in ipairs(_zones) do
+      addSensorRectCallback(zone.sensor_rect)
+   end
+end
+
+-- called by the level script when the player touches a sensor rect.
+-- crossfades to the zone's track unless it is already the one playing.
+-- returns true when the rect belonged to a music zone.
+function MusicZones.playerCollidesWithSensorRect(rect_id)
+   for _, zone in ipairs(_zones) do
+      if (zone.sensor_rect == rect_id) then
+         if (zone.track ~= _current_track) then
+            _current_track = zone.track
+            playMusic(zone.track, _transition_crossfade, _crossfade_duration_ms, _post_action_loop)
+         end
+         return true
+      end
+   end
+
+   return false
+end
+
+return MusicZones

--- a/doc/level_scripts/readme.md
+++ b/doc/level_scripts/readme.md
@@ -391,6 +391,28 @@ Starts music playback with a specified transition and post-playback behaviour.
 |2|`PlayNext`|Play the next track in the list|
 
 
+## `setLevelMusic`
+
+Selects the level music track without starting playback. The engine starts the level music once
+level loading has finished, i.e. after `initialize` but before the first `update`, so calling this
+from `initialize` picks the track the level starts with. Use `playMusic` to change tracks while the
+level is running.
+
+|Parameter Position|Type|Description|
+|-|-|-|
+|1|string|Music filename or identifier|
+
+
+## `getCheckpoint`
+
+Returns the checkpoint index the player has reached in the current level, or `-1` when no
+checkpoint has been reached yet. Takes no parameters.
+
+|Return Value|Type|Description|
+|-|-|-|
+|1|int|Reached checkpoint index, or -1|
+
+
 ## `playSound`
 
 Plays a one-shot sound effect.

--- a/src/game/audio/musicbackend.h
+++ b/src/game/audio/musicbackend.h
@@ -37,6 +37,15 @@ public:
    /// \return true if the slot holds a stream that is playing.
    virtual bool isPlaying(int slot) const = 0;
 
+   /// \brief enables or disables seamless looping of the stream in the given slot.
+   ///
+   /// Looping is handled by the stream itself rather than by restarting the track once it
+   /// reports that it stopped: on Emscripten a finished stream keeps reporting that it is
+   /// playing, so a restart-on-finish approach never loops there.
+   /// \param slot stream slot index (0 or 1).
+   /// \param looping true to repeat the track when it reaches its end.
+   virtual void setLooping(int slot, bool looping) = 0;
+
    /// \brief begins loading a track into the given slot.
    ///
    /// The desktop backend opens the file on a background thread so the game loop never

--- a/src/game/audio/musicbackenddesktop.cpp
+++ b/src/game/audio/musicbackenddesktop.cpp
@@ -54,6 +54,11 @@ public:
       return _music[slot].getStatus() == sf::SoundStream::Status::Playing;
    }
 
+   void setLooping(int slot, bool looping) override
+   {
+      _music[slot].setLooping(looping);
+   }
+
    void beginLoad(int slot, const std::string& filename) override
    {
       _load_state[slot] = LoadState::Loading;

--- a/src/game/audio/musicbackendemscripten.cpp
+++ b/src/game/audio/musicbackendemscripten.cpp
@@ -93,6 +93,14 @@ public:
       return _music[slot] && _music[slot]->isPlaying();
    }
 
+   void setLooping(int slot, bool looping) override
+   {
+      if (_music[slot])
+      {
+         _music[slot]->setLooping(looping);
+      }
+   }
+
    void beginLoad(int slot, const std::string& filename) override
    {
       _load_succeeded[slot] = loadIntoSlot(slot, filename);

--- a/src/game/audio/musicplayer.cpp
+++ b/src/game/audio/musicplayer.cpp
@@ -123,6 +123,10 @@ void MusicPlayer::processPendingRequest()
 
       case MusicPlayerTypes::TransitionType::LetCurrentFinish:
       {
+         // a looping stream repeats forever and never reports that it stopped, so the loop has to
+         // be dropped for the current track to be able to run out.
+         _backend->setLooping(_current_index, false);
+
          if (!_backend->isPlaying(_current_index))
          {
             beginTransition(request);
@@ -255,6 +259,8 @@ void MusicPlayer::activateLoadedTrack(bool load_succeeded)
    }
 
    const auto next_index = 1 - _current_index;
+
+   _backend->setLooping(next_index, request.post_action == MusicPlayerTypes::PostPlaybackAction::Loop);
 
    if (request.transition == MusicPlayerTypes::TransitionType::Crossfade)
    {

--- a/src/game/audio/musicplayer.h
+++ b/src/game/audio/musicplayer.h
@@ -26,7 +26,7 @@ public:
       std::string filename;
       MusicPlayerTypes::TransitionType transition;
       std::chrono::milliseconds duration{2000};  // for crossfade or fadeout
-      MusicPlayerTypes::PostPlaybackAction post_action = MusicPlayerTypes::PostPlaybackAction::None;
+      MusicPlayerTypes::PostPlaybackAction post_action = MusicPlayerTypes::PostPlaybackAction::Loop;
    };
 
    /// \brief returns the global music-player singleton instance.

--- a/src/game/level/levelscript.cpp
+++ b/src/game/level/levelscript.cpp
@@ -168,6 +168,8 @@ void LevelScript::setup(const std::filesystem::path& path)
    lua_register(_lua_state, "fadeIn", LevelScriptCallbacks::fadeIn);
    lua_register(_lua_state, "log", LevelScriptCallbacks::debug);
    lua_register(_lua_state, "playMusic", LevelScriptCallbacks::playMusic);
+   lua_register(_lua_state, "setLevelMusic", LevelScriptCallbacks::setLevelMusic);
+   lua_register(_lua_state, "getCheckpoint", LevelScriptCallbacks::getCheckpoint);
    lua_register(_lua_state, "removePlayerSkill", LevelScriptCallbacks::removePlayerSkill);
    lua_register(_lua_state, "setLuaNodeActive", LevelScriptCallbacks::setLuaNodeActive);
    lua_register(_lua_state, "setLuaNodeVisible", LevelScriptCallbacks::setLuaNodeVisible);
@@ -668,6 +670,16 @@ void LevelScript::playMusic(
 {
    MusicFilenames::setLevelMusic(filename);
    MusicPlayer::getInstance().queueTrack({filename, transition_type, transition_duration, post_action});
+}
+
+void LevelScript::setLevelMusic(const std::string& filename)
+{
+   MusicFilenames::setLevelMusic(filename);
+}
+
+int32_t LevelScript::getCheckpoint() const
+{
+   return SaveState::getCurrentLevelCheckpoint();
 }
 
 namespace

--- a/src/game/level/levelscript.h
+++ b/src/game/level/levelscript.h
@@ -196,6 +196,18 @@ public:
       MusicPlayerTypes::PostPlaybackAction post_action
    );
 
+   /// \brief selects the level music track without starting playback.
+   ///
+   /// The engine plays the level music once level loading has finished, so a script can pick the
+   /// track that matches the reached checkpoint from its initialize function and let the regular
+   /// level music playback start it.
+   /// \param filename music filename or id.
+   void setLevelMusic(const std::string& filename);
+
+   /// \brief returns the checkpoint index reached in the current level.
+   /// \return checkpoint index, or -1 when no checkpoint has been reached yet.
+   int32_t getCheckpoint() const;
+
    /// \brief loads and starts playback of a recorded player event stream.
    /// \param filename recording file name with or without .dat extension.
    void playEventRecording(const std::string& filename);

--- a/src/game/level/levelscriptcallbacks.cpp
+++ b/src/game/level/levelscriptcallbacks.cpp
@@ -494,6 +494,23 @@ int32_t playMusic(lua_State* state)
    return 0;
 }
 
+int32_t setLevelMusic(lua_State* state)
+{
+   if (lua_gettop(state) != 1)
+   {
+      return 0;
+   }
+
+   LevelScript::getCurrent()->setLevelMusic(std::string(lua_tostring(state, 1)));
+   return 0;
+}
+
+int32_t getCheckpoint(lua_State* state)
+{
+   lua_pushinteger(state, LevelScript::getCurrent()->getCheckpoint());
+   return 1;
+}
+
 int32_t lockPlayerControls(lua_State* state)
 {
    if (lua_gettop(state) != 1)

--- a/src/game/level/levelscriptcallbacks.h
+++ b/src/game/level/levelscriptcallbacks.h
@@ -53,6 +53,8 @@ int32_t setLuaNodeActive(lua_State* state);
 // audio / camera / scene
 int32_t getCameraCenter(lua_State* state);
 int32_t playMusic(lua_State* state);
+int32_t setLevelMusic(lua_State* state);
+int32_t getCheckpoint(lua_State* state);
 int32_t lockPlayerControls(lua_State* state);
 int32_t setCutsceneActive(lua_State* state);
 int32_t fadeOut(lua_State* state);


### PR DESCRIPTION
Two related things: music never looped, and the catacombs sewers track was lost on every level reload.

## 1. Looping

Music played once and then went silent instead of looping.

Looping was never actual looping: `MusicPlayer::handleTrackFinished()` polled `isPlaying()` every frame and called `play()` again once the current slot reported that it had stopped. Whether that works depends entirely on the stream reporting the end of playback, and the two SFML flavors disagree:

- **vanilla SFML 3** (desktop) keeps its own status field and sets it to `Stopped` in its end callback, so the poll fired and the track restarted.
- **VRSFML** (WASM) reports playback state straight from `ma_sound_is_playing()`, which reads the node state. miniaudio only raises its internal `atEnd` flag when a data source runs dry — it never stops the node (`miniaudio.c`, `ma_engine_node_process_pcm_frames__sound`). So a finished track kept claiming it was playing, the restart never happened, and the music was gone for the rest of the session.

Worth knowing what a finished VRSFML stream actually does, since it explains the symptom: `atEnd` is only ever cleared by `ma_sound_start()`, while the node stays `started`. The processing loop then breaks out on `ma_sound_at_end()` after handing over at most one cache chunk per callback, and VRSFML's `onEnd` has already re-seeked the reader to zero — so it dribbles a fraction of the requested frames from the top of the track. Desktop passed through that same regime for a single frame before the poll restarted it, which is why it was never audible there.

**The fix:** let the stream loop itself. `MusicBackend` gains `setLooping(int slot, bool looping)`, which `MusicPlayer::activateLoadedTrack()` applies to the freshly loaded slot based on the request's post action. A looping data source returns a loop position from `onLoop()` instead of `MA_AT_END`, so `atEnd` is never set, the broken end-of-track regime is never entered, and the loop is seamless — no polling, no frame-timing coupling, no gap between cycles.

`LetCurrentFinish` now drops the loop on the current slot, otherwise the track it waits for would repeat forever.

Looping is also the default now — `TrackRequest::post_action` and the cutscene runner's `play_music` entry — so an unspecified post action keeps the music playing instead of leaving silence behind. Explicit `"none"` still works.

## 2. Zone music tied to checkpoint progress

The catacombs sewers get their own track when the player walks into the zone's sensor rect. That switch only lived in a Lua local, so it was lost whenever the level was reloaded: respawning at a checkpoint behind the sewers entrance played the level's opening track again, and the sewers track only came back by walking through the rect once more — which a player respawning past it never does.

Checkpoint progress is already persisted per level in the save state, so the track is keyed off that instead. `data/scripts/music_zones.lua` takes a default track plus a list of zones, each with a sensor rect, a track and the checkpoint it belongs to:

```lua
music_zones.configure({
   default_track = "data/music/level_test_track_muffler_awakening.ogg",
   zones = {
      {sensor_rect = "zone_rect", track = "data/music/level_test_track_muffler_ancestors.ogg", from_checkpoint = 1}
   }
})
```

On level start it selects the track of the furthest zone the player has already checkpointed into; while the level runs it crossfades whenever the player enters a zone's rect. Any level script can reuse it — catacombs is just the first caller, and its ad-hoc one-shot flag is gone.

Two new Lua bindings back it:

- `getCheckpoint()` — the reached checkpoint index in the current level, or -1.
- `setLevelMusic(filename)` — hands a track to the engine without starting playback.

`setLevelMusic` exists because of load ordering: the engine starts the level music once loading has finished, which is after the script's `initialize` but before its first `update`. So `initialize` is the only place where the starting track can still be picked without the default track being audible first. Registering the sensor rects, on the other hand, has to wait for the first update tick — the engine's mechanism lookup is not wired up while `initialize` runs. Both bindings are documented in `doc/level_scripts/readme.md`.

The sewers track also plays looped now; it used to ask for `PostPlaybackAction.None`, which left silence behind after one cycle.

## Still broken on WASM, deliberately out of scope

`LetCurrentFinish` and `PlayNext` both wait for `isPlaying()` to go false, which never happens there. Neither is used by the engine's own music paths (menu and level music are `Crossfade` + `Loop`); they are only reachable from cutscene Lua. Fixing them needs real end-of-track detection in the Emscripten backend — either elapsed-time bookkeeping against the reader duration, or a VRSFML patch exposing at-end. Comparing `getPlayingOffset()` against `getDuration()` does *not* work: VRSFML's `onEnd` re-seeks the cursor to zero, so a finished track reports an offset near zero.

## Testing

- desktop `build_rel` compiles and links; `em++ -fsyntax-only` passes against the VRSFML headers for the touched Emscripten sources
- `music_zones.lua` logic covered by a stubbed-binding harness: track selection per checkpoint (including multiple zones, zones without a checkpoint, and walking back into an earlier zone), no re-trigger when re-entering the current zone, crossfade/loop/duration arguments, sensor rect registration
- ran the desktop build into the catacombs: level script loads, `configure()` → `getCheckpoint()` → `setLevelMusic()` and the module's sensor rect registration all execute without a Lua or engine error (the six errors in the log are pre-existing TMX/missing-sample noise)
- **not verified by ear.** No track has been heard wrapping around, and no crossfade into the sewers has been listened to, on either platform. The WASM build was never built or opened in a browser for this change.
