### PR TITLE
fix the level reload crash: delete the outgoing level on the drawing thread, before the loader starts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,8 @@ set(GAME_FILES
     src/framework/tools/elapsedtimer.h
     src/framework/tools/crashhandler.cpp
     src/framework/tools/crashhandler.h
+    src/framework/tools/filewatcher.cpp
+    src/framework/tools/filewatcher.h
     src/framework/tools/gamepaths.cpp
     src/framework/tools/gamepaths.h
     src/framework/tools/globalclock.cpp

--- a/src/framework/tools/filewatcher.cpp
+++ b/src/framework/tools/filewatcher.cpp
@@ -1,0 +1,62 @@
+#include "filewatcher.h"
+
+#include "framework/tools/log.h"
+
+FileWatcher::~FileWatcher()
+{
+   stop();
+}
+
+void FileWatcher::start(const std::filesystem::path& path, const std::string& description, std::chrono::milliseconds poll_interval)
+{
+   if (_active)
+   {
+      return;
+   }
+
+   _path = path;
+   _description = description;
+   _poll_interval = poll_interval;
+   _modified = false;
+   _active = true;
+
+   _thread = std::thread([this]() { poll(); });
+}
+
+void FileWatcher::stop()
+{
+   _active = false;
+   _stop_condition.notify_all();
+
+   if (_thread.joinable())
+   {
+      _thread.join();
+   }
+}
+
+bool FileWatcher::modified() const
+{
+   return _modified;
+}
+
+void FileWatcher::poll()
+{
+   // the error_code overload throughout: a file being rewritten right now can fail to stat, and an
+   // exception escaping this thread would take the process down
+   std::error_code error;
+   auto reference_time = std::filesystem::last_write_time(_path, error);
+
+   while (_active)
+   {
+      const auto current_time = std::filesystem::last_write_time(_path, error);
+      if (!error && current_time != reference_time)
+      {
+         Log::Info() << _description << " was modified, marking as dirty";
+         reference_time = current_time;
+         _modified = true;
+      }
+
+      std::unique_lock<std::mutex> lock(_mutex);
+      _stop_condition.wait_for(lock, _poll_interval, [this]() { return !_active.load(); });
+   }
+}

--- a/src/framework/tools/filewatcher.h
+++ b/src/framework/tools/filewatcher.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <filesystem>
+#include <mutex>
+#include <string>
+#include <thread>
+
+//! \brief watches a single file and reports whether it has been modified since watching started.
+//!
+//! Polls the file's last write time on a background thread. The poll interval is waited out on a
+//! condition variable rather than slept through, so stop() - and therefore the destructor - returns
+//! immediately instead of blocking for up to a full interval. That matters wherever the owning
+//! object is destroyed on a thread that must not stall, such as a render loop.
+class FileWatcher
+{
+public:
+   FileWatcher() = default;
+   ~FileWatcher();
+
+   FileWatcher(const FileWatcher&) = delete;
+   FileWatcher& operator=(const FileWatcher&) = delete;
+
+   /// \brief starts watching a file; does nothing if already watching.
+   /// \param path file to watch.
+   /// \param description name used when logging a detected change.
+   /// \param poll_interval how often the write time is checked.
+   void start(
+      const std::filesystem::path& path,
+      const std::string& description,
+      std::chrono::milliseconds poll_interval = std::chrono::seconds{1}
+   );
+
+   /// \brief stops watching and joins the thread; safe to call more than once.
+   void stop();
+
+   /// \brief returns whether the file changed since start() was called.
+   bool modified() const;
+
+private:
+   void poll();
+
+   std::filesystem::path _path;
+   std::string _description;
+   std::chrono::milliseconds _poll_interval{std::chrono::seconds{1}};
+
+   std::thread _thread;
+   std::atomic<bool> _active{false};
+   std::atomic<bool> _modified{false};
+   std::mutex _mutex;
+   std::condition_variable _stop_condition;
+};

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -391,6 +391,61 @@ void Game::showPauseMenu()
 
 void Game::loadLevel(LoadingMode loading_mode)
 {
+   // Only record the request here; the teardown and the load itself happen at the top of the next
+   // frame, in processPendingLevelLoad(). See the note there for why.
+   //
+   // Flipping the flags right away is what stops update() and draw() touching the outgoing level in
+   // the meantime, so callers still get "the level is going away" semantics immediately.
+   _level_loading_finished = false;
+   _level_loading_finished_previous = false;
+   _info_layer->setLoading(true);
+
+   _pending_level_load = loading_mode;
+}
+
+void Game::processPendingLevelLoad()
+{
+   if (!_pending_level_load.has_value())
+   {
+      return;
+   }
+
+   const auto loading_mode = _pending_level_load.value();
+   _pending_level_load.reset();
+
+   // Destroy the outgoing level here: on the thread that owns the drawing context, and strictly
+   // before the loader thread is started.
+   //
+   // The thread matters because the loader activates its own sf::Context. Destroying the level there
+   // deletes its GL objects - every shader, every texture - from a context other than the one that
+   // draws them. Loading then recreates those objects and the driver hands out the same GL handles
+   // again, while the drawing context still resolves those handles to the objects it saw before,
+   // which have just been freed. The first draw after a reload then walks freed driver memory and
+   // dies inside glGetUniformLocation.
+   //
+   // The ordering matters just as much: a Level constructor resets shared state that the outgoing
+   // level's nodes still belong to (LuaInterface::reset() destroys its LuaNodes, and ~GameNode
+   // deregisters from its parent). Letting that run on the loader thread while this thread tears the
+   // old level down has the two of them mutating the same node lists at once. Destroying first, then
+   // loading, keeps it sequential.
+   //
+   // And doing all of it a frame late rather than inside loadLevel() is what keeps it off the level's
+   // own call stack: a load can be requested from inside the level's update, by a lua script calling
+   // nextLevel().
+   _player->resetWorld();  // free the pointer that's shared with the player
+   LevelRegistry::clearCurrent();
+
+   const auto teardown_start = std::chrono::steady_clock::now();
+   _level.reset();
+   const auto teardown_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - teardown_start).count();
+
+   // only worth mentioning when it actually cost a frame
+   if (teardown_ms > 16)
+   {
+      Log::Info() << "previous level torn down in " << teardown_ms << "ms";
+   }
+
    const auto level_loader = [this, loading_mode]()
    {
    // create an opengl context for this thread
@@ -450,36 +505,6 @@ void Game::loadLevel(LoadingMode loading_mode)
       loader_context.setActive(false);
 #endif
    };
-
-   _level_loading_finished = false;
-   _level_loading_finished_previous = false;
-   _info_layer->setLoading(true);
-
-   // Hand the previous level over to the main thread for destruction instead of letting the loader
-   // thread destroy it.
-   //
-   // The loader runs in its own sf::Context, so destroying the level there deletes its GL objects
-   // (every shader, every texture) from a context other than the one that draws them. Level loading
-   // then recreates those objects and the driver hands out the same GL handles again, while the
-   // drawing context still resolves those handles to the objects it saw before - which have just
-   // been freed. The first draw after a reload then walks freed driver memory and dies inside
-   // glGetUniformLocation.
-   //
-   // The destruction is deferred to the top of the next frame rather than run right here: a level
-   // load can be requested from inside the level's own update (a lua script calling nextLevel()),
-   // and freeing it on the spot would pull the object out from under the call stack still running in
-   // it.
-   _player->resetWorld();  // free the pointer that's shared with the player
-   LevelRegistry::clearCurrent();
-
-#ifdef __EMSCRIPTEN__
-   // single threaded, and the loader below runs synchronously in this very context, so there is no
-   // cross-context handle to protect. Freeing right away also keeps peak memory down, which matters
-   // more in a browser than the deferral would gain.
-   _level.reset();
-#else
-   _level_pending_teardown = std::move(_level);
-#endif
 
 #ifdef __EMSCRIPTEN__
    level_loader();
@@ -1091,7 +1116,7 @@ int32_t Game::loop()
       [](void* arg)
       {
          Game* game = static_cast<Game*>(arg);
-         game->destroyPendingLevel();
+         game->processPendingLevelLoad();
          game->processEvents();
          game->timedUpdate();
          game->timedDraw();
@@ -1104,7 +1129,7 @@ int32_t Game::loop()
 #else
    while (_window->isOpen())
    {
-      destroyPendingLevel();
+      processPendingLevelLoad();
       processEvents();
       timedUpdate();
       timedDraw();
@@ -1112,27 +1137,6 @@ int32_t Game::loop()
 
    return 0;
 #endif
-}
-
-void Game::destroyPendingLevel()
-{
-   if (!_level_pending_teardown)
-   {
-      return;
-   }
-
-   // runs on the thread that owns the drawing context, and outside any call stack belonging to the
-   // level being destroyed - see the note in loadLevel()
-   const auto teardown_start = std::chrono::steady_clock::now();
-   _level_pending_teardown.reset();
-   const auto teardown_ms =
-      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - teardown_start).count();
-
-   // only worth mentioning when it actually cost a frame
-   if (teardown_ms > 16)
-   {
-      Log::Info() << "previous level torn down in " << teardown_ms << "ms";
-   }
 }
 
 void Game::reset()

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -46,6 +46,7 @@
 #include <emscripten/html5.h>
 #endif
 
+#include <chrono>
 #include <ctime>
 #include <iomanip>
 #include <iostream>
@@ -398,10 +399,6 @@ void Game::loadLevel(LoadingMode loading_mode)
       loader_context.setActive(true);
 #endif
 
-      _player->resetWorld();  // free the pointer that's shared with the player
-      LevelRegistry::clearCurrent();
-      _level.reset();
-
       // load level
       const auto level_item = Levels::readLevelItem(SaveState::getCurrent()._level_index);
       _level = std::make_shared<Level>(_render_targets);
@@ -457,6 +454,33 @@ void Game::loadLevel(LoadingMode loading_mode)
    _level_loading_finished = false;
    _level_loading_finished_previous = false;
    _info_layer->setLoading(true);
+
+   // Hand the previous level over to the main thread for destruction instead of letting the loader
+   // thread destroy it.
+   //
+   // The loader runs in its own sf::Context, so destroying the level there deletes its GL objects
+   // (every shader, every texture) from a context other than the one that draws them. Level loading
+   // then recreates those objects and the driver hands out the same GL handles again, while the
+   // drawing context still resolves those handles to the objects it saw before - which have just
+   // been freed. The first draw after a reload then walks freed driver memory and dies inside
+   // glGetUniformLocation.
+   //
+   // The destruction is deferred to the top of the next frame rather than run right here: a level
+   // load can be requested from inside the level's own update (a lua script calling nextLevel()),
+   // and freeing it on the spot would pull the object out from under the call stack still running in
+   // it.
+   _player->resetWorld();  // free the pointer that's shared with the player
+   LevelRegistry::clearCurrent();
+
+#ifdef __EMSCRIPTEN__
+   // single threaded, and the loader below runs synchronously in this very context, so there is no
+   // cross-context handle to protect. Freeing right away also keeps peak memory down, which matters
+   // more in a browser than the deferral would gain.
+   _level.reset();
+#else
+   _level_pending_teardown = std::move(_level);
+#endif
+
 #ifdef __EMSCRIPTEN__
    level_loader();
 #else
@@ -1000,7 +1024,9 @@ void Game::update()
          // this might trigger level-reloading, so this ought to be the last drawing call in the loop
          updateGameState(dt);
 
-         if (_level->isDirty())
+         // a lua script can request a level change from inside the update above, which hands _level
+         // over for teardown, so it is not necessarily still there by the time we get here
+         if (_level && _level->isDirty())
          {
             reloadLevel(LoadingMode::Clean);
          }
@@ -1065,6 +1091,7 @@ int32_t Game::loop()
       [](void* arg)
       {
          Game* game = static_cast<Game*>(arg);
+         game->destroyPendingLevel();
          game->processEvents();
          game->timedUpdate();
          game->timedDraw();
@@ -1077,6 +1104,7 @@ int32_t Game::loop()
 #else
    while (_window->isOpen())
    {
+      destroyPendingLevel();
       processEvents();
       timedUpdate();
       timedDraw();
@@ -1084,6 +1112,27 @@ int32_t Game::loop()
 
    return 0;
 #endif
+}
+
+void Game::destroyPendingLevel()
+{
+   if (!_level_pending_teardown)
+   {
+      return;
+   }
+
+   // runs on the thread that owns the drawing context, and outside any call stack belonging to the
+   // level being destroyed - see the note in loadLevel()
+   const auto teardown_start = std::chrono::steady_clock::now();
+   _level_pending_teardown.reset();
+   const auto teardown_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - teardown_start).count();
+
+   // only worth mentioning when it actually cost a frame
+   if (teardown_ms > 16)
+   {
+      Log::Info() << "previous level torn down in " << teardown_ms << "ms";
+   }
 }
 
 void Game::reset()

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -27,6 +27,7 @@
 #include <SFML/Graphics.hpp>
 #include <SFML/System.hpp>
 #include <future>
+#include <optional>
 #include "box2d/box2d.h"
 
 class Level;
@@ -86,13 +87,14 @@ private:
    /// \brief calls draw() and submits frame timings to the profiling ui.
    void timedDraw();
 
-   /// \brief destroys the level handed over by the last loadLevel(), if any.
+   /// \brief carries out a level load requested by loadLevel(), if one is pending.
    ///
-   /// Called at the top of each frame so the previous level is released on the thread that owns the
-   /// drawing context, and never from inside a call stack running in that level.
-   void destroyPendingLevel();
+   /// Called at the top of each frame. Destroys the outgoing level on the thread that owns the
+   /// drawing context and strictly before the loader thread starts, and never from inside a call
+   /// stack running in that level.
+   void processPendingLevelLoad();
 
-   /// \brief asynchronously loads current save-state level and syncs player/world links.
+   /// \brief requests a load of the current save-state level; the work starts on the next frame.
    /// \param loading_mode loading strategy used by Level initialization.
    void loadLevel(LoadingMode loading_mode = LoadingMode::Standard);
 
@@ -176,8 +178,8 @@ private:
    std::shared_ptr<Player> _player;
    std::shared_ptr<Level> _level;
 
-   //! \brief previous level, waiting to be destroyed by destroyPendingLevel() on the main thread
-   std::shared_ptr<Level> _level_pending_teardown;
+   //! \brief load requested by loadLevel(), carried out by processPendingLevelLoad() next frame
+   std::optional<LoadingMode> _pending_level_load;
    std::unique_ptr<InfoLayer> _info_layer;
    std::unique_ptr<InGameMenu> _ingame_menu;
    std::unique_ptr<ControllerOverlay> _controller_overlay;

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -86,6 +86,12 @@ private:
    /// \brief calls draw() and submits frame timings to the profiling ui.
    void timedDraw();
 
+   /// \brief destroys the level handed over by the last loadLevel(), if any.
+   ///
+   /// Called at the top of each frame so the previous level is released on the thread that owns the
+   /// drawing context, and never from inside a call stack running in that level.
+   void destroyPendingLevel();
+
    /// \brief asynchronously loads current save-state level and syncs player/world links.
    /// \param loading_mode loading strategy used by Level initialization.
    void loadLevel(LoadingMode loading_mode = LoadingMode::Standard);
@@ -169,6 +175,9 @@ private:
    RenderTargets _render_targets;
    std::shared_ptr<Player> _player;
    std::shared_ptr<Level> _level;
+
+   //! \brief previous level, waiting to be destroyed by destroyPendingLevel() on the main thread
+   std::shared_ptr<Level> _level_pending_teardown;
    std::unique_ptr<InfoLayer> _info_layer;
    std::unique_ptr<InGameMenu> _ingame_menu;
    std::unique_ptr<ControllerOverlay> _controller_overlay;

--- a/src/game/level/level.cpp
+++ b/src/game/level/level.cpp
@@ -222,11 +222,7 @@ Level::~Level()
    }
 
 #ifndef __EMSCRIPTEN__
