### PR TITLE
Link the binaries directly in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,25 @@ The complete documentation lives in [doc/readme.md](doc/readme.md). The most tra
 
 # Get a Build
 
-Every push to `master` is built for all four targets by GitHub Actions. Pick the latest run of
-[your platform's workflow](https://github.com/varnholt/deceptus_engine/actions) and grab the
-artifact at the bottom of the summary page. The Linux and macOS artifacts ship the shared
-libraries next to the binary along with a `run.sh` that points the loader at them.
+Every push to `master` is built for all four targets. These links always give you the newest
+successful build and need no GitHub account:
+
+|Platform|Download|
+|-|-|
+|Windows|[deceptus-windows.zip](https://nightly.link/varnholt/deceptus_engine/workflows/windows/master/deceptus-windows.zip)|
+|Linux|[deceptus-linux.zip](https://nightly.link/varnholt/deceptus_engine/workflows/linux/master/deceptus-linux.zip)|
+|macOS|[deceptus-macos.zip](https://nightly.link/varnholt/deceptus_engine/workflows/macos/master/deceptus-macos.zip)|
+|Web|[deceptus-wasm.zip](https://nightly.link/varnholt/deceptus_engine/workflows/wasm/master/deceptus-wasm.zip)|
+
+The desktop archives contain the executable next to the `data/` directory. On Linux and macOS the
+shared libraries come along in `lib/` with a `run.sh` that points the loader at them, so start
+those through `run.sh`. The web archive holds the Emscripten output and needs a server that sends
+the `COOP`/`COEP` headers described under [Web (WebAssembly)](#web-webassembly).
+
+The links resolve through [nightly.link](https://nightly.link), which hands out the artifact of
+the latest successful workflow run. That indirection exists because GitHub only serves Actions
+artifacts to signed-in users. If you are signed in you can equally take them straight from the
+[workflow runs](https://github.com/varnholt/deceptus_engine/actions).
 
 
 # How to Build


### PR DESCRIPTION
Follow-up to #405: the "Get a Build" section pointed at the workflow run pages, which turns out to be useless for most visitors.

GitHub only serves Actions artifacts to signed-in users — an anonymous request for one answers **404**, which I verified against a real artifact URL. With no releases and no tags in the repository, someone arriving without a GitHub account had no way to obtain a build; the itch.io web build was the only thing they could actually run.

So the section now carries a per-platform table of direct links:

| Platform | Artifact |
|-|-|
| Windows | `deceptus-windows.zip` |
| Linux | `deceptus-linux.zip` |
| macOS | `deceptus-macos.zip` |
| Web | `deceptus-wasm.zip` |

These resolve through [nightly.link](https://nightly.link), which hands out the artifact of the latest successful run for a given workflow and branch. All four verified to return a 302 to a real signed zip without any credentials. The signed-in route via the workflow runs page is kept as the alternative.

Also documents what each archive actually holds — the desktop ones pair the executable with `data/`, Linux and macOS additionally ship `lib/` plus the `run.sh` that points the loader at it, and the web archive is Emscripten output that needs the `COOP`/`COEP` headers the build section describes.

Worth noting the trade-off: nightly.link is a third-party redirect, so the front page now sends users through a service outside this project. The first-party alternative is a release workflow that attaches the four zips to a tagged GitHub Release — permanent links, no third party, but nothing appears until a tag is pushed. Happy to write that as a follow-up if you'd prefer to own the whole path.
