### PR TITLE
Derive the catacombs locked box texts from the chest state

### DIFF
--- a/data/level-catacombs/level.lua
+++ b/data/level-catacombs/level.lua
@@ -225,6 +225,19 @@ function initDrawer()
 end
 
 ------------------------------------------------------------------------------------------------------------------------
+function initLockedBox()
+   -- the chest restores its own open state from the save game, so the texts that describe it are derived from
+   -- the chest instead of being remembered separately
+   -- the search group is the tmx layer name, which is not the group id that mechanismEvent reports
+   if (getMechanismProperty("locked_box", "treasure_chests", "open")) then
+      setMechanismEnabled("locked_message", false, "dialogues")
+      setMechanismEnabled("locked_box_interaction_help", false, "interaction_help")
+      setMechanismEnabled("handle_help", false, "interaction_help")
+   end
+end
+
+
+------------------------------------------------------------------------------------------------------------------------
 function openDrawer()
    if (inventoryHas("key")) then
       return
@@ -285,6 +298,7 @@ function update(dt)
 
       initLocker()
       initDrawer()
+      initLockedBox()
       initLeverSpike()
    end
 

--- a/doc/level_design/mechanisms.md
+++ b/doc/level_design/mechanisms.md
@@ -1488,6 +1488,28 @@ When the `observed` flag is set to `true`, the treasure chest will emit the foll
 |state|`locked`|Emitted when the player attempts to open the chest without having the required item|
 |state|`open`|Emitted when the chest has fully opened and the spawn effect is shown|
 
+These events are only emitted while the level is running. A chest restores its open state from the
+save game before the level script starts, so the `open` event does not fire again on load. Any
+script state that was set up in reaction to it has to be derived from the chest instead, see below.
+
+### Readable Properties
+
+The chest exposes its state to the level script through `getMechanismProperty`:
+
+|Property|Type|Description|
+|-|-|-|
+|open|bool|`true` once the chest has been opened, including while the opening animation runs|
+
+```lua
+-- reproduce on load what the "open" event did while playing
+if (getMechanismProperty("locked_box", "treasure_chests", "open")) then
+   setMechanismEnabled("locked_message", false, "dialogues")
+end
+```
+
+Note the group is the object group `treasure_chests`, not the `treasurechests` group id that
+`mechanismEvent` reports.
+
 ### Spawn Effect Properties (extension to the Object Properties above)
 
 The spawn effect consists of an orb animation in the center and particles that move towards that orb.

--- a/doc/level_scripts/readme.md
+++ b/doc/level_scripts/readme.md
@@ -263,6 +263,46 @@ Returns the bounding rectangle of the first mechanism matching the search patter
 |return|table or nil|Table with fields `x`, `y`, `width`, `height` in world pixels|
 
 
+## `getMechanismProperty`
+
+Reads a named runtime property from the first mechanism matching the search pattern, or `nil` if
+nothing matches or the mechanism does not expose that property.
+
+Use this to derive script state from a mechanism that already persists it, instead of remembering
+the same fact separately in the level script. A mechanism restores its own state from the save game
+before the level script starts, so a script that reacts to a state change in `mechanismEvent` can
+reproduce the same result on load by querying the mechanism.
+
+|Parameter Position|Type|Description|
+|-|-|-|
+|1|string|Mechanism search pattern (regular expression)|
+|2|string|Mechanism group|
+|3|string|Property name|
+|return|bool, number, string or nil|Property value, or `nil` when unavailable|
+
+The group is the **tmx layer name** the mechanism lives on, for example `treasure_chests`. This is
+not always the same string as the group id that `mechanismEvent` reports for the same mechanism,
+which is `treasurechests` for a treasure chest. A group that does not match a layer name silently
+yields `nil`.
+
+Mechanisms opt in individually, so only the properties listed here are available:
+
+|Mechanism|Group|Property|Type|Description|
+|-|-|-|-|-|
+|`TreasureChest`|`treasure_chests`|`open`|bool|`true` once the chest has been opened, including while the opening animation runs|
+
+```lua
+-- the chest restores its own open state, so the texts that describe it are derived from the chest
+if (getMechanismProperty("locked_box", "treasure_chests", "open")) then
+   setMechanismEnabled("locked_message", false, "dialogues")
+   setMechanismEnabled("locked_box_interaction_help", false, "interaction_help")
+end
+```
+
+To expose a property on another mechanism, override `GameMechanism::getProperty` and return the
+value for the property names it supports.
+
+
 ## `getCameraCenter`
 
 Returns the current camera center in world pixel coordinates.

