### PR TITLE
fix(menu): show the real resolution in fullscreen and lock the row

### DIFF
--- a/data/locale/en.json
+++ b/data/locale/en.json
@@ -58,6 +58,7 @@
   "Do you want to end the game?": "",
   "Resolution": "",
   "Set the display resolution": "",
+  "The display resolution is used while in fullscreen mode": "",
   "Display Mode": "",
   "Change the display render mode of the game": "",
   "Windowed": "",

--- a/data/locale/it.json
+++ b/data/locale/it.json
@@ -58,6 +58,7 @@
   "Do you want to end the game?": "Vuoi terminare la partita?",
   "Resolution": "Risoluzione",
   "Set the display resolution": "Imposta la risoluzione dello schermo",
+  "The display resolution is used while in fullscreen mode": "In modalità a schermo intero viene usata la risoluzione dello schermo",
   "Display Mode": "Modalità Schermo",
   "Change the display render mode of the game": "Cambia la modalità di rendering dello schermo",
   "Windowed": "Finestra",

--- a/data/locale/ja.json
+++ b/data/locale/ja.json
@@ -58,6 +58,7 @@
   "Do you want to end the game?": "ゲームを終了しますか？",
   "Resolution": "解像度",
   "Set the display resolution": "表示解像度を設定する",
+  "The display resolution is used while in fullscreen mode": "フルスクリーンモードではディスプレイの解像度が使用されます",
   "Display Mode": "表示モード",
   "Change the display render mode of the game": "ゲームの表示レンダリングモードを変更する",
   "Windowed": "ウィンドウ",

--- a/src/menus/menuscreenvideo.cpp
+++ b/src/menus/menuscreenvideo.cpp
@@ -6,6 +6,7 @@
 #include "menus/menu.h"
 #include "menus/menuaudio.h"
 
+#include <algorithm>
 #include <cmath>
 #include <format>
 
@@ -20,7 +21,7 @@ MenuScreenVideo::MenuScreenVideo()
 {
    setFilename("data/menus/video.psd");
 
-   _video_modes = {{640, 360}, {1280, 720}, {1366, 768}, {1600, 900}, {1920, 1080}, {2560, 1440}, {3840, 2160}};
+   _base_video_modes = {{640, 360}, {1280, 720}, {1366, 768}, {1600, 900}, {1920, 1080}, {2560, 1440}, {3840, 2160}};
 
 #ifdef __EMSCRIPTEN__
    const auto desktop_mode = sf::VideoModeUtils::getDesktopMode();
@@ -28,10 +29,32 @@ MenuScreenVideo::MenuScreenVideo()
    const auto desktop_mode = sf::VideoMode::getDesktopMode();
 #endif
    std::erase_if(
-      _video_modes,
+      _base_video_modes,
       [&desktop_mode](const std::array<int32_t, 2>& mode)
       { return mode[0] > static_cast<int32_t>(desktop_mode.size.x) || mode[1] > static_cast<int32_t>(desktop_mode.size.y); }
    );
+
+   refreshVideoModes();
+}
+
+void MenuScreenVideo::refreshVideoModes()
+{
+   // the active resolution is not necessarily one of the predefined modes: going fullscreen adopts the
+   // desktop mode and resizing the window by dragging its border yields arbitrary sizes. keep the active
+   // resolution in the list so it can be found and stepped away from in either direction.
+   _video_modes = _base_video_modes;
+
+   const std::array<int32_t, 2> current_mode{
+      GameConfiguration::getInstance()._video_mode_width, GameConfiguration::getInstance()._video_mode_height
+   };
+
+   if (std::find(_video_modes.begin(), _video_modes.end(), current_mode) != _video_modes.end())
+   {
+      return;
+   }
+
+   // std::array compares lexicographically, so this keeps the list ordered by width, then height
+   _video_modes.insert(std::lower_bound(_video_modes.begin(), _video_modes.end(), current_mode), current_mode);
 }
 
 void MenuScreenVideo::up()