-   _file_watcher_thread_active = false;
-   if (_file_watcher_thread.joinable())
-   {
-      _file_watcher_thread.join();
-   }
+   _file_watcher.stop();
 #endif
 }
 
@@ -489,28 +485,9 @@ bool Level::load()
 
    Log::Info() << "level loading complete";
 
-   // set up file watcher
+   // set up file watcher so a level edited while the game runs is picked up
 #ifndef __EMSCRIPTEN__
-   _file_watcher_thread = std::thread(
-      [this]()
-      {
-         auto first_modified_time = std::filesystem::last_write_time(_description->_filename);
-
-         while (_file_watcher_thread_active)
-         {
-            const auto current_modified_time = std::filesystem::last_write_time(_description->_filename);
-            if (current_modified_time != first_modified_time)
-            {
-               Log::Info() << "level was modified, marking as dirty";
-               first_modified_time = current_modified_time;
-               _dirty = true;
-            }
-
-            using namespace std::chrono_literals;
-            std::this_thread::sleep_for(1s);
-         }
-      }
-   );
+   _file_watcher.start(_description->_filename, "level");
 #endif
 
    return true;
@@ -1516,7 +1493,7 @@ void Level::setLoadingMode(LoadingMode loading_mode)
 
 bool Level::isDirty() const
 {
-   return _dirty;
+   return _file_watcher.modified();
 }
 
 // Level Rendering Flow