--- a/src/game/level/levelscript.cpp
+++ b/src/game/level/levelscript.cpp
@@ -197,6 +197,7 @@ void LevelScript::setup(const std::filesystem::path& path)
    lua_register(_lua_state, "loadCutscene", LevelScriptCallbacks::loadCutscene);
    lua_register(_lua_state, "getCameraCenter", LevelScriptCallbacks::getCameraCenter);
    lua_register(_lua_state, "getMechanismRect", LevelScriptCallbacks::getMechanismRect);
+   lua_register(_lua_state, "getMechanismProperty", LevelScriptCallbacks::getMechanismProperty);
 
    // make standard libraries available in the Lua object
    luaL_openlibs(_lua_state);
@@ -535,6 +536,27 @@ bool LevelScript::isMechanismEnabled(const std::string& search_pattern, const st
       return false;
    }
    return mechanisms.front()->isEnabled();
+}
+
+std::optional<GameMechanismObserver::LuaVariant> LevelScript::getMechanismProperty(
+   const std::string& search_pattern,
+   const std::optional<std::string>& group,
+   const std::string& property_name
+) const
+{
+   if (!_search_mechanism_callback)
+   {
+      Log::Error() << "search mechanism callback not initialized yet";
+      return std::nullopt;
+   }
+
+   const auto mechanisms = _search_mechanism_callback(search_pattern, group);
+   if (mechanisms.empty())
+   {
+      return std::nullopt;
+   }
+
+   return mechanisms.front()->getProperty(property_name);
 }
 
 void LevelScript::setMechanismVisible(const std::string& search_pattern, bool visible, const std::optional<std::string>& group)

--- a/src/game/level/levelscript.h
+++ b/src/game/level/levelscript.h
@@ -54,6 +54,14 @@ public:
    /// \return true when at least one mechanism matches and the first one is enabled.
    bool isMechanismEnabled(const std::string& mechanism_id, const std::optional<std::string>& group) const;
 
+   /// \brief reads a named property from the first mechanism that matches the query.
+   /// \param search_pattern regex used to select mechanisms.
+   /// \param group optional mechanism group filter.
+   /// \param property_name name of the property to read from the matched mechanism.
+   /// \return property value, or nullopt when nothing matches or the mechanism does not expose the property.
+   std::optional<GameMechanismObserver::LuaVariant>
+   getMechanismProperty(const std::string& search_pattern, const std::optional<std::string>& group, const std::string& property_name) const;
+
    /// \brief sets visibility for all matching mechanisms.
    /// \param search_pattern regex used to select mechanisms.
    /// \param visible target visibility state.

--- a/src/game/level/levelscriptcallbacks.cpp
+++ b/src/game/level/levelscriptcallbacks.cpp
@@ -5,6 +5,8 @@
 #include <fstream>
 #include <lua.hpp>
 #include <sstream>
+#include <type_traits>
+#include <variant>
 
 #include "SFML/Graphics.hpp"
 #include "framework/tmxparser/tmxtools.h"
@@ -95,6 +97,52 @@ int32_t isMechanismVisible(lua_State* state)
    }
 
    lua_pushboolean(state, LevelScript::getCurrent()->isMechanismVisible(search_pattern, group));
