### PR TITLE
fix(level): repair save state handling across level transitions

### DIFF
--- a/doc/level_design/mechanisms.md
+++ b/doc/level_design/mechanisms.md
@@ -900,7 +900,7 @@ The way to create a moveable object, create a rectangle as usual. So far the spr
 |density|float|Density of the moveable object, default is 1.0f.|
 |gravity_scale|float|Gravity scale of the moveable object, default is 1.0f.|
 |z|int|The layer's z index|
-|serialized|bool|If set to `true`, the box's position is saved and restored when the level is reloaded (default is `true`). Set it to `false` for boxes that should always start from their position in the level. Serialized boxes need a name, and that name has to be unique within the level, since the save state identifies mechanisms by it.|
+|serialized|bool|If set to `true`, the box's position is saved and restored when the level is reloaded (default is `true`). Set it to `false` for boxes that should always start from their position in the level. Boxes are identified in the save state by their name combined with their Tiled object id, so two boxes may share a name.|
 
 
 ---

--- a/doc/level_design/mechanisms.md
+++ b/doc/level_design/mechanisms.md
@@ -900,7 +900,7 @@ The way to create a moveable object, create a rectangle as usual. So far the spr
 |density|float|Density of the moveable object, default is 1.0f.|
 |gravity_scale|float|Gravity scale of the moveable object, default is 1.0f.|
 |z|int|The layer's z index|
-|serialized|bool|If set to `true`, the box's position is saved and restored when the level is reloaded (default is `true`). Set it to `false` for boxes that should always start from their position in the level. Serialized boxes need a name so they can be identified in the save state.|
+|serialized|bool|If set to `true`, the box's position is saved and restored when the level is reloaded (default is `true`). Set it to `false` for boxes that should always start from their position in the level. Serialized boxes need a name, and that name has to be unique within the level, since the save state identifies mechanisms by it.|
 
 
 ---

--- a/doc/level_design/mechanisms.md
+++ b/doc/level_design/mechanisms.md
@@ -900,7 +900,7 @@ The way to create a moveable object, create a rectangle as usual. So far the spr
 |density|float|Density of the moveable object, default is 1.0f.|
 |gravity_scale|float|Gravity scale of the moveable object, default is 1.0f.|
 |z|int|The layer's z index|
-|serialized|bool|If set to `true`, the box's position is saved and restored when the level is reloaded (default is `true`). Set it to `false` for boxes that should always start from their position in the level. Boxes are identified in the save state by their name combined with their Tiled object id, so two boxes may share a name.|
+|serialized|bool|If set to `true`, the box's position is saved and restored when the level is reloaded (default is `true`). Set it to `false` for boxes that should always start from their position in the level.|
 
 
 ---

--- a/doc/level_design/mechanisms.md
+++ b/doc/level_design/mechanisms.md
@@ -900,6 +900,7 @@ The way to create a moveable object, create a rectangle as usual. So far the spr
 |density|float|Density of the moveable object, default is 1.0f.|
 |gravity_scale|float|Gravity scale of the moveable object, default is 1.0f.|
 |z|int|The layer's z index|
+|serialized|bool|If set to `true`, the box's position is saved and restored when the level is reloaded (default is `true`). Set it to `false` for boxes that should always start from their position in the level. Serialized boxes need a name so they can be identified in the save state.|
 
 
 ---

--- a/src/game/level/level.cpp
+++ b/src/game/level/level.cpp
@@ -622,7 +622,15 @@ void Level::loadSaveState()
       return;
    }
 
-   const auto& level_json = save_state._level_state[_description->_filename];
+   // a level that has never been saved has no entry here; the const operator[] would assert in debug and
+   // dereference the end iterator in release, so the key has to be looked up explicitly
+   const auto level_state_it = save_state._level_state.find(_description->_filename);
+   if (level_state_it == save_state._level_state.end())
+   {
+      return;
+   }
+
+   const auto& level_json = *level_state_it;
    if (level_json.is_null())
    {
       return;

--- a/src/game/level/leveltransitionhandler.cpp
+++ b/src/game/level/leveltransitionhandler.cpp
@@ -99,9 +99,12 @@ void LevelTransitionHandler::update()
             level->saveState();
          }
 
