### PR TITLE
feat(treasurechest): consume the required key when the chest is unlocked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ build_*/*
 **/build/
 .idea/*
 /doc/doxygen-html
+/data/schemas/
 /lab/patch_tool/target
 /lab/patch_tool/Cargo.lock
 /lab/wasm_browser_test/.venv

--- a/doc/level_design/mechanisms.md
+++ b/doc/level_design/mechanisms.md
@@ -1469,6 +1469,7 @@ Further, when the extra is spawned, a 'Spawn Animation' is played which introduc
 |sample_locked|string|Sample that is played when the player attempts to open the chest without the required item (optional)|
 |spawn_extra|string|The identifier of the extra that's supposed to be spawned when opened (default is an empty string)|
 |item_required|string|The identifier of the item required to open the chest (optional)|
+|item_required_consumed|bool|Whether the item given in `item_required` is removed from the player's inventory once the chest has been unlocked (default is `true`). Set this to `false` for a key that is supposed to stay in the inventory and unlock more than one chest.|
 |animation_idle_closed|string|The closed idle animation loaded from `data/sprites/treasure_chest_animations.json` (default is "idle")|
 |animation_opening|string|The opening animation loaded from `data/sprites/treasure_chest_animations.json` (default is "opening")|
 |animation_idle_open|string|The open idle animation loaded from `data/sprites/treasure_chest_animations.json` (default is "open")|

--- a/doc/level_design/mechanisms.md
+++ b/doc/level_design/mechanisms.md
@@ -1468,6 +1468,8 @@ Further, when the extra is spawned, a 'Spawn Animation' is played which introduc
 |sample_open|string|Sample that is played when the chest is opened (default is `treasure_chest_open.wav`)|
 |sample_locked|string|Sample that is played when the player attempts to open the chest without the required item (optional)|
 |spawn_extra|string|The identifier of the extra that's supposed to be spawned when opened (default is an empty string)|
+|spawn_offset_x|float|Horizontal offset in px that is added to the spawned extra's own position when it appears (default is `0`)|
+|spawn_offset_y|float|Vertical offset in px that is added to the spawned extra's own position when it appears (default is `0`). Negative values move the extra up, which is how the extra is usually lifted out of the chest.|
 |item_required|string|The identifier of the item required to open the chest (optional)|
 |item_required_consumed|bool|Whether the item given in `item_required` is removed from the player's inventory once the chest has been unlocked (default is `true`). Set this to `false` for a key that is supposed to stay in the inventory and unlock more than one chest.|
 |animation_idle_closed|string|The closed idle animation loaded from `data/sprites/treasure_chest_animations.json` (default is "idle")|

--- a/src/game/mechanisms/treasurechest.cpp
+++ b/src/game/mechanisms/treasurechest.cpp
@@ -21,6 +21,18 @@ namespace
 static constexpr int32_t default_treasure_chest_z = 0;
 static constexpr std::array treasure_chest_properties{
    PropertyInfo{.name = "z", .type = "int", .default_value = default_treasure_chest_z},
+   PropertyInfo{.name = "texture", .type = "string", .default_value = std::string_view{"data/sprites/treasure_chest.png"}},
+   PropertyInfo{.name = "sample_open", .type = "string", .default_value = std::string_view{"treasure_chest_open.wav"}},
+   PropertyInfo{.name = "sample_locked", .type = "string", .default_value = std::string_view{""}},
+   PropertyInfo{.name = "spawn_extra", .type = "string", .default_value = std::string_view{""}},
+   PropertyInfo{.name = "spawn_offset_x", .type = "float", .default_value = 0.0f},
+   PropertyInfo{.name = "spawn_offset_y", .type = "float", .default_value = 0.0f},
+   PropertyInfo{.name = "item_required", .type = "string", .default_value = std::string_view{""}},
+   PropertyInfo{.name = "item_required_consumed", .type = "bool", .default_value = true},
+   PropertyInfo{.name = "animation_idle_closed", .type = "string", .default_value = std::string_view{"idle"}},
+   PropertyInfo{.name = "animation_opening", .type = "string", .default_value = std::string_view{"opening"}},
+   PropertyInfo{.name = "animation_idle_open", .type = "string", .default_value = std::string_view{"open"}},
+   PropertyInfo{.name = "observed", .type = "bool", .default_value = false},
 };
 static constexpr MechanismSchema treasure_chest_schema{
    .type_name = "TreasureChest",

--- a/src/game/mechanisms/treasurechest.cpp
+++ b/src/game/mechanisms/treasurechest.cpp
@@ -212,6 +212,8 @@ void TreasureChest::update(const sf::Time& dt)
             {
                if (playerHasRequiredKey())
                {
+                  consumeRequiredKey();
+
                   _spawn_effect->activate();
                   _state = State::Opening;
                   _animation_opening->seekToStart();
@@ -320,4 +322,14 @@ std::optional<sf::FloatRect> TreasureChest::getBoundingBoxPx()
 bool TreasureChest::playerHasRequiredKey() const
 {
    return !_item_required.has_value() || (_item_required.has_value() && SaveState::getPlayerInfo()._inventory.has(*_item_required));
+}
+
+void TreasureChest::consumeRequiredKey()
+{
+   if (!_item_required.has_value())
+   {
+      return;
+   }
+
+   SaveState::getPlayerInfo()._inventory.remove(*_item_required);
 }

--- a/src/game/mechanisms/treasurechest.cpp
+++ b/src/game/mechanisms/treasurechest.cpp
@@ -120,6 +120,8 @@ void TreasureChest::deserialize(const GameDeserializeData& data)
       _item_required = item_required;
    }
 
+   _item_required_consumed = ValueReader::readValue<bool>("item_required_consumed", map).value_or(true);
+
    _observed = ValueReader::readValue<bool>("observed", map).value_or(false);
 
    // read animations if set up
@@ -326,7 +328,7 @@ bool TreasureChest::playerHasRequiredKey() const
 
 void TreasureChest::consumeRequiredKey()
 {
-   if (!_item_required.has_value())
+   if (!_item_required.has_value() || !_item_required_consumed)
    {
       return;
    }

--- a/src/game/mechanisms/treasurechest.h
+++ b/src/game/mechanisms/treasurechest.h
@@ -63,6 +63,9 @@ private:
    /// \return true when no key is required or when the required inventory item is present.
    bool playerHasRequiredKey() const;
 
+   /// \brief removes the configured key item from the player's inventory after the chest has been unlocked.
+   void consumeRequiredKey();
+
    sf::FloatRect _rect;
    Alignment _alignment{Alignment::Left};
    std::shared_ptr<sf::Texture> _texture;

--- a/src/game/mechanisms/treasurechest.h
+++ b/src/game/mechanisms/treasurechest.h
@@ -63,7 +63,7 @@ private:
    /// \return true when no key is required or when the required inventory item is present.
    bool playerHasRequiredKey() const;
 
-   /// \brief removes the configured key item from the player's inventory after the chest has been unlocked.
+   /// \brief removes the configured key item from the player's inventory after the chest has been unlocked, unless the chest opted out.
    void consumeRequiredKey();
 
    sf::FloatRect _rect;
@@ -75,6 +75,7 @@ private:
    State _state{State::Closed};
    std::optional<std::string> _spawn_extra;
    std::optional<std::string> _item_required;
+   bool _item_required_consumed{true};  //!< when set, the required item is taken out of the inventory once the chest is unlocked
    sf::Vector2f _spawn_offset;
    bool _extra_spawned{false};                   //!< guards against calling spawnExtra more than once
    std::weak_ptr<GameMechanism> _spawned_extra;  //!< non-owning reference used to disable pickup during the spawn effect


### PR DESCRIPTION
## Problem

The locked box in the catacombs (the one that reveals the head torch) requires the `key` inventory item to open. After opening, the key remained in the inventory — and in an equipped slot — with nothing left to unlock.

## Change

`TreasureChest` now removes the item named by its `item_required` property from the player's inventory at the moment the chest transitions to `Opening`. `Inventory::remove` also clears the item from any equipped slot and fires the removed/updated callbacks, so the inventory UI updates on its own.

Consumption is controlled by a new TMX property:

| property | type | default | meaning |
| --- | --- | --- | --- |
| `item_required_consumed` | bool | `true` | take `item_required` out of the inventory once the chest unlocks |

Defaulting to `true` means no existing TMX needs editing. Set it to `false` for a reusable key — worth having as a knob because `item_required` takes a *generic* item name (`key`), so the same item can front both one-shot and reusable locks. Chests without an `item_required` property are unaffected either way.

Note this is deliberately separate from the item-level `consumed_after_use` flag in `data/sprites/inventory_items.json`, which `Inventory::use()` only honors on the active "use selected slot" path; chests never go through `use()`.

## Also in here

The chest's `MechanismSchema` declared only `z`, while `deserialize()` reads twelve more properties — so the generated `data/schemas/mechanisms.json` described almost nothing about the mechanism. All of them are now declared, and the two previously undocumented `spawn_offset_x` / `spawn_offset_y` properties were added to the level design docs alongside the new one.

`data/schemas/` is also gitignored now, since `writeMechanismSchemas()` rewrites it on every development-mode startup.

## Files

- `src/game/mechanisms/treasurechest.cpp` / `.h`: new `consumeRequiredKey()` called from the successful-unlock branch in `update()`; completed `treasure_chest_properties`.
- `doc/level_design/mechanisms.md`: `item_required_consumed`, `spawn_offset_x`, `spawn_offset_y`.
- `.gitignore`: `/data/schemas/`.

## Notes

Chest state is not persisted across level loads, so a reloaded level shows the box closed again while the key is gone. No progression is lost — the head torch is already permanently in the inventory — but the box can no longer be re-opened. That behaviour is unchanged by this PR and left as-is.

## Testing

Release build passes. Launched the dev build to regenerate `data/schemas/mechanisms.json` and confirmed all 13 chest properties, defaults and types come out as intended. The in-game unlock/consume flow itself is not verified.