+   return 1;
+}
+
+int32_t getMechanismProperty(lua_State* state)
+{
+   const auto argc = lua_gettop(state);
+   if (argc != 3)
+   {
+      return 0;
+   }
+
+   const std::string search_pattern = lua_tostring(state, 1);
+   const std::string group = lua_tostring(state, 2);
+   const std::string property_name = lua_tostring(state, 3);
+
+   const auto property = LevelScript::getCurrent()->getMechanismProperty(search_pattern, group, property_name);
+   if (!property.has_value())
+   {
+      lua_pushnil(state);
+      return 1;
+   }
+
+   std::visit(
+      [state](const auto& property_value)
+      {
+         using PropertyType = std::decay_t<decltype(property_value)>;
+         if constexpr (std::is_same_v<PropertyType, bool>)
+         {
+            lua_pushboolean(state, property_value);
+         }
+         else if constexpr (std::is_same_v<PropertyType, int64_t>)
+         {
+            lua_pushinteger(state, property_value);
+         }
+         else if constexpr (std::is_same_v<PropertyType, double>)
+         {
+            lua_pushnumber(state, property_value);
+         }
+         else
+         {
+            lua_pushstring(state, property_value.c_str());
+         }
+      },
+      property.value()
+   );
+
    return 1;
 }
 

--- a/src/game/level/levelscriptcallbacks.h
+++ b/src/game/level/levelscriptcallbacks.h
@@ -15,6 +15,7 @@ int32_t isPlayerIntersectingSensorRect(lua_State* state);
 
 // mechanisms
 int32_t getMechanismRect(lua_State* state);
+int32_t getMechanismProperty(lua_State* state);
 int32_t isMechanismEnabled(lua_State* state);
 int32_t isMechanismVisible(lua_State* state);
 int32_t setMechanismEnabled(lua_State* state);

--- a/src/game/mechanisms/gamemechanism.cpp
+++ b/src/game/mechanisms/gamemechanism.cpp
@@ -24,6 +24,11 @@ bool GameMechanism::isSerialized() const
    return _serialized;
 }
 
+std::optional<GameMechanismObserver::LuaVariant> GameMechanism::getProperty(const std::string&) const
+{
+   return std::nullopt;
+}
+
 bool GameMechanism::isDestructible() const
 {
    return false;

--- a/src/game/mechanisms/gamemechanism.h
+++ b/src/game/mechanisms/gamemechanism.h
@@ -5,6 +5,7 @@
 #include "game/constants.h"
 #include "game/level/chunk.h"
 #include "game/level/hitbox.h"
+#include "game/mechanisms/gamemechanismobserver.h"
 
 #include "SFML/Graphics.hpp"
 
@@ -12,6 +13,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <string>
 
 struct Room;
 
@@ -161,6 +163,12 @@ public:
    /// \brief checks whether this mechanism contributes to save-state serialization.
    /// \return true when serializeState and deserializeState are expected to be used.
    virtual bool isSerialized() const;
+
+   /// \brief reads one named runtime property so level scripts can derive their state from this mechanism
+   /// instead of keeping a duplicate copy of it in the save state.
+   /// \param property_name name of the property to read.
+   /// \return property value when this mechanism exposes the property, std::nullopt otherwise.
+   virtual std::optional<GameMechanismObserver::LuaVariant> getProperty(const std::string& property_name) const;
 
    /// \brief checks whether this mechanism can receive damage and be destroyed.
    /// \return true when hit points and destruction are implemented.

--- a/src/game/mechanisms/treasurechest.cpp
+++ b/src/game/mechanisms/treasurechest.cpp
@@ -349,6 +349,17 @@ void TreasureChest::serializeState(nlohmann::json& json_object)
    json_object[getObjectId()] = {{"open", _state != State::Closed}};
 }
 