--- a/src/game/level/level.h
+++ b/src/game/level/level.h
@@ -1,6 +1,7 @@
 #pragma once
 
 // game
+#include "framework/tools/filewatcher.h"
 #include "framework/tools/sfmlshader.h"
 #include "game/audio/volumeupdater.h"
 #include "game/constants.h"
@@ -394,10 +395,8 @@ protected:
    std::vector<std::vector<b2Vec2>> _world_chains;
    Winding _winding = Winding::Clockwise;
 
-   // file watcher and re-generation
-   std::thread _file_watcher_thread;
-   bool _file_watcher_thread_active{true};
-   bool _dirty{false};
+   // watches the level's tmx so a level edited while the game runs is reloaded
+   FileWatcher _file_watcher;
    LoadingMode _loading_mode{LoadingMode::Standard};
 
 #ifdef DEVELOPMENT_MODE

--- a/src/game/level/levelscript.cpp
+++ b/src/game/level/levelscript.cpp
@@ -849,7 +849,18 @@ void LevelScript::fadeOut(float speed)
    transition->_effect_1 = fade_out;
    transition->_effect_2 = _pending_fade_in;
    transition->_autostart_effect_2 = false;
-   transition->_callbacks_effect_1_ended.emplace_back([this]() { luaMechanismEvent("fade", "", "out_done", true); });
+   // the handler outlives this script, so the callback must not touch the lua state once the level
+   // it belongs to has been torn down
+   transition->_callbacks_effect_1_ended.emplace_back(
+      [this, alive = std::weak_ptr<bool>{_alive_token}]()
+      {
+         if (alive.expired())
+         {
+            return;
+         }
+         luaMechanismEvent("fade", "", "out_done", true);
+      }
+   );
    transition->_callbacks_effect_2_ended.emplace_back([]() { ScreenTransitionHandler::getInstance().pop(); });
 
    transition->startEffect1();
