### PR TITLE
fix(lighting): keep the head torch shadow origin out of pushed boxes

### DIFF
--- a/src/game/effects/lightsystem.cpp
+++ b/src/game/effects/lightsystem.cpp
@@ -103,7 +103,7 @@ void LightSystem::drawShadowQuads(
 #endif
 ) const
 {
-   const auto light_pos_m = light->_pos_m + light->_center_offset_m;
+   const auto light_pos_m = light->_shadow_origin_m.value_or(light->_pos_m + light->_center_offset_m);
 
 #ifdef __EMSCRIPTEN__
    sf::RenderStates shadow_states = states;

--- a/src/game/effects/lightsystem.h
+++ b/src/game/effects/lightsystem.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <unordered_set>
 #include <vector>
 
@@ -33,6 +34,11 @@ public:
       b2Vec2 _pos_m = b2Vec2{0.0f, 0.0f};            //!< world position of the light in box2d meters
       b2Vec2 _center_offset_m = b2Vec2{0.0f, 0.0f};  //!< offset from the light's box2d position to the center of its sprite
       sf::Vector2i _center_offset_px;                //!< pixel offset used for sprite positioning
+
+      /// \brief world position to cast shadows from, overriding the sprite center. owners whose
+      ///        light sits close to solid geometry can use this to keep the origin outside occluder
+      ///        polygons; an origin inside a polygon leaves that polygon's interior unshadowed.
+      std::optional<b2Vec2> _shadow_origin_m;
 
       sf::Color _color = {255, 255, 255, 80};
 

--- a/src/game/items/itemheadtorch.cpp
+++ b/src/game/items/itemheadtorch.cpp
@@ -2,6 +2,7 @@
 
 #include "itemheadtorch.h"
 
+#include <algorithm>
 #include <fstream>
 
 #include "framework/easings/easings.h"
@@ -169,6 +170,23 @@ void ItemHeadTorch::update(const sf::Time& delta_time)
    sfcompat::setOrigin(*active_light->_sprite, {0.0f, 0.0f});
    active_light->_pos_m = light_pos_m;
    active_light->updateSpritePosition();
+
+   // the beam casts its shadows from the lamp end, which sits right about on the player's own
+   // collision edge. anything adam presses against - a moveable box he is pushing, or a wall he is
+   // standing at - then has its near face at that very position, and once the origin slips inside
+   // that polygon every edge extrudes away from an interior point, so nothing shadows the polygon's
+   // interior and the box lights up from within. keeping the origin comfortably inside the player's
+   // own collision half width (0.16m, see Player::createBody) means it can never end up inside
+   // something the player is touching.
+   constexpr auto shadow_origin_max_offset_x_m = 0.12f;
+   const auto body_position_m = player->getBody()->GetPosition();
+   const auto sprite_shadow_origin_m = light_pos_m + active_light->_center_offset_m;
+   active_light->_shadow_origin_m = b2Vec2{
+      std::clamp(
+         sprite_shadow_origin_m.x, body_position_m.x - shadow_origin_max_offset_x_m, body_position_m.x + shadow_origin_max_offset_x_m
+      ),
+      sprite_shadow_origin_m.y
+   };
 
    // set rotation origin at the lamp end in local texture coords (512x512 texture, scaled to display size)
    const sf::Vector2f sprite_scale = sfcompat::getScale(*active_light->_sprite);


### PR DESCRIPTION
## Problem

With the head torch equipped, pushing a moveable box would sometimes light up the inside of the box.

The head torch casts its shadows from the lamp end of the beam sprite (`_pos_m + _center_offset_m`, where `_pos_m` is the sprite *center*). Combining `data/config/player_headtorch.json` with the real eye positions from `data/sprites/eye_positions.json`, that origin lands at:

- facing right: `body + (45−37, 16−48)` = `body + (8, −32)` px
- facing left: `body + (26−35, 15−48)` = `body + (−9, −33)` px

The player's collision box is `0.16 m = 7.68 px` half width (`Player::createBody`), so the shadow origin sits **on** Adam's own collision edge — precisely where the near face of a box he is pushing ends up.

Once the origin crosses inside that polygon, every edge extrudes its shadow quad away from an interior point, so nothing covers the interior and the box lights up from within.

Two things made it intermittent rather than constant: the eye x drifts across the run cycle, and the landing jitter adds `0.35 m ≈ 17 px` of horizontal swing on top. Vertically it predicts 48 px boxes leaking while 24 px ones don't, since the origin at `body − 32 px` clears a short box but sits inside a tall one.

## Fix

Clamp the shadow origin's x into ±0.12 m of the player body, so it can never leave the player's own collision silhouette and therefore never end up inside something the player is touching.

Clamping x alone is sufficient: with the origin horizontally outside the box, the near vertical face extrudes correctly and shadows the interior whether the origin is above the box or beside it.

Notable choices:

- **Unconditional, not proximity-gated** — no pop when a box comes into contact. It permanently shifts the origin ~2–3 px toward the body, which is invisible on a 256 px beam.
- **y is untouched** — the beam keeps its head-height origin, so nothing about how it looks changes.
- **New `std::optional<b2Vec2> _shadow_origin_m` on `LightInstance`** rather than adjusting `_center_offset_m`. That field is `sf::Vector2i` in its pixel form and also feeds the bump-map light position (`lightsystem.cpp:349`), so overloading it would force integer rounding and drag the normal-map lighting along.
- Static level geometry is chain shapes with the identical inside-the-polygon failure, so this also fixes walls Adam stands against, not just boxes.

## Testing

- Desktop release builds and links clean.
- Both changed `.cpp` files pass `em++ -fsyntax-only` for the WASM/VRSFML path.
- clang-format run on all three files.
- Verified in-game by @varnholt.
