### PR TITLE
feat(enemies): play a smash sound for all frogs

### DIFF
--- a/data/scripts/enemies/frog.lua
+++ b/data/scripts/enemies/frog.lua
@@ -149,6 +149,10 @@ function initialize()
    setSpriteOffset(2, 36, 12)
    setSpriteVisible(2, false)
 
+   addSample("splat_01.wav")
+   setReferenceVolume(1.0)
+   setAudioUpdateBehavior(AudioUpdateBehavior["AlwaysOn"])
+
    updateSprite(0.0)
 end
 
@@ -372,6 +376,7 @@ function smashed()
 
    -- print("Frog: Smashed, starting to die")
 
+   playSample("splat_01.wav", 1.0)
    _smashed = true
    startDying()
 end

--- a/data/scripts/enemies/frog_blue.lua
+++ b/data/scripts/enemies/frog_blue.lua
@@ -213,6 +213,10 @@ function initialize()
    setSpriteVisible(1, false)
    setSpriteZ(1, _orb_z)
 
+   addSample("splat_01.wav")
+   setReferenceVolume(1.0)
+   setAudioUpdateBehavior(AudioUpdateBehavior["AlwaysOn"])
+
    updateSprite(0.0)
 end
 
@@ -438,6 +442,7 @@ function smashed()
 
    -- print("Frog: Smashed, starting to die")
 
+   playSample("splat_01.wav", 1.0)
    _smashed = true
    startDying()
 end

--- a/data/scripts/enemies/frog_bubble.lua
+++ b/data/scripts/enemies/frog_bubble.lua
@@ -148,6 +148,10 @@ function initialize()
       )
    end
 
+   addSample("splat_01.wav")
+   setReferenceVolume(1.0)
+   setAudioUpdateBehavior(AudioUpdateBehavior["AlwaysOn"])
+
    updateSprite(0.0)
 end
 
@@ -320,6 +324,7 @@ function smashed()
 
    -- print("FrogBubble: Smashed, starting to die")
 
+   playSample("splat_01.wav", 1.0)
    _smashed = true
    startDying()
 end


### PR DESCRIPTION
All three frogs (`frog`, `frog_blue`, `frog_bubble`) now play `splat_01.wav` when smashed, the same way `blob_2` does.

No asset was added: `splat_01.wav` already lives in `data/sounds/`.

### Why the two extra audio lines

`addSample` + `playSample` alone would have been a no-op twice over:

- `_audio_enabled` defaults to `false` (`gamemechanism.h`) and `LuaNode::playSample` returns early while it is false (`luanode.cpp:1204`).
- The only thing that sets it is `VolumeUpdater::updateVolume`, whose default `RangeBased` branch returns early unless the node registered an audio range (`volumeupdater.cpp:55`). The frogs never call `addAudioRange`, so the flag would have stayed false forever.
- `_reference_volume` defaults to `0.0f` and `playSample` multiplies by it, so even past that gate the sample would have played at zero volume.

`setReferenceVolume(1.0)` plus `AudioUpdateBehavior["AlwaysOn"]` covers both, which is exactly the pairing `blob_2`, `klonk_2` and `shadow_monk` use.

### Testing

Not verified in a running game — the change is script-only and mirrors a known-working enemy.