@@ -875,9 +886,13 @@ void LevelScript::fadeIn(float speed)
       transition->_effect_1 = null_effect;
       transition->_effect_2 = fade_in;
       transition->_callbacks_effect_2_ended.emplace_back(
-         [this]()
+         [this, alive = std::weak_ptr<bool>{_alive_token}]()
          {
             ScreenTransitionHandler::getInstance().pop();
+            if (alive.expired())
+            {
+               return;
+            }
             luaMechanismEvent("fade", "", "in_done", true);
          }
       );

--- a/src/game/level/levelscript.h
+++ b/src/game/level/levelscript.h
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <lua.hpp>
 #include <map>
+#include <memory>
 #include <string>
 #include <variant>
 #include <vector>
@@ -420,4 +421,12 @@ private:
       _event_observer_reference;
 
    std::shared_ptr<FadeTransitionEffect> _pending_fade_in;
+
+   //! \brief lifetime token for callbacks handed to objects that outlive this script.
+   //!
+   //! fadeOut()/fadeIn() push a ScreenTransition into ScreenTransitionHandler, a singleton that
+   //! outlives the level. Those transitions call back into the lua state, so a fade still in flight
+   //! when the level is replaced would otherwise run against a closed lua_State. The callbacks hold
+   //! a weak_ptr to this token and do nothing once it has expired.
+   std::shared_ptr<bool> _alive_token{std::make_shared<bool>(true)};
 };