@@ -76,6 +99,14 @@ void MenuScreenVideo::select(int32_t step)
 
       case Selection::Resolution:
       {
+         // in fullscreen the resolution follows the desktop mode, so the row is a readout and cannot be changed
+         if (GameConfiguration::getInstance()._fullscreen)
+         {
+            return;
+         }
+
+         refreshVideoModes();
+
          auto it = std::find_if(
             std::begin(_video_modes),
             std::end(_video_modes),
@@ -322,12 +353,13 @@ void MenuScreenVideo::draw(sf::RenderTarget& window, sf::RenderStates states)
 
 void MenuScreenVideo::updateLayers()
 {
+   refreshVideoModes();
+
    const auto resolution_selected = _selection == Selection::Resolution;
    const auto display_mode_selected = _selection == Selection::DisplayMode;
    const auto vsync_selected = _selection == Selection::VSync;
    const auto brightness_selected = _selection == Selection::Brightness;
 
-   auto resolution_index = 0u;
    auto display_mode_value_index = 0;
 
    const auto fullscreen = GameConfiguration::getInstance()._fullscreen;
@@ -336,17 +368,11 @@ void MenuScreenVideo::updateLayers()
       display_mode_value_index = 2;
    }
 
+   // the resolution is dictated by the desktop mode while fullscreen, so the row turns into a readout
+   const auto resolution_editable = !fullscreen;
+
    const auto resolution_width = GameConfiguration::getInstance()._video_mode_width;
    const auto resolution_height = GameConfiguration::getInstance()._video_mode_height;
-
-   for (auto index = 0u; index < _video_modes.size(); index++)
-   {
-      if (_video_modes[index][0] == resolution_width && _video_modes[index][1] == resolution_height)
-      {
-         resolution_index = index;
-         break;
-      }
-   }
 
    const auto brightness_value = GameConfiguration::getInstance()._brightness;
    const auto vsync_enabled = GameConfiguration::getInstance()._vsync_enabled;
@@ -362,7 +388,7 @@ void MenuScreenVideo::updateLayers()
    _layers["back_pc_1"]->_visible = false;
 
    _layers["resolution_highlight"]->_visible = resolution_selected;
-   _layers["resolution_arrows"]->_visible = resolution_selected;
+   _layers["resolution_arrows"]->_visible = resolution_selected && resolution_editable;
 
    _layers["brightness_body_0"]->_visible = !brightness_selected;
    _layers["brightness_body_1"]->_visible = brightness_selected;
@@ -398,21 +424,26 @@ void MenuScreenVideo::updateLayers()
 
    // resolution row
    _resolution_label->setString(sftr("Resolution"));
-   _resolution_label->setFillColor(resolution_selected ? color_label_selected : color_label_normal);
+   if (resolution_editable)
+   {
+      _resolution_label->setFillColor(resolution_selected ? color_label_selected : color_label_normal);
+   }
+   else
+   {
+      _resolution_label->setFillColor(color_help_text);
+   }
    placeTextLeft(*_resolution_label, rowRect(_row_label_base_rect, 0));
 
-   _resolution_help_text->setString(sftr("Set the display resolution"));
+   _resolution_help_text->setString(
+      resolution_editable ? sftr("Set the display resolution") : sftr("The display resolution is used while in fullscreen mode")
+   );
    placeTextCentered(*_resolution_help_text, _row_help_base_rect);
 
-   if (!_video_modes.empty())
-   {
-      const auto& mode = _video_modes[resolution_index];
 #ifdef __EMSCRIPTEN__
-      _resolution_text->setString(std::format("{}x{}", mode[0], mode[1]).c_str());
+   _resolution_text->setString(std::format("{}x{}", resolution_width, resolution_height).c_str());
 #else
-      _resolution_text->setString(std::format("{}x{}", mode[0], mode[1]));
+   _resolution_text->setString(std::format("{}x{}", resolution_width, resolution_height));
 #endif
-   }
 
    // display mode row
    _displaymode_label->setString(sftr("Display Mode"));

--- a/src/menus/menuscreenvideo.h
+++ b/src/menus/menuscreenvideo.h
@@ -69,10 +69,14 @@ public:
    Selection _selection = Selection::Resolution;
 
 private:
+   /// \brief rebuilds the selectable resolution list so it contains the active resolution.
+   void refreshVideoModes();
+
    FullscreenCallback _fullscreen_callback;
    ResolutionCallback _resolution_callback;
    VSyncCallback _vsync_callback;
-   std::vector<std::array<int32_t, 2>> _video_modes;
+   std::vector<std::array<int32_t, 2>> _base_video_modes;  //!< predefined modes that fit the desktop resolution
+   std::vector<std::array<int32_t, 2>> _video_modes;       //!< base modes plus the active resolution if it is not one of them
    std::vector<std::shared_ptr<Layer>> _brightness_value_layers;
 
    std::unique_ptr<sf::Text> _resolution_text;  //!< dynamic "WxH" value, e.g. "1280x720"


### PR DESCRIPTION
## Problem

Switching the video options to fullscreen changed the displayed resolution from `1280x720` to `640x360`.

`MenuScreenVideo::updateLayers()` initialised `resolution_index` to `0` and only overwrote it on an exact match against the hardcoded `_video_modes` list. `Game::toggleFullScreen()` writes the desktop mode into the config, and on a 1920x1200 display that value is not in the list, so the index stayed at `0` — entry 0 being `640x360`.

Rendering was never affected: the window and render targets read `_video_mode_width/height` directly.

The same stale index also drove `select()`. `find_if` returned `end()`, `current_index` became one past the last entry, and both `std::clamp(size + 1, ...)` and `std::clamp(size - 1, ...)` resolved to the last mode. Left and right therefore did the same thing and recreated the fullscreen window at a non-native resolution.

An unlisted resolution is not unique to fullscreen — the window is resizable, so dragging its border beyond the 10px threshold also writes an arbitrary size into the config.

## Changes

- Format the configured resolution directly instead of indexing the list, so the readout is correct for any value.
- Add `refreshVideoModes()`: the predefined modes move to `_base_video_modes`, and `_video_modes` is rebuilt as those plus the active resolution when it is not among them, inserted in sorted position. This keeps `find_if` matching, which is what fixes stepping after a manual resize.
- In fullscreen the resolution follows the desktop mode, so the row becomes a readout: `select()` returns early, the arrows are hidden, the label is drawn in `color_help_text` and the help line changes. New string added to `en.json`, `it.json` and `ja.json`.

## Verification

Driven against the desktop build on a 1920x1200 display at 125% scaling:

- Fullscreen shows `1920x1200`, label dimmed, no arrows.
- Right and left on the resolution row while fullscreen leave it at `1920x1200` with fullscreen intact.
- Windowed stepping still works: 1280x720 → 1366x768 → back.

`PrintWindow` returns black frames for the exclusive fullscreen window, so the fullscreen assertions were taken from `game.json` rather than screenshots, with a probe press (two downs then right reaches V-Sync only if the selection really moved to the resolution row) confirming the row under test.

## Not addressed

`toggleFullScreen()` still hardcodes the fullscreen resolution to the desktop mode, so fullscreen always runs the 640x360 view at an integer scale with letterboxing. The row now reports that honestly; choosing a non-native fullscreen resolution would be a separate change in `game.cpp`.
