### PR TITLE
Write a minidump on unhandled exceptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,8 @@ set(GAME_FILES
     src/framework/tools/checksum.cpp
     src/framework/tools/elapsedtimer.cpp
     src/framework/tools/elapsedtimer.h
+    src/framework/tools/crashhandler.cpp
+    src/framework/tools/crashhandler.h
     src/framework/tools/gamepaths.cpp
     src/framework/tools/gamepaths.h
     src/framework/tools/globalclock.cpp
@@ -1057,6 +1059,9 @@ endif()
 
 if(WIN32)
     target_link_libraries(deceptus PRIVATE opengl32 glu32)
+
+    # MiniDumpWriteDump, used by the crash handler
+    target_link_libraries(deceptus PRIVATE dbghelp)
 
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         set_target_properties(deceptus PROPERTIES WIN32_EXECUTABLE FALSE)

--- a/src/framework/tools/crashhandler.cpp
+++ b/src/framework/tools/crashhandler.cpp
@@ -1,0 +1,84 @@
+#include "crashhandler.h"
+
+#ifdef _WIN32
+
+#include <windows.h>
+// dbghelp.h has to come after windows.h
+#include <dbghelp.h>
+
+#include <ctime>
+#include <filesystem>
+#include <iomanip>
+#include <sstream>
+
+#include "framework/tools/gamepaths.h"
+
+namespace
+{
+
+std::filesystem::path dumpPath()
+{
+   auto directory = GamePaths::getGameDataDir() / "crashdumps";
+   std::error_code error;
+   std::filesystem::create_directories(directory, error);
+
+   const auto now = std::time(nullptr);
+   std::tm local{};
+   localtime_s(&local, &now);
+
+   std::ostringstream filename;
+   filename << std::put_time(&local, "%Y-%m-%d__%H-%M-%S") << ".dmp";
+   return directory / filename.str();
+}
+
+LONG WINAPI writeMiniDump(EXCEPTION_POINTERS* exception_pointers)
+{
+   const auto path = dumpPath();
+
+   auto* file = CreateFileW(path.wstring().c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+   if (file != INVALID_HANDLE_VALUE)
+   {
+      MINIDUMP_EXCEPTION_INFORMATION exception_info{};
+      exception_info.ThreadId = GetCurrentThreadId();
+      exception_info.ExceptionPointers = exception_pointers;
+      exception_info.ClientPointers = FALSE;
+
+      // MiniDumpWithThreadInfo and the memory ranges keep enough context to walk every thread's
+      // stack afterwards, which is the point: these crashes only happen with no debugger attached.
+      const auto type = static_cast<MINIDUMP_TYPE>(
+         MiniDumpWithThreadInfo | MiniDumpWithIndirectlyReferencedMemory | MiniDumpWithDataSegs | MiniDumpWithHandleData
+      );
+
+      MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), file, type, &exception_info, nullptr, nullptr);
+      CloseHandle(file);
+
+      // the log thread is very likely gone by now, so report on stderr where it is still visible
+      fwprintf(stderr, L"\ncrash dump written to %s\n", path.wstring().c_str());
+      fflush(stderr);
+   }
+
+   return EXCEPTION_EXECUTE_HANDLER;
+}
+
+}  // namespace
+
+namespace CrashHandler
+{
+
+void install()
+{
+   SetUnhandledExceptionFilter(writeMiniDump);
+}
+
+}  // namespace CrashHandler
+
+#else
+
+namespace CrashHandler
+{
+void install()
+{
+}
+}  // namespace CrashHandler
+
+#endif

--- a/src/framework/tools/crashhandler.h
+++ b/src/framework/tools/crashhandler.h
@@ -1,0 +1,14 @@
+#pragma once
+
+/// \brief writes a minidump when the process dies from an unhandled exception.
+namespace CrashHandler
+{
+
+/// \brief installs the unhandled exception filter.
+/// \details on windows an access violation that reaches the top of the stack normally kills the
+///          process silently, leaving nothing to inspect unless a debugger happened to be attached.
+///          this writes a minidump to <appdata>/deceptus/crashdumps so a crash that only reproduces
+///          without a debugger can still be analysed afterwards. a no-op on other platforms.
+void install();
+
+}  // namespace CrashHandler

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,7 @@
 #include <emscripten.h>
 #endif
 
+#include "framework/tools/crashhandler.h"
 #include "framework/tools/gamepaths.h"
 #include "framework/tools/localization.h"
 #include "framework/tools/logthread.h"
@@ -71,6 +72,8 @@ int main(int /*argc*/, char** /*argv*/)
       emscripten_sleep(50);
    }
 #endif
+
+   CrashHandler::install();
 
    GamePaths::createGameDirectories();
 


### PR DESCRIPTION
On Windows an access violation that reaches the top of the stack kills the process silently, leaving nothing to inspect unless a debugger happened to be attached.

That is exactly the case that needs inspecting for the level-loading crash: it reproduces reliably with no debugger and **not once** under `cdb` across four runs, so the stack was unreachable until now. This is what finally produced one.

## What it does

`SetUnhandledExceptionFilter` writes a minidump to `<appdata>/deceptus/crashdumps/<timestamp>.dmp` and reports the path on stderr. Installed first thing in `main`, before `GamePaths::createGameDirectories`.

Analyse with:

```
cdb -z <dump> -y <build dir> -c ".ecxr; kn 25; q"
```

`.ecxr` matters — without it cdb lands on the dump-writing thread rather than the faulting one.

## Portability

`crashhandler.cpp` is `#ifdef _WIN32` with an empty `install()` for every other platform, and `dbghelp` is linked only inside `if(WIN32)`. Linux, macOS and the wasm build compile the same call as a no-op.

## Caveat

The Release config emits no PDB, so dumps from it are unsymbolised — the stacks below came from `build_deb`. Adding `/Zi` and `/DEBUG` to Release would make production dumps readable; not done here to keep this change small.

## What it already found

Two symbolised stacks from the level-transition crash, same fault in the driver, different shader owner:

```
nvoglv64+0x58fa54
sf::Shader::getUniformLocation+0x159
sf::Shader::setUniform+0x63
sfcompat::Shader::setUniform<sf::Texture>+0x8c
LightSystem::draw+0x193          ← and, after fixing that one, ShaderLayer::draw+0x142
Level::draw → Game::draw → timedDraw → loop → main
```

Every `sf::Shader` created during level load is built on the `std::async` loader thread under its own `sf::Context`. Loading `LightSystem`'s shader on first draw instead removed it from the stack and the identical fault moved to the next shader created during load. Other sites in the same position: `shaderlayer.cpp:198`, `level.cpp:181`, `stenciltilemap.cpp:40`, `luanode.cpp:137`, `gateway.cpp:820`, `destructibleblockingrect.cpp:104`, `itemheadtorch.cpp:306`.

No fix attempted here — this PR is the diagnostic tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)