### PR DESCRIPTION
Loading a level a second time crashed on the first frame after the load. Five earlier attempts missed it for one reason: **it only reproduces on the discrete NVIDIA GPU.** On the Intel integrated GPU the same sequence is harmless, so the failing path was never being executed during testing.

## What the dump said

The minidump from the crash handler pointed straight at it:

```
nvoglv64                                    <- access violation
sf::Shader::getUniformLocation
sf::Shader::UniformBinder::UniformBinder
sf::Shader::setUniform
AtmosphereShader::update
Level::draw
Game::draw
```

The faulting driver instruction dereferenced a pointer whose value was float payload — `rcx = 3f8000003f80000f`, and `0x3f800000` is `1.0f`. So the driver resolved a program handle to an object and read recycled memory: the program had been freed.

## Cause

`Game::loadLevel()` ran on a worker thread that activates its own `sf::Context`, and it destroyed the outgoing level *there*. That deleted every GL object the level owned — shaders, textures — from a context other than the one that draws them. Loading then recreated those objects and the driver handed out **the same GL handles again** (instrumentation showed program `11` freed and reissued as `11`), while the drawing context still resolved that handle to the object it had cached before, now freed.

Nothing shader-specific about it: whichever shader was used first in the frame died, so it surfaced as `AtmosphereShader::update` or `LightSystem::draw` depending on timing. Two hypotheses were tested and ruled out — a stale `GL_CURRENT_PROGRAM` binding (it reads `0` every frame, so SFML always rebinds) and missing cross-context visibility (a `glFinish()` on the loader thread changed nothing).