+std::optional<GameMechanismObserver::LuaVariant> TreasureChest::getProperty(const std::string& property_name) const
+{
+   if (property_name == "open")
+   {
+      // consistent with serializeState, a chest that is opening already counts as open
+      return _state != State::Closed;
+   }
+
+   return std::nullopt;
+}
+
 void TreasureChest::deserializeState(const nlohmann::json& json_object)
 {
    if (!json_object.at("open").get<bool>())

--- a/src/game/mechanisms/treasurechest.h
+++ b/src/game/mechanisms/treasurechest.h
@@ -53,6 +53,11 @@ public:
    /// \param json json object containing previously serialized state.
    void deserializeState(const nlohmann::json& json) override;
 
+   /// \brief exposes chest state to level scripts. supported property: "open".
+   /// \param property_name name of the property to read.
+   /// \return true when the chest is no longer closed, std::nullopt for unknown properties.
+   std::optional<GameMechanismObserver::LuaVariant> getProperty(const std::string& property_name) const override;
+
 private:
    enum class Alignment
    {


### PR DESCRIPTION
## Why

The catacombs locked box shows different text depending on whether it is open, but that text was
only switched off by the `mechanismEvent` handler at the moment the chest opened. `TreasureChest`
already persists its own open state, so after a reload the chest came back open while
`locked_message` and the interaction help came back enabled from their tmx defaults — an opened box
claiming to be locked.

The two options were remembering the flag in a new lua-side save mechanism, or deriving the text
from the box. This takes the second route: the chest already owns that fact, so a lua flag would be
a second source of truth. It also matches `initDrawer()` in the same script, which already derives
its whole visual state from `inventoryHas("key")`.

Replaying the event from `deserializeState` was not an option — `Level::loadSaveState()` runs before
`loadLevelScript()`, so the script is not listening yet. The script has to pull.

## What

**Engine, reusable for any mechanism**

- `virtual GameMechanism::getProperty(property_name)` returning
  `std::optional<GameMechanismObserver::LuaVariant>`. Base returns `nullopt`, mechanisms opt in.
- `TreasureChest` exposes `"open"`, using the same `_state != State::Closed` rule as
  `serializeState` so an opening chest counts as open in both places.
- `LevelScript::getMechanismProperty` reuses the existing search callback.
- Lua binding `getMechanismProperty(object_id, group, property_name)`, pushing bool / integer /
  number / string, or `nil` when nothing matches or the property is unknown.

Any mechanism that already implements `serializeState` can expose the same fields with a few lines.

**Catacombs**

`initLockedBox()` runs next to the existing `initLocker()` / `initDrawer()` on the first update tick
and disables `locked_message`, `locked_box_interaction_help` and `handle_help` when the chest
reports open — mirroring exactly what the `state`/`open` branch of `mechanismEvent` does.

**Docs**

- `doc/level_scripts/readme.md` — API entry for `getMechanismProperty`, with the table of mechanisms
  that currently expose properties and how to add more.
- `doc/level_design/mechanisms.md` — the treasure chest section now says its events are not replayed
  on load, and documents the readable `open` property.

## Worth knowing

The `group` argument is the **tmx layer name** `treasure_chests`, not the `treasurechests` group id
that `mechanismEvent` reports for the same chest. A wrong group returns `nil` silently and the `if`
never fires, so this fails looking like it works. Called out in both docs.

Also note `getMechanismProperty(id, group, key)` puts `group` in the middle, unlike
`isMechanismEnabled(id, group)` and friends which put it last and optional. Easy to flip if you
prefer the family shape.

## Testing

Drove the Debug build with a temporary log line in `initLockedBox`:

- save state with `locked_box.open = true` → property returns `true`
- fresh save state → returns `false`, not `nil`, confirming the lookup actually resolves

Build passes, clang-format run on all nine touched C++ files.

## Not included

Scoped to the locked box, but both of these are nearby:

- `diamond_box_interaction_help` has the identical problem and the identical one-line fix.
- The locker is **not** derivable — `openLocker()` flips an imagelayer and consumes `locker_key`, so
  `inventoryHas` cannot tell "never had it" from "used it". Same for `_monk_hide`. Those are the
  real case for a generic script key/value store if we want one later.