+         // the level index has to be updated before writing, otherwise the file still points at the level
+         // that is being left and a crash or quit before the next save resumes in the wrong level
+         SaveState::getCurrent()._level_index = target_level_index;
+
          SaveState::serializeToFile();
 
-         SaveState::getCurrent()._level_index = target_level_index;
          LevelTransitionHandler::getInstance()._spawn_position_px = spawn_position_px;
 
          CallbackMap::getInstance().call(static_cast<int32_t>(CallbackType::LoadLevel));

--- a/src/game/mechanisms/gateway.cpp
+++ b/src/game/mechanisms/gateway.cpp
@@ -651,6 +651,40 @@ void Gateway::update(const sf::Time& dt)
    _eye->update(dt, _state);
 }
 
+void Gateway::serializeState(nlohmann::json& json_object)
+{
+   if (getObjectId().empty())
+   {
+      return;
+   }
+
+   // a gateway that is still enabling has already been triggered by the player, so it counts as enabled
+   json_object[getObjectId()] = {{"enabled", _state != State::Disabled}};
+}
+
+void Gateway::deserializeState(const nlohmann::json& json_object)
+{
+   if (!json_object.at("enabled").get<bool>())
+   {
+      return;
+   }
+
+   // skip the activation sequence and bring the gateway up already enabled, mirroring what the transition
+   // from Enabling to Enabled does in update()
+   _state = State::Enabled;
+   _enabled_state.resetTime();
+   _enabled_state._distances_when_activated = _pa[0]._distance_factor;
+
+   _eye->wakeUp();
+
+   if (_flowfield_reference_id.has_value() && _flowfield_texture.has_value())
+   {
+      EventDistributor::event(
+         FlowFieldTextureChangeEvent{._object_id = _flowfield_reference_id.value(), ._texture_id = _flowfield_texture.value()}
+      );
+   }
+}
+
 void Gateway::setup(const GameDeserializeData& data)
 {
    setObjectId(data._tmx_object->_name);

--- a/src/game/mechanisms/gateway.cpp
+++ b/src/game/mechanisms/gateway.cpp
@@ -329,17 +329,23 @@ void Gateway::update(const sf::Time& dt)
    if (!_player_intersects && player_intersects)
    {
       _player_intersects = player_intersects;
-      _state = State::Enabling;
 
-      _activated_state._step = 0;
-
-      Audio::getInstance().playSample({"mechanism_gateway_extract_01.wav"});
-
-      for (auto& pa : _pa)
+      // a gateway restored from the save state comes up enabled, so touching it must not replay the
+      // activation sequence and throw it back to the enabling animation
+      if (_state == State::Disabled)
       {
-         pa.reset();
+         _state = State::Enabling;
+
+         _activated_state._step = 0;
+
+         Audio::getInstance().playSample({"mechanism_gateway_extract_01.wav"});
+
+         for (auto& pa : _pa)
+         {
+            pa.reset();
+         }
+         return;
       }
-      return;
    }
 
    // player uses gateway

--- a/src/game/mechanisms/gateway.h
+++ b/src/game/mechanisms/gateway.h
@@ -53,6 +53,14 @@ public:
    /// \param destination_gateway_id object id of the destination gateway.
    void setTargetId(const std::string& destination_gateway_id);
 
+   /// \brief writes whether the gateway has been activated into save data.
+   /// \param json json object to write state fields into.
+   void serializeState(nlohmann::json& json) override;
+
+   /// \brief restores the activated state from save data.
+   /// \param json json object containing previously serialized state.
+   void deserializeState(const nlohmann::json& json) override;
+
 private:
    enum class State
    {

--- a/src/game/mechanisms/moveablebox.cpp
+++ b/src/game/mechanisms/moveablebox.cpp
@@ -209,6 +209,34 @@ void MoveableBox::setup(const GameDeserializeData& data)
    setupTransform();
 }
 
+void MoveableBox::serializeState(nlohmann::json& json_object)
+{
+   if (getObjectId().empty())
+   {
+      return;
+   }
+
+   json_object[getObjectId()] = {{"x_px", _body->GetPosition().x * PPM}, {"y_px", _body->GetPosition().y * PPM}};
+}
+
+void MoveableBox::deserializeState(const nlohmann::json& json_object)
+{
+   const auto x_px = json_object.at("x_px").get<float>();
+   const auto y_px = json_object.at("y_px").get<float>();
+
+   // put the box back where it was pushed to and drop the momentum it had when the level was saved
+   _body->SetTransform(b2Vec2{x_px / PPM, y_px / PPM}, 0.0f);
+   _body->SetLinearVelocity(b2Vec2{0.0f, 0.0f});
+   _body->SetAngularVelocity(0.0f);
+
+   // keep the sprite in sync, update() would otherwise only catch up on the next frame
+#ifdef __EMSCRIPTEN__
+   _sprite->position = {x_px, y_px - 24};
+#else
+   _sprite->setPosition({x_px, y_px - 24});
+#endif
+}
+
 void MoveableBox::setupTransform()
 {
 #ifdef __EMSCRIPTEN__

--- a/src/game/mechanisms/moveablebox.cpp
+++ b/src/game/mechanisms/moveablebox.cpp
@@ -146,7 +146,11 @@ std::optional<sf::FloatRect> MoveableBox::getBoundingBoxPx()
 
 void MoveableBox::setup(const GameDeserializeData& data)
 {
-   setObjectId(data._tmx_object->_name);
+   // the save state identifies mechanisms by their object id and box names are not necessarily unique
+   // within a level, so the tmx object id is folded in to tell two identically named boxes apart
+   const auto& tmx_name = data._tmx_object->_name;
+   const auto& tmx_id = data._tmx_object->_id;
+   setObjectId(tmx_name.empty() ? tmx_id : tmx_name + "_" + tmx_id);
 
    _texture = TexturePool::getInstance().get("data/sprites/moveable_box.png");
 #ifdef __EMSCRIPTEN__
@@ -224,16 +228,7 @@ void MoveableBox::serializeState(nlohmann::json& json_object)
 
    if (getObjectId().empty())
    {
-      Log::Warning() << "a moveable box is set up to be serialized but it doesn't have any id";
-      return;
-   }
-
-   // the save state identifies mechanisms by their object id and restores the first one that matches, so
-   // a shared name would move the wrong box; leave the duplicates alone rather than misplace them
-   if (json_object.find(getObjectId()) != json_object.end())
-   {
-      Log::Warning() << "more than one moveable box is named '" << getObjectId()
-                     << "', only the first one keeps its position across save states";
+      Log::Warning() << "a moveable box is set up to be serialized but it has neither a name nor a tmx id";
       return;
    }
 

--- a/src/game/mechanisms/moveablebox.cpp
+++ b/src/game/mechanisms/moveablebox.cpp
@@ -4,6 +4,7 @@
 #include "framework/tmxparser/tmxobject.h"
 #include "framework/tmxparser/tmxproperties.h"
 #include "framework/tmxparser/tmxproperty.h"
+#include "framework/tools/log.h"
 #include "game/audio/audio.h"
 #include "game/constants.h"
 #include "game/io/texturepool.h"
@@ -18,6 +19,7 @@ namespace
 {
 static constexpr std::array moveable_box_properties{
    PropertyInfo{.name = "z", .type = "int", .default_value = int32_t{20}},
+   PropertyInfo{.name = "serialized", .type = "bool", .default_value = true},
 };
 static constexpr MechanismSchema moveable_box_schema{
    .type_name = "MoveableObject",
@@ -167,6 +169,9 @@ void MoveableBox::setup(const GameDeserializeData& data)
 
    addChunks(rect);
 
+   // boxes remember where they were pushed to unless a level opts out of it
+   _serialized = true;
+
    if (data._tmx_object->_properties)
    {
       const auto& map = data._tmx_object->_properties->_map;
@@ -175,6 +180,7 @@ void MoveableBox::setup(const GameDeserializeData& data)
       _settings._friction = ValueReader::readValue<float>("friction", map).value_or(_settings._friction);
       _settings._gravity_scale = ValueReader::readValue<float>("gravity_scale", map).value_or(_settings._gravity_scale);
       setZ(ValueReader::readValue<int32_t>("z", map).value_or(0));
+      _serialized = ValueReader::readValue<bool>("serialized", map).value_or(_serialized);
    }
 
    switch (static_cast<int32_t>(_size.x))
@@ -211,8 +217,14 @@ void MoveableBox::setup(const GameDeserializeData& data)
 
 void MoveableBox::serializeState(nlohmann::json& json_object)
 {
+   if (!_serialized)
+   {
+      return;
+   }
+
    if (getObjectId().empty())
    {
+      Log::Warning() << "a moveable box is set up to be serialized but it doesn't have any id";
       return;
    }
 

--- a/src/game/mechanisms/moveablebox.cpp
+++ b/src/game/mechanisms/moveablebox.cpp
@@ -228,6 +228,15 @@ void MoveableBox::serializeState(nlohmann::json& json_object)
       return;
    }
 
+   // the save state identifies mechanisms by their object id and restores the first one that matches, so
+   // a shared name would move the wrong box; leave the duplicates alone rather than misplace them
+   if (json_object.find(getObjectId()) != json_object.end())
+   {
+      Log::Warning() << "more than one moveable box is named '" << getObjectId()
+                     << "', only the first one keeps its position across save states";
+      return;
+   }
+
    json_object[getObjectId()] = {{"x_px", _body->GetPosition().x * PPM}, {"y_px", _body->GetPosition().y * PPM}};
 }
 

--- a/src/game/mechanisms/moveablebox.h
+++ b/src/game/mechanisms/moveablebox.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "box2d/box2d.h"
 #include <SFML/Graphics.hpp>
 #include <optional>
+#include "box2d/box2d.h"
 
 #include "game/io/gamedeserializedata.h"
 #include "game/level/gamenode.h"
@@ -48,6 +48,14 @@ public:
    /// \brief initializes sprite, physics settings, and dynamic box2d body from TMX object data.
    /// \param data deserialize context with TMX object and physics world.
    void setup(const GameDeserializeData& data);
+
+   /// \brief writes the current box position into save data.
+   /// \param json json object to write state fields into.
+   void serializeState(nlohmann::json& json) override;
+
+   /// \brief restores the box position from save data.
+   /// \param json json object containing previously serialized state.
+   void deserializeState(const nlohmann::json& json) override;
 
    /// \brief stores configurable physics values read from TMX properties.
    struct Settings

--- a/src/game/mechanisms/treasurechest.cpp
+++ b/src/game/mechanisms/treasurechest.cpp
@@ -338,6 +338,44 @@ bool TreasureChest::playerHasRequiredKey() const
    return !_item_required.has_value() || (_item_required.has_value() && SaveState::getPlayerInfo()._inventory.has(*_item_required));
 }
 
+void TreasureChest::serializeState(nlohmann::json& json_object)
+{
+   if (getObjectId().empty())
+   {
+      return;
+   }
+
+   // a chest that is opening has already consumed the key, so it counts as open for the save state
+   json_object[getObjectId()] = {{"open", _state != State::Closed}};
+}
+
+void TreasureChest::deserializeState(const nlohmann::json& json_object)
+{
+   if (!json_object.at("open").get<bool>())
+   {
+      return;
+   }
+
+   // skip the opening animation, the chest was already opened in a previous visit
+   _state = State::Open;
+
+   if (_animation_idle_closed)
+   {
+      _animation_idle_closed->pause();
+   }
+
+   if (_animation_opening)
+   {
+      _animation_opening->pause();
+   }
+
+   if (_animation_idle_open)
+   {
+      _animation_idle_open->seekToStart();
+      _animation_idle_open->play();
+   }
+}
+
 void TreasureChest::consumeRequiredKey()
 {
    if (!_item_required.has_value() || !_item_required_consumed)

--- a/src/game/mechanisms/treasurechest.h
+++ b/src/game/mechanisms/treasurechest.h
@@ -45,6 +45,14 @@ public:
    /// \return std::nullopt.
    std::optional<sf::FloatRect> getBoundingBoxPx() override;
 
+   /// \brief writes whether the chest has been opened into save data.
+   /// \param json json object to write state fields into.
+   void serializeState(nlohmann::json& json) override;
+
+   /// \brief restores the opened state from save data.
+   /// \param json json object containing previously serialized state.
+   void deserializeState(const nlohmann::json& json) override;
+
 private:
    enum class Alignment
    {


### PR DESCRIPTION
Fixes three defects that combine into losing progress when changing levels.

## 1. Undefined behaviour when entering a level for the first time

`Level::loadSaveState()` read the level entry through nlohmann's **const** `operator[]` (`level.cpp:625`). That overload is:

```cpp
assert(m_value.object->find(key) != m_value.object->end());
return m_value.object->find(key)->second;
```

In Release `NDEBUG` removes the assert, so a missing key dereferences the end iterator of the underlying map. The `is_null()` guard above it only catches an entirely null `levelstate`, never a missing key.

Any level with no entry in `levelstate` hits this — i.e. every first entry into a level. Symptoms vary, as UB does: one session ran ~28s past the transition before dying, an earlier one produced a WER `AppHangB1` seconds after `deleting current level`.

Fixed by looking the key up with `find()`.

## 2. Level transition persisted a stale level index

```cpp
SaveState::serializeToFile();                              // wrote the file...
SaveState::getCurrent()._level_index = target_level_index; // ...then updated the index
```

The file therefore named the level being left. Combined with #1 this is what sent the player back to the previous level at its last checkpoint after a crash. Assign the index first, then serialize.

## 3. Gateway and TreasureChest state was never saved

`Level::saveState()` already calls `serializeState()` on every mechanism and `loadSaveState()` dispatches back by object id, but only `Extra` and `Lever` overrode those. Gateway and chest state was silently dropped.

The chest matters most: since it consumes the required key on unlock, forgetting it was opened leaves the key gone and the chest shut — unopenable.

Both now serialize unconditionally (like `Extra`, not opt-in like `Lever`, so no TMX edits are needed), keyed by their existing TMX object id, and restore into the terminal state — `Open` / `Enabled` — rather than replaying the opening or activation animation.

## Verification

**#1, A/B against a pre-fix binary.** Installed a save whose `levelstate` exists but lacks the level being loaded, then loaded it:

| binary | process alive | window | level loaded |
|---|---|---|---|
| pre-fix | no | no | no |
| fixed | yes | yes | yes, plus 15s of play |

**#3, round-trip.** Installed a save with `gateway_1` enabled and all three chests open, loaded the level, then forced `Level::saveState()` via a checkpoint teleport and read the file back. Had `deserializeState` not applied, the mechanisms would come up in their default state and re-save as `false`:

```
gateways read back:        {"gateway_1": {"enabled": true}}
treasure_chests read back: {"diamond_box": {"open": true}, "diamond_box_02": {"open": true}, "locked_box": {"open": true}}
```

Serialization was also confirmed from a clean state — `levelstate` now contains `gateways` and `treasure_chests` alongside the existing `extras` and `levers`.

**#2 is verified by inspection only.** Triggering it needs the player to walk into a level transition rect, which I could not drive reliably; the change is a two-line reordering inside one lambda.