## Fix

Level teardown has to satisfy **three** constraints at once, and getting any one wrong crashes:

1. **On the thread that owns the drawing context** — otherwise the GL fault above.
2. **Strictly before the loader thread starts.** `Level::Level` calls `LuaInterface::reset()`, which destroys the *outgoing* level's `LuaNode`s, and `~GameNode` deregisters each from its parent's children list. Running that on the loader thread while the main thread tears the old level down has both mutating the same node lists.
3. **Not from inside the level's own call stack** — a load can be requested from inside `Level::update()`, by a lua script calling `nextLevel()`.

All three are satisfied by deferring the **whole load** by one frame: `loadLevel()` only records the request and flips the loading flags (so `update()`/`draw()` stop touching the outgoing level immediately), and `processPendingLevelLoad()` runs at the top of the next frame — destroying the old level and *only then* starting the loader. That also preserves the original invariant: exactly one `Level` alive, the old one fully gone before the new one is constructed.

The first version of this PR deferred only the teardown, which satisfied 1 and 3 but broke 2; see the commit `delete the outgoing level before the loader starts, not alongside it` and the comment below for that stack.

## Two things surfaced while verifying

- **`~Level()` joined a thread that slept a full second between polls**, so main-thread teardown would have frozen the frame loop for up to a second per level change. The watcher is now its own `FileWatcher` class that waits on a condition variable instead of sleeping, so stopping it returns at once — teardown measures 2–31ms. This also lifts a thread, two atomics, a mutex and a condition variable out of `Level`, and its flags are atomic now: they were read from the main thread and written from the watcher with no synchronisation at all.
- **`LevelScript::fadeOut`/`fadeIn` handed `[this]`-capturing callbacks to `ScreenTransitionHandler`**, a singleton that outlives the level, so a fade still in flight when the level was replaced called into a closed `lua_State`. They now hold a `weak_ptr` to a lifetime token. This one crashed on the *sixth* consecutive reload, once the GL fault was out of the way.

## Verification

- **Reload path** — automated, via `lab/record_gameplay` on the NVIDIA GPU: 20 alternating `level load graveyard` / `level load intro` cycles, no crash, no minidump, and rendering intact afterwards (parallax backdrop, lighting, rain, HUD), so this is not just "stopped crashing".
- **Control** — reverting only the teardown change makes it die on the **first** reload, same harness, same sequence.
- **New game path** (start game → exit level → delete slot → new game → start) — confirmed manually by @varnholt. Scripting that menu flow did not work, so it has **no** automated coverage.

Desktop is built and exercised; the Emscripten path is compile-checked by CI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
