### PR TITLE
add full screen post processing with a configurable mechanism

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -565,6 +565,10 @@ set(GAME_FILES
     src/game/shaders/deathshader.h
     src/game/shaders/gammashader.cpp
     src/game/shaders/gammashader.h
+    src/game/shaders/postprocessing.cpp
+    src/game/shaders/postprocessing.h
+    src/game/mechanisms/postprocessingmechanism.cpp
+    src/game/mechanisms/postprocessingmechanism.h
     src/game/state/displaymode.cpp
     src/game/state/displaymode.h
     src/game/state/gamestate.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,6 +551,8 @@ set(GAME_FILES
     src/game/player/timerlock.h
     src/game/player/weaponsystem.cpp
     src/game/player/weaponsystem.h
+    src/game/rendering/postprocessingpass.cpp
+    src/game/rendering/postprocessingpass.h
     src/game/rendering/rendertargets.cpp
     src/game/rendering/rendertargets.h
     src/game/scenes/forestscene.cpp

--- a/data/shaders/gameboy.frag
+++ b/data/shaders/gameboy.frag
@@ -1,0 +1,115 @@
+// renders the composited frame at game boy resolution and reduces it to the 4 color dmg palette.
+// the grid size arrives in normalized units so the effect looks identical at every window scale.
+//
+// the tone curve is what makes this readable: the game is lit far below the palette thresholds,
+// so without it almost every pixel collapses into the darkest color. it is a reinhard curve
+// rather than a linear window on purpose - a linear one clips everything above its white point to
+// the lightest color, which turned brightly lit sprites such as the player into flat silhouettes.
+// this one never reaches 1.0, so highlights keep their relative differences and stay shaded.
+// u_mid_grey is the input luminance that lands halfway up the palette.
+
+#ifdef GL_ES
+uniform sampler2D u_texture;
+uniform vec2 u_grid_size;
+uniform float u_black_point;
+uniform float u_mid_grey;
+
+const vec3 dmg_darkest = vec3(0.059, 0.220, 0.059);
+const vec3 dmg_dark = vec3(0.188, 0.384, 0.188);
+const vec3 dmg_light = vec3(0.545, 0.675, 0.059);
+const vec3 dmg_lightest = vec3(0.608, 0.737, 0.059);
+
+// a full palette step of dither turns the whole image into checkerboard noise, this only
+// softens the edges between the four bands
+const float dither_strength = 0.06;
+
+in vec2 sf_v_texCoord;
+
+layout(location = 0) out vec4 sf_fragColor;
+
+// closed form 2x2 bayer matrix: [[0.0, 0.5], [0.75, 0.25]]
+float bayer2x2(vec2 pixel_position)
+{
+   vec2 cell = floor(pixel_position);
+   return fract(cell.x * 0.5 + cell.y * cell.y * 0.75);
+}
+
+// 4x4 ordered dither threshold built from two nested 2x2 matrices. without it the
+// luminance quantization collapses gradients into flat blobs instead of the stippled
+// shading the real hardware produced.
+float bayer4x4(vec2 pixel_position)
+{
+   return bayer2x2(pixel_position * 0.5) * 0.25 + bayer2x2(pixel_position);
+}
+
+void main()
+{
+   // snap to the low resolution grid and sample the center of each grid cell
+   vec2 grid_position = floor(sf_v_texCoord * u_grid_size);
+   vec2 uv = (grid_position + 0.5) / u_grid_size;
+
+   vec4 color = texture(u_texture, uv);
+
+   float luminance = dot(color.rgb, vec3(0.299, 0.587, 0.114));
+   luminance = max(luminance - u_black_point, 0.0);
+   luminance = luminance / (luminance + u_mid_grey);
+   luminance += (bayer4x4(grid_position) - 0.5) * dither_strength;
+
+   vec3 palette_color = dmg_darkest;
+   palette_color = mix(palette_color, dmg_dark, step(0.25, luminance));
+   palette_color = mix(palette_color, dmg_light, step(0.50, luminance));
+   palette_color = mix(palette_color, dmg_lightest, step(0.75, luminance));
+
+   sf_fragColor = vec4(palette_color, color.a);
+}
+#else
+uniform sampler2D u_texture;
+uniform vec2 u_grid_size;
+uniform float u_black_point;
+uniform float u_mid_grey;
+
+const vec3 dmg_darkest = vec3(0.059, 0.220, 0.059);
+const vec3 dmg_dark = vec3(0.188, 0.384, 0.188);
+const vec3 dmg_light = vec3(0.545, 0.675, 0.059);
+const vec3 dmg_lightest = vec3(0.608, 0.737, 0.059);
+
+// a full palette step of dither turns the whole image into checkerboard noise, this only
+// softens the edges between the four bands
+const float dither_strength = 0.06;
+
+// closed form 2x2 bayer matrix: [[0.0, 0.5], [0.75, 0.25]]
+float bayer2x2(vec2 pixel_position)
+{
+   vec2 cell = floor(pixel_position);
+   return fract(cell.x * 0.5 + cell.y * cell.y * 0.75);
+}
+
+// 4x4 ordered dither threshold built from two nested 2x2 matrices. without it the
+// luminance quantization collapses gradients into flat blobs instead of the stippled
+// shading the real hardware produced.
+float bayer4x4(vec2 pixel_position)
+{
+   return bayer2x2(pixel_position * 0.5) * 0.25 + bayer2x2(pixel_position);
+}
+
+void main()
+{
+   // snap to the low resolution grid and sample the center of each grid cell
+   vec2 grid_position = floor(gl_TexCoord[0].xy * u_grid_size);
+   vec2 uv = (grid_position + 0.5) / u_grid_size;
+
+   vec4 color = texture2D(u_texture, uv);
+
+   float luminance = dot(color.rgb, vec3(0.299, 0.587, 0.114));
+   luminance = max(luminance - u_black_point, 0.0);
+   luminance = luminance / (luminance + u_mid_grey);
+   luminance += (bayer4x4(grid_position) - 0.5) * dither_strength;
+
+   vec3 palette_color = dmg_darkest;
+   palette_color = mix(palette_color, dmg_dark, step(0.25, luminance));
+   palette_color = mix(palette_color, dmg_light, step(0.50, luminance));
+   palette_color = mix(palette_color, dmg_lightest, step(0.75, luminance));
+
+   gl_FragColor = vec4(palette_color, color.a);
+}
+#endif

--- a/data/shaders/gameboy.frag
+++ b/data/shaders/gameboy.frag
@@ -1,18 +1,26 @@
 // renders the composited frame at game boy resolution and reduces it to the 4 color dmg palette.
-// the grid size arrives in normalized units so the effect looks identical at every window scale.
+// the grid is derived from u_resolution, the size of the game's own pixel grid, so the effect
+// looks identical at every window scale.
 //
 // the tone curve is what makes this readable: the game is lit far below the palette thresholds,
 // so without it almost every pixel collapses into the darkest color. it is a reinhard curve
 // rather than a linear window on purpose - a linear one clips everything above its white point to
 // the lightest color, which turned brightly lit sprites such as the player into flat silhouettes.
 // this one never reaches 1.0, so highlights keep their relative differences and stay shaded.
-// u_mid_grey is the input luminance that lands halfway up the palette.
+// mid_grey is the input luminance that lands halfway up the palette, tuned against the catacombs
+// so the player keeps its shading; raise it to darken the image.
 
 #ifdef GL_ES
 uniform sampler2D u_texture;
-uniform vec2 u_grid_size;
-uniform float u_black_point;
-uniform float u_mid_grey;
+uniform vec2 u_resolution;
+
+// screen size in game boy pixels, expressed as a divisor of the view so it stays an integer
+// divisor of the pixel grid at any window scale. raise it for chunkier pixels
+const float grid_divisor = 1.0;
+
+// tone curve constants, see the note above
+const float black_point = 0.0;
+const float mid_grey = 0.17;
 
 const vec3 dmg_darkest = vec3(0.059, 0.220, 0.059);
 const vec3 dmg_dark = vec3(0.188, 0.384, 0.188);
@@ -45,14 +53,15 @@ float bayer4x4(vec2 pixel_position)
 void main()
 {
    // snap to the low resolution grid and sample the center of each grid cell
-   vec2 grid_position = floor(sf_v_texCoord * u_grid_size);
-   vec2 uv = (grid_position + 0.5) / u_grid_size;
+   vec2 grid_size = u_resolution / grid_divisor;
+   vec2 grid_position = floor(sf_v_texCoord * grid_size);
+   vec2 uv = (grid_position + 0.5) / grid_size;
 
    vec4 color = texture(u_texture, uv);
 
    float luminance = dot(color.rgb, vec3(0.299, 0.587, 0.114));
-   luminance = max(luminance - u_black_point, 0.0);
-   luminance = luminance / (luminance + u_mid_grey);
+   luminance = max(luminance - black_point, 0.0);
+   luminance = luminance / (luminance + mid_grey);
    luminance += (bayer4x4(grid_position) - 0.5) * dither_strength;
 
    vec3 palette_color = dmg_darkest;
@@ -64,9 +73,15 @@ void main()
 }
 #else
 uniform sampler2D u_texture;
-uniform vec2 u_grid_size;
-uniform float u_black_point;
-uniform float u_mid_grey;
+uniform vec2 u_resolution;
+
+// screen size in game boy pixels, expressed as a divisor of the view so it stays an integer
+// divisor of the pixel grid at any window scale. raise it for chunkier pixels
+const float grid_divisor = 1.0;
+
+// tone curve constants, see the note above
+const float black_point = 0.0;
+const float mid_grey = 0.17;
 
 const vec3 dmg_darkest = vec3(0.059, 0.220, 0.059);
 const vec3 dmg_dark = vec3(0.188, 0.384, 0.188);
@@ -95,14 +110,15 @@ float bayer4x4(vec2 pixel_position)
 void main()
 {
    // snap to the low resolution grid and sample the center of each grid cell
-   vec2 grid_position = floor(gl_TexCoord[0].xy * u_grid_size);
-   vec2 uv = (grid_position + 0.5) / u_grid_size;
+   vec2 grid_size = u_resolution / grid_divisor;
+   vec2 grid_position = floor(gl_TexCoord[0].xy * grid_size);
+   vec2 uv = (grid_position + 0.5) / grid_size;
 
    vec4 color = texture2D(u_texture, uv);
 
    float luminance = dot(color.rgb, vec3(0.299, 0.587, 0.114));
-   luminance = max(luminance - u_black_point, 0.0);
-   luminance = luminance / (luminance + u_mid_grey);
+   luminance = max(luminance - black_point, 0.0);
+   luminance = luminance / (luminance + mid_grey);
    luminance += (bayer4x4(grid_position) - 0.5) * dither_strength;
 
    vec3 palette_color = dmg_darkest;

--- a/data/shaders/glitch.frag
+++ b/data/shaders/glitch.frag
@@ -1,0 +1,83 @@
+// tears the composited frame apart in short bursts: horizontal bands jump sideways,
+// the color channels drift apart while a burst is active and scanlines darken the image.
+// between bursts the frame passes through untouched apart from the scanlines.
+// u_pixel_size is the size of one game pixel in uv space, so the channel separation and
+// the scanline spacing stay tied to game pixels rather than to the window resolution.
+
+#ifdef GL_ES
+uniform sampler2D u_texture;
+uniform vec2 u_pixel_size;
+uniform float u_time;
+
+in vec2 sf_v_texCoord;
+
+layout(location = 0) out vec4 sf_fragColor;
+
+float hash(float seed)
+{
+   return fract(sin(seed * 12.9898) * 43758.5453);
+}
+
+void main()
+{
+   vec2 uv = sf_v_texCoord;
+
+   // most burst slots stay quiet, roughly every third one tears
+   float burst_slot = floor(u_time * 2.0);
+   float burst = step(0.72, hash(burst_slot));
+
+   // horizontal bands, reshuffled several times within a single burst
+   float band = floor(uv.y * 28.0);
+   float band_noise = hash(band + burst_slot * 17.0 + floor(u_time * 18.0) * 3.0) - 0.5;
+   float band_active = step(0.55, abs(band_noise) * 2.0);
+   float displacement = band_noise * 0.06 * burst * band_active;
+   uv.x += displacement;
+
+   vec2 separation = vec2(6.0 * burst * band_active, 0.0) * u_pixel_size;
+   float red = texture(u_texture, uv + separation).r;
+   float green = texture(u_texture, uv).g;
+   float blue = texture(u_texture, uv - separation).b;
+   float alpha = texture(u_texture, uv).a;
+
+   vec3 color = vec3(red, green, blue);
+   color *= 1.0 - 0.12 * step(0.5, fract(uv.y / (u_pixel_size.y * 2.0)));
+
+   sf_fragColor = vec4(color, alpha);
+}
+#else
+uniform sampler2D u_texture;
+uniform vec2 u_pixel_size;
+uniform float u_time;
+
+float hash(float seed)
+{
+   return fract(sin(seed * 12.9898) * 43758.5453);
+}
+
+void main()
+{
+   vec2 uv = gl_TexCoord[0].xy;
+
+   // most burst slots stay quiet, roughly every third one tears
+   float burst_slot = floor(u_time * 2.0);
+   float burst = step(0.72, hash(burst_slot));
+
+   // horizontal bands, reshuffled several times within a single burst
+   float band = floor(uv.y * 28.0);
+   float band_noise = hash(band + burst_slot * 17.0 + floor(u_time * 18.0) * 3.0) - 0.5;
+   float band_active = step(0.55, abs(band_noise) * 2.0);
+   float displacement = band_noise * 0.06 * burst * band_active;
+   uv.x += displacement;
+
+   vec2 separation = vec2(6.0 * burst * band_active, 0.0) * u_pixel_size;
+   float red = texture2D(u_texture, uv + separation).r;
+   float green = texture2D(u_texture, uv).g;
+   float blue = texture2D(u_texture, uv - separation).b;
+   float alpha = texture2D(u_texture, uv).a;
+
+   vec3 color = vec3(red, green, blue);
+   color *= 1.0 - 0.12 * step(0.5, fract(uv.y / (u_pixel_size.y * 2.0)));
+
+   gl_FragColor = vec4(color, alpha);
+}
+#endif

--- a/data/shaders/rgb_split.frag
+++ b/data/shaders/rgb_split.frag
@@ -1,0 +1,50 @@
+// separates the color channels horizontally, like a badly converged crt.
+// the separation breathes slowly so the fringe does not look like a static offset.
+// u_pixel_size is the size of one game pixel in uv space, so u_offset stays a game
+// pixel count and the fringe keeps its width at any window scale.
+
+#ifdef GL_ES
+uniform sampler2D u_texture;
+uniform vec2 u_pixel_size;
+uniform float u_offset;
+uniform float u_time;
+
+in vec2 sf_v_texCoord;
+
+layout(location = 0) out vec4 sf_fragColor;
+
+void main()
+{
+   vec2 uv = sf_v_texCoord;
+
+   float wobble = 1.0 + sin(u_time * 1.7) * 0.35;
+   vec2 separation = vec2(u_offset * wobble, 0.0) * u_pixel_size;
+
+   float red = texture(u_texture, uv + separation).r;
+   float green = texture(u_texture, uv).g;
+   float blue = texture(u_texture, uv - separation).b;
+   float alpha = texture(u_texture, uv).a;
+
+   sf_fragColor = vec4(red, green, blue, alpha);
+}
+#else
+uniform sampler2D u_texture;
+uniform vec2 u_pixel_size;
+uniform float u_offset;
+uniform float u_time;
+
+void main()
+{
+   vec2 uv = gl_TexCoord[0].xy;
+
+   float wobble = 1.0 + sin(u_time * 1.7) * 0.35;
+   vec2 separation = vec2(u_offset * wobble, 0.0) * u_pixel_size;
+
+   float red = texture2D(u_texture, uv + separation).r;
+   float green = texture2D(u_texture, uv).g;
+   float blue = texture2D(u_texture, uv - separation).b;
+   float alpha = texture2D(u_texture, uv).a;
+
+   gl_FragColor = vec4(red, green, blue, alpha);
+}
+#endif

--- a/data/shaders/rgb_split.frag
+++ b/data/shaders/rgb_split.frag
@@ -1,13 +1,15 @@
 // separates the color channels horizontally, like a badly converged crt.
 // the separation breathes slowly so the fringe does not look like a static offset.
-// u_pixel_size is the size of one game pixel in uv space, so u_offset stays a game
+// u_pixel_size is the size of one game pixel in uv space, so the offset stays a game
 // pixel count and the fringe keeps its width at any window scale.
 
 #ifdef GL_ES
 uniform sampler2D u_texture;
 uniform vec2 u_pixel_size;
-uniform float u_offset;
 uniform float u_time;
+
+// horizontal channel separation in game pixels
+const float channel_offset = 2.0;
 
 in vec2 sf_v_texCoord;
 
@@ -18,7 +20,7 @@ void main()
    vec2 uv = sf_v_texCoord;
 
    float wobble = 1.0 + sin(u_time * 1.7) * 0.35;
-   vec2 separation = vec2(u_offset * wobble, 0.0) * u_pixel_size;
+   vec2 separation = vec2(channel_offset * wobble, 0.0) * u_pixel_size;
 
    float red = texture(u_texture, uv + separation).r;
    float green = texture(u_texture, uv).g;
@@ -30,15 +32,17 @@ void main()
 #else
 uniform sampler2D u_texture;
 uniform vec2 u_pixel_size;
-uniform float u_offset;
 uniform float u_time;
+
+// horizontal channel separation in game pixels
+const float channel_offset = 2.0;
 
 void main()
 {
    vec2 uv = gl_TexCoord[0].xy;
 
    float wobble = 1.0 + sin(u_time * 1.7) * 0.35;
-   vec2 separation = vec2(u_offset * wobble, 0.0) * u_pixel_size;
+   vec2 separation = vec2(channel_offset * wobble, 0.0) * u_pixel_size;
 
    float red = texture2D(u_texture, uv + separation).r;
    float green = texture2D(u_texture, uv).g;

--- a/doc/development_hotkeys.md
+++ b/doc/development_hotkeys.md
@@ -55,6 +55,19 @@ All hotkeys in this document are only active in `DEVELOPMENT_MODE` builds, excep
 
 ## Developer Console (`F12`)
 
+### Finding commands
+
+The help panel on the right reacts to what you type, so it never lists more than you need:
+
+| Input | Panel shows |
+|-------|-------------|
+| _(nothing typed)_ | The topic names only |
+| any text | Every command whose description contains that text |
+| `help <command>` | The matching commands together with their usage examples |
+
+Examples are deliberately hidden until you ask for them with `help`, and the panel is capped to the
+height of the screen; whatever does not fit is reported as `+n more, keep typing`.
+
 ### Navigation
 
 | Command | Action |

--- a/doc/level_design/mechanisms.md
+++ b/doc/level_design/mechanisms.md
@@ -1072,6 +1072,100 @@ In the screenshot above, Adam enters at the top left, exits at the bottom right,
 
 
 
+## Post Processing
+
+A post processing mechanism applies a full screen shader to the rendered frame. Where a Shader Quad draws a shader inside its own rectangle, this one processes the picture the game has already drawn, so it is the mechanism to use for effects that colour, distort or filter the whole screen: a Game Boy look, a chromatic aberration, a glitch, a heat haze, a nightmare tint.
+
+Unlike every other mechanism it does not draw anything itself. It hands its shader to the post processing stage, which runs after the level has been composited.
+
+Three fragment shaders ship with the engine and can be used as a starting point: `data/shaders/gameboy.frag`, `data/shaders/rgb_split.frag` and `data/shaders/glitch.frag`.
+
+### Object Type / Object Group
+
+|Method|Value|
+|-|-|
+|Object Type|`PostProcessing`|
+|Object Group|`post_processing`|
+
+### Object Properties
+
+|Property|Type|Description|
+|-|-|-|
+|fragment_shader|string|The relative path to your fragment shader. Without a fragment shader the mechanism is skipped.|
+|vertex_shader|string|The relative path to your vertex shader (optional).|
+|scope|string|`all` processes the whole frame including the HUD and menus (the default), `level` processes only the level so the HUD stays untouched on top.|
+|z|int|Used to pick a winner when several post processing mechanisms are enabled at once; the highest one is applied.|
+|u_*|any|Any property whose name starts with `u_` is passed to the shader as a uniform of that name. See _Shader uniforms_ below.|
+
+### Enabling the effect
+
+If the object rectangle has a size, it acts as a trigger area: the effect is active while the player is inside it and switches itself off again on the way out. This is the simplest way to make a room feel different without writing a single line of script.
+
+If you draw the rectangle with a width and height of `0`, the mechanism starts disabled and stays under the control of the level script:
+
+```lua
+setMechanismEnabled("nightmare_filter", true, "post_processing")
+```
+
+### Shader uniforms
+
+Every property starting with `u_` is forwarded to the shader as a uniform, so an arbitrary shader can be driven straight from Tiled without touching the C++ code. The Tiled property type decides the uniform type:
+
+|Tiled type|Becomes|
+|-|-|
+|float|`float`|
+|int|`int`|
+|bool|`bool`|
+|string with 2, 3 or 4 numbers separated by commas|`vec2`, `vec3`, `vec4`|
+|string holding a path to an existing file|`sampler2D` (the file is loaded as a texture)|
+
+On top of that the engine writes the following uniforms whenever a shader declares them. You do not have to configure these, and a shader that does not use one simply ignores it:
+
+|Uniform|Type|Description|
+|-|-|-|
+|u_texture|sampler2D|The frame being processed.|
+|u_time|float|Seconds since the mechanism was created; use this to animate.|
+|u_resolution|vec2|The size of the game's pixel grid (`640` x `360`), _not_ the window size. Deriving from this keeps an effect looking the same at every resolution.|
+|u_pixel_size|vec2|The size of one game pixel in UV space, i.e. `1.0 / u_resolution`. Multiply by this to express an offset in game pixels.|
+
+A word of warning on resolution: the game renders at an integer multiple of `640` x `360`, so if you work in window pixels your effect will change its look on every monitor. Derive sizes and offsets from `u_resolution` or `u_pixel_size` instead.
+
+### Example
+
+A corrupted room that renders the level in Game Boy colours while leaving the HUD readable:
+
+```xml
+<objectgroup name="post_processing">
+ <object name="corrupt_zone" x="1000" y="2450" width="600" height="500">
+  <properties>
+   <property name="fragment_shader" value="data/shaders/gameboy.frag"/>
+   <property name="scope" value="level"/>
+  </properties>
+ </object>
+</objectgroup>
+```
+
+### Debugging
+
+The debug console (F12) can force an effect regardless of what the level configures, which is handy while authoring a shader:
+
+|Command|Description|
+|-|-|
+|`postfx <none\|gameboy\|rgbsplit\|glitch>`|Select one of the built-in effects, `none` to switch off.|
+|`postfx scope <all\|level>`|Switch the scope of the console-selected effect.|
+
+A console-selected effect overrides the mechanism, so remember to run `postfx none` when you want to see the level's own effect again.
+
+---
+
+&nbsp;
+
+&nbsp;
+
+---
+
+
+
 ## Ropes
 
 The Deceptus Engine is able to connect other objects to ropes attached to mounts. So far this is only used for visual effects, later on - if there is any demand - the Engine can be extended to allow the player to hold on to the rope or attach other objects to it.

--- a/src/game/debug/console.cpp
+++ b/src/game/debug/console.cpp
@@ -1147,9 +1147,13 @@ std::vector<Console::Help::HelpLine> Console::Help::getVisibleLines(const std::s
       {
          std::vector<HelpLine> topic_lines;
 
+         // the panel offers the topic names as the way in, so typing one has to select that whole
+         // topic rather than being matched against the command descriptions and finding nothing
+         const auto topic_matches = toLowerCase(topic).contains(needle);
+
          for (const auto& command : _help_messages.at(topic))
          {
-            if (!needle.empty() && !toLowerCase(command.description).contains(needle))
+            if (!needle.empty() && !topic_matches && !toLowerCase(command.description).contains(needle))
             {
                continue;
             }

--- a/src/game/debug/console.cpp
+++ b/src/game/debug/console.cpp
@@ -34,6 +34,20 @@ void giveWeaponToPlayer(const std::shared_ptr<Weapon>& weapon)
    weapons._selected = weapon;
 }
 
+std::string toLowerCase(const std::string& text)
+{
+   std::string lower_case;
+   lower_case.reserve(text.size());
+   for (const auto character : text)
+   {
+      lower_case.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(character))));
+   }
+   return lower_case;
+}
+
+//! \brief console input prefix that switches the help panel into its detailed mode
+constexpr std::string_view help_prefix{"help"};
+
 std::string joinNames(const std::vector<std::string>& names)
 {
    std::string joined;
@@ -610,6 +624,26 @@ Console::Console()
       "ra: reload animations"
    );
 
+   // help
+   registerCallback(
+      "help",
+      [this](const auto& args)
+      {
+         // the panel already answers this live while typing, so executing it only needs to leave
+         // something in the log confirming what was looked up
+         if (args.size() < 2)
+         {
+            _log.emplace_back("help: type a command name to see its examples in the panel");
+            return;
+         }
+
+         _log.emplace_back("help: " + args.at(1));
+      },
+      "general",
+      "help <command>: show examples for a command in the help panel",
+      {"help postfx", "help tpp"}
+   );
+
    // rendering
    registerCallback(
       "postfx",
@@ -1075,6 +1109,93 @@ const std::deque<std::string>& Console::getLog() const
 void Console::Help::registerCommand(const std::string& topic, const std::string& description, const std::vector<std::string>& examples)
 {
    _help_messages[topic].emplace_back(HelpCommand{description, examples});
+}
+
+std::vector<Console::Help::HelpLine> Console::Help::getVisibleLines(const std::string& filter, size_t max_lines) const
+{
+   using Kind = HelpLine::Kind;
+
+   std::vector<std::string> sorted_topics;
+   sorted_topics.reserve(_help_messages.size());
+   for (const auto& entry : _help_messages)
+   {
+      sorted_topics.push_back(entry.first);
+   }
+   std::ranges::sort(sorted_topics);
+
+   // "help <something>" asks for detail about a command, which is the only case where the examples
+   // are worth the lines they cost
+   const auto trimmed = toLowerCase(filter).substr(0, filter.find_last_not_of(' ') + 1);
+   const auto detailed = trimmed.starts_with(help_prefix);
+   const auto search_term = detailed ? trimmed.substr(help_prefix.size()) : trimmed;
+   const auto needle = search_term.substr(std::min(search_term.find_first_not_of(' '), search_term.size()));
+
+   std::vector<HelpLine> lines;
+
+   // nothing to filter by: list the topics only, so the panel keeps its size as commands are added
+   if (needle.empty() && !detailed)
+   {
+      for (const auto& topic : sorted_topics)
+      {
+         lines.push_back({._kind = Kind::Topic, ._text = topic});
+      }
+      lines.push_back({._kind = Kind::Hint, ._text = "type to filter, 'help <command>' for examples"});
+   }
+   else
+   {
+      for (const auto& topic : sorted_topics)
+      {
+         std::vector<HelpLine> topic_lines;
+
+         for (const auto& command : _help_messages.at(topic))
+         {
+            if (!needle.empty() && !toLowerCase(command.description).contains(needle))
+            {
+               continue;
+            }
+
+            topic_lines.push_back({._kind = Kind::Command, ._text = command.description});
+
+            if (detailed)
+            {
+               for (const auto& example : command.examples)
+               {
+                  topic_lines.push_back({._kind = Kind::Example, ._text = example});
+               }
+            }
+         }
+
+         if (topic_lines.empty())
+         {
+            continue;
+         }
+
+         lines.push_back({._kind = Kind::Topic, ._text = topic});
+         lines.insert(lines.end(), topic_lines.begin(), topic_lines.end());
+      }
+
+      if (lines.empty())
+      {
+         lines.push_back({._kind = Kind::Hint, ._text = "no matching command"});
+      }
+   }
+
+   // hard clamp, so the panel cannot outgrow the screen again however many commands are added
+   if (max_lines > 0 && lines.size() > max_lines)
+   {
+      if (max_lines == 1)
+      {
+         lines.resize(1);
+      }
+      else
+      {
+         const auto hidden = lines.size() - (max_lines - 1);
+         lines.resize(max_lines - 1);
+         lines.push_back({._kind = Kind::Hint, ._text = "+" + std::to_string(hidden) + " more, keep typing"});
+      }
+   }
+
+   return lines;
 }
 
 std::string Console::Help::getFormattedHelp() const

--- a/src/game/debug/console.cpp
+++ b/src/game/debug/console.cpp
@@ -13,6 +13,7 @@
 #include "game/player/playerinfo.h"
 #include "game/player/playerregistry.h"
 #include "game/player/weaponsystem.h"
+#include "game/shaders/postprocessing.h"
 #include "game/state/gamestate.h"
 #include "game/state/savestate.h"
 #include "game/weapons/bow.h"
@@ -31,6 +32,30 @@ void giveWeaponToPlayer(const std::shared_ptr<Weapon>& weapon)
    auto& weapons = SaveState::getPlayerInfo()._weapons;
    weapons._weapons.push_back(weapon);
    weapons._selected = weapon;
+}
+
+std::string joinNames(const std::vector<std::string>& names)
+{
+   std::string joined;
+   for (const auto& name : names)
+   {
+      if (!joined.empty())
+      {
+         joined += '|';
+      }
+      joined += name;
+   }
+   return joined;
+}
+
+std::string joinEffectNames()
+{
+   return joinNames(PostProcessing::getEffectNames());
+}
+
+std::string joinScopeNames()
+{
+   return joinNames(PostProcessing::getScopeNames());
 }
 }  // namespace
 
@@ -583,6 +608,59 @@ Console::Console()
       [](const auto&) { std::static_pointer_cast<Player>(PlayerRegistry::getFirst())->reloadAnimationPool(); },
       "leveldesign",
       "ra: reload animations"
+   );
+
+   // rendering
+   registerCallback(
+      "postfx",
+      [this](const auto& args)
+      {
+         if (args.size() != 2)
+         {
+            _log.emplace_back("usage: postfx <" + joinEffectNames() + ">");
+            return;
+         }
+
+         const auto effect = PostProcessing::effectFromName(args.at(1));
+         if (!effect.has_value())
+         {
+            _log.emplace_back("unknown post processing effect: " + args.at(1));
+            _log.emplace_back("available effects: " + joinEffectNames());
+            return;
+         }
+
+         PostProcessing::getInstance().setEffect(effect.value());
+         _log.emplace_back("post processing effect: " + args.at(1));
+      },
+      "rendering",
+      "postfx <" + joinEffectNames() + ">: set the full screen post processing effect",
+      {"postfx gameboy", "postfx none"}
+   );
+
+   registerCallback(
+      "postfx scope",
+      [this](const auto& args)
+      {
+         if (args.size() != 3)
+         {
+            _log.emplace_back("usage: postfx scope <" + joinScopeNames() + ">");
+            return;
+         }
+
+         const auto scope = PostProcessing::scopeFromName(args.at(2));
+         if (!scope.has_value())
+         {
+            _log.emplace_back("unknown post processing scope: " + args.at(2));
+            _log.emplace_back("available scopes: " + joinScopeNames());
+            return;
+         }
+
+         PostProcessing::getInstance().setScope(scope.value());
+         _log.emplace_back("post processing scope: " + args.at(2));
+      },
+      "rendering",
+      "postfx scope <" + joinScopeNames() + ">: apply the effect to the whole frame or to the level only",
+      {"postfx scope level", "postfx scope all"}
    );
 }
 

--- a/src/game/debug/console.h
+++ b/src/game/debug/console.h
@@ -23,11 +23,38 @@ public:
    /// \brief groups help entries by topic and formats them for display in the console.
    struct Help
    {
+      /// \brief one rendered line of the help panel, classified so the renderer can indent and color it.
+      struct HelpLine
+      {
+         enum class Kind
+         {
+            Topic,
+            Command,
+            Example,
+            Hint
+         };
+
+         Kind _kind{Kind::Command};  //!< how the line should be indented and colored
+         std::string _text;          //!< text to render
+      };
+
       /// \brief adds a command description to a help topic.
       /// \param topic topic name used to group related commands.
       /// \param description one-line command description shown in help output.
       /// \param examples optional usage examples shown below the description.
       void registerCommand(const std::string& topic, const std::string& description, const std::vector<std::string>& examples = {});
+
+      /// \brief builds the help lines to show for the current console input.
+      ///
+      /// With nothing typed only the topic names are listed, so the panel stays a fixed handful of
+      /// lines no matter how many commands exist. Typing narrows the list to the commands matching
+      /// the input and reveals their examples, which are only interesting for the command actually
+      /// being reached for. The result never exceeds max_lines, so the panel cannot outgrow the
+      /// screen again however many commands are added later.
+      /// \param filter current console input, matched case insensitively against the descriptions.
+      /// \param max_lines maximum number of lines the caller is able to display.
+      /// \return lines to render, in display order.
+      std::vector<HelpLine> getVisibleLines(const std::string& filter, size_t max_lines) const;
 
       /// \brief builds a sorted, multi-line help text containing all registered topics and commands.
       /// \return formatted help text ready to print into the console log.

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -280,8 +280,8 @@ void Game::initializeRenderTargets()
       _window_render_texture.reset();
    }
 
-   // dropped rather than resized, createPostProcessingRenderTexture() rebuilds it at the new size
-   _post_processing_render_texture.reset();
+   // dropped rather than resized, the pass rebuilds it at the new size on next use
+   _post_processing_pass.release();
 
    // this the render texture size derived from the window dimensions. as opposed to the window
    // dimensions this one takes the view dimensions into regard and preserves an integer multiplier
@@ -327,31 +327,6 @@ void Game::initializeRenderTargets()
          game_config._video_mode_width, game_config._video_mode_height, game_config._view_width, game_config._view_height
       );
    }
-}
-
-bool Game::createPostProcessingRenderTexture()
-{
-   if (_post_processing_render_texture)
-   {
-      return true;
-   }
-
-   if (!_window_render_texture)
-   {
-      return false;
-   }
-
-   // must match the window render texture exactly, the level blits into it with the same geometry
-   const auto size = _window_render_texture->getSize();
-
-#ifndef __EMSCRIPTEN__
-   _post_processing_render_texture = std::make_shared<sf::RenderTexture>(size);
-#else
-   _post_processing_render_texture = std::make_shared<sf::RenderTexture>(std::move(*sf::RenderTexture::create(size)));
-#endif
-
-   Log::Info() << "created post processing render texture: " << size.x << " x " << size.y;
-   return true;
 }
 
 void Game::initializeController()
@@ -473,6 +448,12 @@ void Game::processPendingLevelLoad()
    // nextLevel().
    _player->resetWorld();  // free the pointer that's shared with the player
    LevelRegistry::clearCurrent();
+
+   // the intermediate post processing target belongs to the outgoing level's effects, so it is
+   // released here rather than kept for a level that may never ask for it. it is deliberately not
+   // released when an effect merely switches off: a trigger area toggling as the player walks in
+   // and out would otherwise reallocate a full screen target on every crossing
+   _post_processing_pass.release();
 
    const auto teardown_start = std::chrono::steady_clock::now();
    _level.reset();
@@ -714,61 +695,18 @@ void Game::draw()
 
    _window_render_texture->clear();
 
-   // with a level-scoped effect the level goes through an intermediate target so the effect can
-   // resolve it into the window render texture before any overlay is drawn on top of it
-   auto& post_processing = PostProcessing::getInstance();
-   post_processing.setLevelEffect(_level_loading_finished && _level ? _level->getActivePostProcessingMechanism() : nullptr);
+   // a level-scoped effect routes the level through an intermediate target so it can be resolved
+   // into the window render texture before any overlay is drawn on top of it
+   PostProcessing::getInstance().setLevelEffect(_level_loading_finished && _level ? _level->getActivePostProcessingMechanism() : nullptr);
 
-   const auto level_scope_active = _level_loading_finished && post_processing.isActive() &&
-                                   post_processing.getScope() == PostProcessing::Scope::Level && createPostProcessingRenderTexture();
+   const auto level_target = _post_processing_pass.selectLevelTarget(_window_render_texture, _level_loading_finished);
 
    if (_level_loading_finished)
    {
-      if (level_scope_active)
-      {
-         // Level::draw blits with view_to_texture_scale, which only fills the target when that
-         // target carries the level view. the window render texture happens to have it left over
-         // from the previous frame's overlays, a freshly created target does not, so it is set
-         // explicitly here rather than relying on that leftover
-#ifndef __EMSCRIPTEN__
-         const auto& game_config = GameConfiguration::getInstance();
-         const sf::View level_view{
-            sf::FloatRect{{0.0f, 0.0f}, {static_cast<float>(game_config._view_width), static_cast<float>(game_config._view_height)}}
-         };
-         _post_processing_render_texture->setView(level_view);
-         _window_render_texture->setView(level_view);
-#endif
-
-         _post_processing_render_texture->clear();
-         _level->draw(_post_processing_render_texture, _screenshot);
-         _post_processing_render_texture->display();
-
-         const sf::Texture& post_processing_texture = _post_processing_render_texture->getTexture();
-         const auto* level_post_processing_shader = post_processing.prepare(post_processing_texture);
-
-#ifdef __EMSCRIPTEN__
-         sf::Sprite post_processing_sprite;
-         post_processing_sprite.textureRect = sf::FloatRect{
-            {0.f, 0.f}, {static_cast<float>(post_processing_texture.getSize().x), static_cast<float>(post_processing_texture.getSize().y)}
-         };
-         _window_render_texture->draw(
-            post_processing_sprite, sf::RenderStates{.texture = &post_processing_texture, .shader = level_post_processing_shader}
-         );
-#else
-         // the window render texture still carries the level's 640x360 view, so this blit has to use
-         // the same scale Level::draw uses. without it the sprite covers three times the view, only
-         // a corner of it stays visible and the effect sees texture coordinates spanning 0..1/scale,
-         // which makes anything resolution dependent (the game boy grid) come out far too coarse
-         auto post_processing_sprite = sf::Sprite(post_processing_texture);
-         post_processing_sprite.scale({_render_targets.view_to_texture_scale, _render_targets.view_to_texture_scale});
-         _window_render_texture->draw(post_processing_sprite, level_post_processing_shader);
-#endif
-      }
-      else
-      {
-         _level->draw(_window_render_texture, _screenshot);
-      }
+      _level->draw(level_target, _screenshot);
    }
+
+   _post_processing_pass.resolveLevelTarget(*_window_render_texture.get(), _render_targets.view_to_texture_scale);
 
    _screenshot = false;
 
@@ -870,10 +808,8 @@ void Game::draw()
    }
 
    // a frame-scoped effect runs here, on the fully composited frame, i.e. on top of the level's
-   // gamma pass as well as on all overlays. a level-scoped one has already been resolved above,
-   // and deliberately does nothing at all while no level is running.
-   const sf::Shader* post_processing_shader =
-      (post_processing.getScope() == PostProcessing::Scope::All) ? post_processing.prepare(_window_render_texture->getTexture()) : nullptr;
+   // gamma pass as well as on all overlays. a level-scoped one has already been resolved above.
+   const auto* post_processing_shader = _post_processing_pass.getFrameShader(_window_render_texture->getTexture());
 
 #ifdef __EMSCRIPTEN__
    _window->draw(window_texture_sprite, sf::RenderStates{.texture = &window_render_texture_ref, .shader = post_processing_shader});

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -27,6 +27,7 @@
 #include "game/player/inventoryconfig.h"
 #include "game/player/player.h"
 #include "game/player/playerregistry.h"
+#include "game/shaders/postprocessing.h"
 #include "game/state/displaymode.h"
 #include "game/state/gamestate.h"
 #include "game/state/savestate.h"
@@ -279,6 +280,9 @@ void Game::initializeRenderTargets()
       _window_render_texture.reset();
    }
 
+   // dropped rather than resized, createPostProcessingRenderTexture() rebuilds it at the new size
+   _post_processing_render_texture.reset();
+
    // this the render texture size derived from the window dimensions. as opposed to the window
    // dimensions this one takes the view dimensions into regard and preserves an integer multiplier
    const auto ratio_width = game_config._video_mode_width / game_config._view_width;
@@ -323,6 +327,31 @@ void Game::initializeRenderTargets()
          game_config._video_mode_width, game_config._video_mode_height, game_config._view_width, game_config._view_height
       );
    }
+}
+
+bool Game::createPostProcessingRenderTexture()
+{
+   if (_post_processing_render_texture)
+   {
+      return true;
+   }
+
+   if (!_window_render_texture)
+   {
+      return false;
+   }
+
+   // must match the window render texture exactly, the level blits into it with the same geometry
+   const auto size = _window_render_texture->getSize();
+
+#ifndef __EMSCRIPTEN__
+   _post_processing_render_texture = std::make_shared<sf::RenderTexture>(size);
+#else
+   _post_processing_render_texture = std::make_shared<sf::RenderTexture>(std::move(*sf::RenderTexture::create(size)));
+#endif
+
+   Log::Info() << "created post processing render texture: " << size.x << " x " << size.y;
+   return true;
 }
 
 void Game::initializeController()
@@ -571,6 +600,8 @@ void Game::initialize()
 
    initializeController();
 
+   PostProcessing::getInstance().initialize();
+
    _player = std::make_shared<Player>();
    PlayerRegistry::add(_player);
    _player->initialize();
@@ -683,9 +714,60 @@ void Game::draw()
 
    _window_render_texture->clear();
 
+   // with a level-scoped effect the level goes through an intermediate target so the effect can
+   // resolve it into the window render texture before any overlay is drawn on top of it
+   auto& post_processing = PostProcessing::getInstance();
+   post_processing.setLevelEffect(_level_loading_finished && _level ? _level->getActivePostProcessingMechanism() : nullptr);
+
+   const auto level_scope_active = _level_loading_finished && post_processing.isActive() &&
+                                   post_processing.getScope() == PostProcessing::Scope::Level && createPostProcessingRenderTexture();
+
    if (_level_loading_finished)
    {
-      _level->draw(_window_render_texture, _screenshot);
+      if (level_scope_active)
+      {
+         // Level::draw blits with view_to_texture_scale, which only fills the target when that
+         // target carries the level view. the window render texture happens to have it left over
+         // from the previous frame's overlays, a freshly created target does not, so it is set
+         // explicitly here rather than relying on that leftover
+#ifndef __EMSCRIPTEN__
+         const auto& game_config = GameConfiguration::getInstance();
+         const sf::View level_view{
+            sf::FloatRect{{0.0f, 0.0f}, {static_cast<float>(game_config._view_width), static_cast<float>(game_config._view_height)}}
+         };
+         _post_processing_render_texture->setView(level_view);
+         _window_render_texture->setView(level_view);
+#endif
+
+         _post_processing_render_texture->clear();
+         _level->draw(_post_processing_render_texture, _screenshot);
+         _post_processing_render_texture->display();
+
+         const sf::Texture& post_processing_texture = _post_processing_render_texture->getTexture();
+         const auto* level_post_processing_shader = post_processing.prepare(post_processing_texture);
+
+#ifdef __EMSCRIPTEN__
+         sf::Sprite post_processing_sprite;
+         post_processing_sprite.textureRect = sf::FloatRect{
+            {0.f, 0.f}, {static_cast<float>(post_processing_texture.getSize().x), static_cast<float>(post_processing_texture.getSize().y)}
+         };
+         _window_render_texture->draw(
+            post_processing_sprite, sf::RenderStates{.texture = &post_processing_texture, .shader = level_post_processing_shader}
+         );
+#else
+         // the window render texture still carries the level's 640x360 view, so this blit has to use
+         // the same scale Level::draw uses. without it the sprite covers three times the view, only
+         // a corner of it stays visible and the effect sees texture coordinates spanning 0..1/scale,
+         // which makes anything resolution dependent (the game boy grid) come out far too coarse
+         auto post_processing_sprite = sf::Sprite(post_processing_texture);
+         post_processing_sprite.scale({_render_targets.view_to_texture_scale, _render_targets.view_to_texture_scale});
+         _window_render_texture->draw(post_processing_sprite, level_post_processing_shader);
+#endif
+      }
+      else
+      {
+         _level->draw(_window_render_texture, _screenshot);
+      }
    }
 
    _screenshot = false;
@@ -787,10 +869,16 @@ void Game::draw()
       );
    }
 
+   // a frame-scoped effect runs here, on the fully composited frame, i.e. on top of the level's
+   // gamma pass as well as on all overlays. a level-scoped one has already been resolved above,
+   // and deliberately does nothing at all while no level is running.
+   const sf::Shader* post_processing_shader =
+      (post_processing.getScope() == PostProcessing::Scope::All) ? post_processing.prepare(_window_render_texture->getTexture()) : nullptr;
+
 #ifdef __EMSCRIPTEN__
-   _window->draw(window_texture_sprite, sf::RenderStates{.texture = &window_render_texture_ref});
+   _window->draw(window_texture_sprite, sf::RenderStates{.texture = &window_render_texture_ref, .shader = post_processing_shader});
 #else
-   _window->draw(window_texture_sprite);
+   _window->draw(window_texture_sprite, post_processing_shader);
 #endif
 #ifndef __EMSCRIPTEN__
    _window->popGLStates();
@@ -1000,6 +1088,7 @@ void Game::update()
    Timer::update(Timer::Scope::UpdateAlways);
    MusicPlayer::getInstance().update(dt);
    MessageBox::update(dt);
+   PostProcessing::getInstance().update(dt);
 
    // update screen transitions here
    ScreenTransitionHandler::getInstance().update(dt);

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -19,6 +19,7 @@
 #include "game/layers/controlleroverlay.h"
 #include "game/layers/infolayer.h"
 #include "game/physics/physicsconfigurationui.h"
+#include "game/rendering/postprocessingpass.h"
 #include "game/rendering/rendertargets.h"
 #include "game/scenes/forestscene.h"
 #include "game/sfx/gameaudio.h"
@@ -74,14 +75,6 @@ private:
    /// \brief creates or recreates the render textures and deferred render targets for the
    ///        configured video mode, without touching the window itself.
    void initializeRenderTargets();
-
-   /// \brief creates the post processing render texture on first use.
-   ///
-   /// only the level-scoped post processing needs an intermediate target, so this is allocated
-   /// lazily instead of in initializeRenderTargets(): a session that never selects that scope
-   /// never pays for the texture.
-   /// \return true when the texture is available.
-   bool createPostProcessingRenderTexture();
 
    /// \brief initializes game controller integration and pause bindings.
    void initializeController();
@@ -183,9 +176,8 @@ private:
    std::shared_ptr<sf::RenderWindow> _window;
    std::shared_ptr<sf::RenderTexture> _window_render_texture;
 
-   //! \brief intermediate target the level renders into while post processing is level-scoped,
-   //!        created on demand by createPostProcessingRenderTexture()
-   std::shared_ptr<sf::RenderTexture> _post_processing_render_texture;
+   //! \brief owns the render target and blits needed to apply a post processing effect to the frame
+   PostProcessingPass _post_processing_pass;
    RenderTargets _render_targets;
    std::shared_ptr<Player> _player;
    std::shared_ptr<Level> _level;

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -75,6 +75,14 @@ private:
    ///        configured video mode, without touching the window itself.
    void initializeRenderTargets();
 
+   /// \brief creates the post processing render texture on first use.
+   ///
+   /// only the level-scoped post processing needs an intermediate target, so this is allocated
+   /// lazily instead of in initializeRenderTargets(): a session that never selects that scope
+   /// never pays for the texture.
+   /// \return true when the texture is available.
+   bool createPostProcessingRenderTexture();
+
    /// \brief initializes game controller integration and pause bindings.
    void initializeController();
 
@@ -174,6 +182,10 @@ private:
 
    std::shared_ptr<sf::RenderWindow> _window;
    std::shared_ptr<sf::RenderTexture> _window_render_texture;
+
+   //! \brief intermediate target the level renders into while post processing is level-scoped,
+   //!        created on demand by createPostProcessingRenderTexture()
+   std::shared_ptr<sf::RenderTexture> _post_processing_render_texture;
    RenderTargets _render_targets;
    std::shared_ptr<Player> _player;
    std::shared_ptr<Level> _level;

--- a/src/game/layers/infolayer.cpp
+++ b/src/game/layers/infolayer.cpp
@@ -270,7 +270,7 @@ void InfoLayer::loadInventoryItems()
       inventory_item_descriptions,
       [this](const auto& image)
       {
-         // store sprites
+   // store sprites
 #ifdef __EMSCRIPTEN__
          std::unique_ptr<sf::Sprite> sprite = std::make_unique<sf::Sprite>();
          sprite->textureRect = sf::FloatRect{
@@ -719,77 +719,55 @@ void InfoLayer::drawConsole(sf::RenderTarget& window, sf::RenderStates states)
    }
 
    // draw console help
-   line_index = 0;
+   const auto help_x_px = console_base_width_px / 2;
    const auto indent_px = console_base_width_px / 40;
-   const auto& help = console.help();
-   std::ostringstream oss;
+   // two lines of margin so the last one stays inside the console frame rather than on its border
+   const auto help_line_capacity = static_cast<size_t>(std::max(0, offset_y_px / line_spacing_px - 2));
+   const auto help_lines = console.help().getVisibleLines(command, help_line_capacity);
 
-   std::vector<std::string> sorted_topics;
-   sorted_topics.reserve(help._help_messages.size());
-   for (const auto& entry : help._help_messages)
+   line_index = 0;
+   for (const auto& help_line : help_lines)
    {
-      sorted_topics.push_back(entry.first);
-   }
+      auto text_x_px = help_x_px;
+      auto color = sf::Color::White;
 
-   std::ranges::sort(sorted_topics.begin(), sorted_topics.end());
-   for (const auto& topic : sorted_topics)
-   {
-#ifdef __EMSCRIPTEN__
-      console_text.setString(topic.c_str());
-#else
-      console_text.setString(topic);
-#endif
-      console_text.setFillColor(sf::Color::Green);
-#ifdef __EMSCRIPTEN__
-      console_text.position = {static_cast<float>(console_base_width_px / 2), static_cast<float>((++line_index) * line_spacing_px)};
-      window.draw(console_text, sf::RenderStates{.view = view_screen});
-#else
-      console_text.setPosition({static_cast<float>(console_base_width_px / 2), static_cast<float>((++line_index) * line_spacing_px)});
-      window.draw(console_text);
-#endif
-
-      const auto& commands = help._help_messages.at(topic);
-      for (const auto& command : commands)
+      switch (help_line._kind)
       {
-#ifdef __EMSCRIPTEN__
-         console_text.setString(command.description.c_str());
-#else
-         console_text.setString(command.description);
-#endif
-         console_text.setFillColor(sf::Color::White);
-#ifdef __EMSCRIPTEN__
-         console_text.position = {
-            static_cast<float>(console_base_width_px / 2 + indent_px), static_cast<float>((++line_index) * line_spacing_px)
-         };
-         window.draw(console_text, sf::RenderStates{.view = view_screen});
-#else
-         console_text.setPosition(
-            {static_cast<float>(console_base_width_px / 2 + indent_px), static_cast<float>((++line_index) * line_spacing_px)}
-         );
-         window.draw(console_text);
-#endif
-
-         for (const auto& example : command.examples)
+         case Console::Help::HelpLine::Kind::Topic:
          {
-#ifdef __EMSCRIPTEN__
-            console_text.setString(example.c_str());
-#else
-            console_text.setString(example);
-#endif
-            console_text.setFillColor(sf::Color::Red);
-#ifdef __EMSCRIPTEN__
-            console_text.position = {
-               static_cast<float>(console_base_width_px / 2 + indent_px * 2), static_cast<float>((++line_index) * line_spacing_px)
-            };
-            window.draw(console_text, sf::RenderStates{.view = view_screen});
-#else
-            console_text.setPosition(
-               {static_cast<float>(console_base_width_px / 2 + indent_px * 2), static_cast<float>((++line_index) * line_spacing_px)}
-            );
-            window.draw(console_text);
-#endif
+            color = sf::Color::Green;
+            break;
+         }
+         case Console::Help::HelpLine::Kind::Command:
+         {
+            text_x_px += indent_px;
+            break;
+         }
+         case Console::Help::HelpLine::Kind::Example:
+         {
+            text_x_px += indent_px * 2;
+            color = sf::Color::Red;
+            break;
+         }
+         case Console::Help::HelpLine::Kind::Hint:
+         {
+            color = sf::Color{128, 128, 128};
+            break;
          }
       }
+
+#ifdef __EMSCRIPTEN__
+      console_text.setString(help_line._text.c_str());
+#else
+      console_text.setString(help_line._text);
+#endif
+      console_text.setFillColor(color);
+      sfcompat::setPosition(console_text, {static_cast<float>(text_x_px), static_cast<float>((++line_index) * line_spacing_px)});
+#ifdef __EMSCRIPTEN__
+      window.draw(console_text, sf::RenderStates{.view = view_screen});
+#else
+      window.draw(console_text);
+#endif
    }
 }
 

--- a/src/game/level/gamemechanismregistry.cpp
+++ b/src/game/level/gamemechanismregistry.cpp
@@ -39,6 +39,7 @@ GameMechanismRegistry::GameMechanismRegistry()
       &_mechanism_on_off_blocks,
       &_mechanism_platforms,
       &_mechanism_portals,
+      &_mechanism_post_processing,
       &_mechanism_ropes,
       &_mechanism_rotating_blades,
       &_mechanism_sensor_rects,
@@ -90,6 +91,7 @@ GameMechanismRegistry::GameMechanismRegistry()
    _mechanisms_map[std::string{layer_name_on_off_blocks}] = &_mechanism_on_off_blocks;
    _mechanisms_map[std::string{layer_name_platforms}] = &_mechanism_platforms;
    _mechanisms_map[std::string{layer_name_portals}] = &_mechanism_portals;
+   _mechanisms_map[std::string{layer_name_post_processing}] = &_mechanism_post_processing;
    _mechanisms_map[std::string{layer_name_ropes}] = &_mechanism_ropes;
    _mechanisms_map[std::string{layer_name_rotating_blades}] = &_mechanism_rotating_blades;
    _mechanisms_map[std::string{layer_name_sensor_rects}] = &_mechanism_sensor_rects;

--- a/src/game/level/gamemechanismregistry.h
+++ b/src/game/level/gamemechanismregistry.h
@@ -103,6 +103,7 @@ private:
    MechanismVector _mechanism_on_off_blocks;
    MechanismVector _mechanism_platforms;
    MechanismVector _mechanism_portals;
+   MechanismVector _mechanism_post_processing;
    MechanismVector _mechanism_ropes;
    MechanismVector _mechanism_rotating_blades;
    MechanismVector _mechanism_sensor_rects;

--- a/src/game/level/level.cpp
+++ b/src/game/level/level.cpp
@@ -40,6 +40,7 @@
 #include "game/mechanisms/gamemechanismdeserializer.h"
 #include "game/mechanisms/gamemechanismdeserializerconstants.h"
 #include "game/mechanisms/lever.h"
+#include "game/mechanisms/postprocessingmechanism.h"
 #include "game/physics/chainshapeanalyzer.h"
 #include "game/physics/gamecontactlistener.h"
 #include "game/physics/physicsconfiguration.h"
@@ -1479,6 +1480,40 @@ bool Level::isMapRevealed() const
 void Level::setMapRevealed(bool revealed)
 {
    _map_revealed = revealed;
+}
+
+std::shared_ptr<PostProcessingMechanism> Level::getActivePostProcessingMechanism()
+{
+   const auto it = _mechanism_registry.getMap().find(std::string{layer_name_post_processing});
+   if (it == _mechanism_registry.getMap().end() || it->second == nullptr)
+   {
+      return nullptr;
+   }
+
+   std::shared_ptr<PostProcessingMechanism> active;
+   auto enabled_count = 0;
+
+   for (const auto& mechanism : *it->second)
+   {
+      if (!mechanism->isEnabled() || mechanism->getRenderStage() != MechanismRenderStage::PostProcessing)
+      {
+         continue;
+      }
+
+      enabled_count++;
+
+      if (!active || mechanism->getZ() > active->getZ())
+      {
+         active = std::dynamic_pointer_cast<PostProcessingMechanism>(mechanism);
+      }
+   }
+
+   if (enabled_count > 1)
+   {
+      Log::Warning() << enabled_count << " post processing mechanisms are enabled at once, only the highest z is applied";
+   }
+
+   return active;
 }
 
 const GameMechanismRegistry& Level::getMechanismRegistry() const

--- a/src/game/level/level.h
+++ b/src/game/level/level.h
@@ -53,6 +53,7 @@ class Bouncer;
 class IngameMenuMap;
 class TmxParser;
 struct ParseData;
+struct PostProcessingMechanism;
 
 /// \brief manages a playable level including tmx loading, physics, mechanisms, camera, and rendering.
 class Level : public GameNode, public LevelInterface
@@ -184,6 +185,13 @@ public:
    /// \brief returns access to grouped level mechanisms.
    /// \return immutable reference to the mechanism registry.
    const GameMechanismRegistry& getMechanismRegistry() const override;
+
+   /// \brief returns the enabled post processing mechanism that should drive the post processing pass.
+   ///
+   /// When several are enabled at once the one with the highest z wins and the others are logged,
+   /// since stacking would require a second full screen target and an extra pass per effect.
+   /// \return active mechanism, or nullptr when the level has none enabled.
+   std::shared_ptr<PostProcessingMechanism> getActivePostProcessingMechanism();
 
    /// \brief returns all rooms parsed from the level.
    /// \return immutable reference to room list.

--- a/src/game/mechanisms/gamemechanism.cpp
+++ b/src/game/mechanisms/gamemechanism.cpp
@@ -172,6 +172,11 @@ bool GameMechanism::isOverlay() const
    return _is_overlay;
 }
 
+MechanismRenderStage GameMechanism::getRenderStage() const
+{
+   return _render_stage;
+}
+
 void GameMechanism::setVisible(bool visible)
 {
    _visible = visible;

--- a/src/game/mechanisms/gamemechanism.h
+++ b/src/game/mechanisms/gamemechanism.h
@@ -17,6 +17,18 @@
 
 struct Room;
 
+/// \brief identifies which render stage a mechanism contributes to.
+///
+/// Ordinary mechanisms draw themselves into the level render targets. A post processing mechanism
+/// cannot: its pass runs after the level has been composited, and for the frame-wide scope even
+/// after the hud. Those mechanisms therefore do not draw at all, they hand a shader to the post
+/// processing pass instead.
+enum class MechanismRenderStage
+{
+   Level,          //!< drawn into the level render targets like an ordinary mechanism
+   PostProcessing  //!< contributes a full screen shader pass applied after the level
+};
+
 /// \brief defines the shared interface and common state for all level mechanisms.
 class GameMechanism
 {
@@ -66,6 +78,10 @@ public:
    /// deferred target afterwards so normal-map lighting does not render on top of it.
    /// \return true when the mechanism opts out of the lighting pass.
    virtual bool isPostLighting() const;
+
+   /// \brief returns the render stage this mechanism contributes to.
+   /// \return stage deciding whether the mechanism draws itself or feeds the post processing pass.
+   virtual MechanismRenderStage getRenderStage() const;
 
    /// \brief checks whether this mechanism is a screen overlay drawn on top of all other layers,
    /// including post-lighting layers, so it is always visible regardless of lighting compositing.
@@ -190,6 +206,8 @@ protected:
    bool _observed{false};
    bool _post_lighting{false};  //!< when true, drawn after the lighting pass so normal-map lighting does not composite on top
    bool _is_overlay{false};     //!< when true, drawn after all other layers including post-lighting layers
+
+   MechanismRenderStage _render_stage{MechanismRenderStage::Level};  //!< render stage this mechanism contributes to
 
    // audio related
    bool _has_audio{false};

--- a/src/game/mechanisms/gamemechanismdeserializerconstants.h
+++ b/src/game/mechanisms/gamemechanismdeserializerconstants.h
@@ -104,6 +104,12 @@ constexpr std::string_view layer_name_platforms{"moving_platforms"};
 /// \brief tmx layer name for portal mechanisms.
 constexpr std::string_view layer_name_portals{"portals"};
 
+/// \brief tmx layer name for post processing mechanisms.
+constexpr std::string_view layer_name_post_processing{"post_processing"};
+
+/// \brief object template type name for post processing mechanisms.
+constexpr std::string_view type_name_post_processing{"PostProcessing"};
+
 /// \brief tmx layer name for rope mechanisms.
 constexpr std::string_view layer_name_ropes{"ropes"};
 

--- a/src/game/mechanisms/postprocessingmechanism.cpp
+++ b/src/game/mechanisms/postprocessingmechanism.cpp
@@ -1,0 +1,302 @@
+#include "postprocessingmechanism.h"
+
+#include <array>
+#include <filesystem>
+#include <sstream>
+
+#include "framework/tmxparser/tmxobject.h"
+#include "framework/tmxparser/tmxproperties.h"
+#include "framework/tmxparser/tmxproperty.h"
+#include "framework/tools/log.h"
+#include "game/config/gameconfiguration.h"
+#include "game/io/texturepool.h"
+#include "game/io/valuereader.h"
+#include "game/mechanisms/gamemechanismdeserializerconstants.h"
+#include "game/mechanisms/gamemechanismdeserializerregistry.h"
+#include "game/player/playerregistry.h"
+
+namespace
+{
+//! \brief prefix marking a tmx property as a shader uniform
+constexpr std::string_view uniform_prefix{"u_"};
+
+static constexpr std::array post_processing_properties{
+   PropertyInfo{.name = "fragment_shader", .type = "string", .default_value = "", .required = true},
+   PropertyInfo{.name = "vertex_shader", .type = "string", .default_value = ""},
+   PropertyInfo{.name = "scope", .type = "string", .default_value = "all"},
+   PropertyInfo{.name = "z", .type = "int", .default_value = int32_t{0}},
+};
+
+static constexpr MechanismSchema post_processing_schema{
+   .type_name = "PostProcessing",
+   .layer_name = "post_processing",
+   .default_width = 480,
+   .default_height = 270,
+   .properties = post_processing_properties,
+};
+
+const auto registered_post_processing = []
+{
+   auto& registry = GameMechanismDeserializerRegistry::instance();
+   registry.registerSchema(post_processing_schema);
+
+   registry.mapGroupToLayer("PostProcessing", "post_processing");
+
+   registry.registerLayerName(
+      "post_processing",
+      [](GameNode* parent, const GameDeserializeData& data, auto& mechanisms)
+      {
+         auto mechanism = PostProcessingMechanism::deserialize(parent, data);
+         if (mechanism)
+         {
+            mechanisms["post_processing"]->push_back(mechanism);
+         }
+      }
+   );
+
+   registry.registerObjectGroup(
+      "PostProcessing",
+      [](GameNode* parent, const GameDeserializeData& data, auto& mechanisms)
+      {
+         auto mechanism = PostProcessingMechanism::deserialize(parent, data);
+         if (mechanism)
+         {
+            mechanisms["post_processing"]->push_back(mechanism);
+         }
+      }
+   );
+   return true;
+}();
+
+//! \brief splits a comma separated string into floats so vec2/vec3/vec4 uniforms can be written as text
+std::vector<float> parseFloatList(const std::string& text)
+{
+   std::vector<float> values;
+   std::stringstream stream(text);
+   std::string token;
+   while (std::getline(stream, token, ','))
+   {
+      try
+      {
+         values.push_back(std::stof(token));
+      }
+      catch (...)
+      {
+         return {};
+      }
+   }
+   return values;
+}
+
+}  // namespace
+
+PostProcessingMechanism::PostProcessingMechanism(GameNode* parent) : GameNode(parent)
+{
+   setClassName(typeid(PostProcessingMechanism).name());
+   _render_stage = MechanismRenderStage::PostProcessing;
+}
+
+std::string_view PostProcessingMechanism::objectName() const
+{
+   return "PostProcessing";
+}
+
+void PostProcessingMechanism::update(const sf::Time& dt)
+{
+   _elapsed_s += dt.asSeconds();
+
+   if (!_has_trigger_area)
+   {
+      return;
+   }
+
+   const auto player = PlayerRegistry::getFirst();
+   if (!player)
+   {
+      return;
+   }
+
+   setEnabled(_rect.contains(player->getPixelPositionFloat()));
+}
+
+std::optional<sf::FloatRect> PostProcessingMechanism::getBoundingBoxPx()
+{
+   return _rect;
+}
+
+PostProcessing::Scope PostProcessingMechanism::getScope() const
+{
+   return _scope;
+}
+
+const sf::Shader* PostProcessingMechanism::prepare(const sf::Texture& texture)
+{
+   if (!_shader.isLoaded())
+   {
+      return nullptr;
+   }
+
+   const auto& game_configuration = GameConfiguration::getInstance();
+   const auto view_width = static_cast<float>(game_configuration._view_width);
+   const auto view_height = static_cast<float>(game_configuration._view_height);
+
+   // built-ins, set unconditionally: setUniform silently ignores names the shader does not declare
+   _shader.setUniform("u_texture", texture);
+   _shader.setUniform("u_time", _elapsed_s);
+   _shader.setUniform("u_resolution", sf::Glsl::Vec2{view_width, view_height});
+   _shader.setUniform("u_pixel_size", sf::Glsl::Vec2{1.0f / view_width, 1.0f / view_height});
+
+   // anything configured in tmx wins over the built-ins above
+   for (const auto& uniform : _uniforms)
+   {
+      std::visit(
+         [this, &uniform](const auto& value)
+         {
+            using ValueType = std::decay_t<decltype(value)>;
+            if constexpr (std::is_same_v<ValueType, std::shared_ptr<sf::Texture>>)
+            {
+               if (value)
+               {
+                  _shader.setUniform(uniform._name, *value);
+               }
+            }
+            else
+            {
+               _shader.setUniform(uniform._name, value);
+            }
+         },
+         uniform._value
+      );
+   }
+
+   return &_shader.native();
+}
+
+std::shared_ptr<PostProcessingMechanism> PostProcessingMechanism::deserialize(GameNode* parent, const GameDeserializeData& data)
+{
+   if (!data._tmx_object->_properties)
+   {
+      Log::Error() << "post processing mechanism has no properties, id: " << data._tmx_object->_name;
+      return nullptr;
+   }
+
+   const auto& map = data._tmx_object->_properties->_map;
+
+   auto instance = std::make_shared<PostProcessingMechanism>(parent);
+   instance->setObjectId(data._tmx_object->_name);
+   instance->_z_index = ValueReader::readValue<int32_t>("z", map).value_or(instance->_z_index);
+
+   instance->_rect =
+      sf::FloatRect{{data._tmx_object->_x_px, data._tmx_object->_y_px}, {data._tmx_object->_width_px, data._tmx_object->_height_px}};
+
+   // a sized rectangle gates the effect on the player being inside it, a zero-sized one leaves the
+   // mechanism disabled until a script enables it
+   instance->_has_trigger_area = (data._tmx_object->_width_px > 0.0f && data._tmx_object->_height_px > 0.0f);
+   if (instance->_has_trigger_area)
+   {
+      instance->addChunks(instance->_rect);
+   }
+   instance->setEnabled(false);
+
+   const auto scope = ValueReader::readValue<std::string>("scope", map);
+   if (scope.has_value())
+   {
+      const auto parsed_scope = PostProcessing::scopeFromName(scope.value());
+      if (parsed_scope.has_value())
+      {
+         instance->_scope = parsed_scope.value();
+      }
+      else
+      {
+         Log::Error() << "unknown post processing scope: " << scope.value();
+      }
+   }
+
+   const auto vertex_file = ValueReader::readValue<std::string>("vertex_shader", map);
+   const auto fragment_file = ValueReader::readValue<std::string>("fragment_shader", map);
+
+   const auto vertex_exists = vertex_file.has_value() && std::filesystem::exists(vertex_file.value());
+   const auto fragment_exists = fragment_file.has_value() && std::filesystem::exists(fragment_file.value());
+
+   if (vertex_file.has_value() && !vertex_exists)
+   {
+      Log::Error() << "vertex shader file does not exist: " << vertex_file.value();
+   }
+   if (fragment_file.has_value() && !fragment_exists)
+   {
+      Log::Error() << "fragment shader file does not exist: " << fragment_file.value();
+   }
+
+   auto shader_loaded = false;
+   if (vertex_exists && fragment_exists)
+   {
+      shader_loaded = instance->_shader.loadFromFile(vertex_file.value(), fragment_file.value());
+   }
+   else if (fragment_exists)
+   {
+      shader_loaded = instance->_shader.loadFromFragment(fragment_file.value());
+   }
+
+   if (!shader_loaded)
+   {
+      Log::Error() << "post processing mechanism has no usable shader, id: " << data._tmx_object->_name;
+      return nullptr;
+   }
+
+   // every "u_" property becomes a uniform, so an arbitrary shader can be driven straight from tmx
+   for (const auto& [key, property] : map)
+   {
+      if (!key.starts_with(uniform_prefix))
+      {
+         continue;
+      }
+
+      if (property->_value_type == "float")
+      {
+         instance->_uniforms.push_back({._name = key, ._value = property->_value_float.value_or(0.0f)});
+      }
+      else if (property->_value_type == "int")
+      {
+         instance->_uniforms.push_back({._name = key, ._value = property->_value_int.value_or(0)});
+      }
+      else if (property->_value_type == "bool")
+      {
+         instance->_uniforms.push_back({._name = key, ._value = property->_value_bool.value_or(false)});
+      }
+      else if (property->_value_string.has_value())
+      {
+         const auto& text = property->_value_string.value();
+         const auto values = parseFloatList(text);
+
+         if (values.size() == 2)
+         {
+            instance->_uniforms.push_back({._name = key, ._value = sf::Glsl::Vec2{values[0], values[1]}});
+         }
+         else if (values.size() == 3)
+         {
+            instance->_uniforms.push_back({._name = key, ._value = sf::Glsl::Vec3{values[0], values[1], values[2]}});
+         }
+         else if (values.size() == 4)
+         {
+            instance->_uniforms.push_back({._name = key, ._value = sf::Glsl::Vec4{values[0], values[1], values[2], values[3]}});
+         }
+         else if (values.size() == 1)
+         {
+            instance->_uniforms.push_back({._name = key, ._value = values[0]});
+         }
+         else if (std::filesystem::exists(text))
+         {
+            instance->_uniforms.push_back({._name = key, ._value = TexturePool::getInstance().get(text)});
+         }
+         else
+         {
+            Log::Error() << "post processing uniform '" << key << "' has no usable value: " << text;
+         }
+      }
+   }
+
+   Log::Info() << "post processing mechanism '" << data._tmx_object->_name << "' loaded " << fragment_file.value_or("") << " with "
+               << instance->_uniforms.size() << " configured uniform(s)";
+
+   return instance;
+}

--- a/src/game/mechanisms/postprocessingmechanism.cpp
+++ b/src/game/mechanisms/postprocessingmechanism.cpp
@@ -8,7 +8,6 @@
 #include "framework/tmxparser/tmxproperties.h"
 #include "framework/tmxparser/tmxproperty.h"
 #include "framework/tools/log.h"
-#include "game/config/gameconfiguration.h"
 #include "game/io/texturepool.h"
 #include "game/io/valuereader.h"
 #include "game/mechanisms/gamemechanismdeserializerconstants.h"
@@ -136,15 +135,7 @@ const sf::Shader* PostProcessingMechanism::prepare(const sf::Texture& texture)
       return nullptr;
    }
 
-   const auto& game_configuration = GameConfiguration::getInstance();
-   const auto view_width = static_cast<float>(game_configuration._view_width);
-   const auto view_height = static_cast<float>(game_configuration._view_height);
-
-   // built-ins, set unconditionally: setUniform silently ignores names the shader does not declare
-   _shader.setUniform("u_texture", texture);
-   _shader.setUniform("u_time", _elapsed_s);
-   _shader.setUniform("u_resolution", sf::Glsl::Vec2{view_width, view_height});
-   _shader.setUniform("u_pixel_size", sf::Glsl::Vec2{1.0f / view_width, 1.0f / view_height});
+   PostProcessing::applyBuiltInUniforms(_shader, texture, _elapsed_s);
 
    // anything configured in tmx wins over the built-ins above
    for (const auto& uniform : _uniforms)

--- a/src/game/mechanisms/postprocessingmechanism.h
+++ b/src/game/mechanisms/postprocessingmechanism.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "framework/tools/sfmlshader.h"
+#include "game/io/gamedeserializedata.h"
+#include "game/level/gamenode.h"
+#include "game/mechanisms/gamemechanism.h"
+#include "game/shaders/postprocessing.h"
+
+#include <SFML/Graphics.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+struct TmxObject;
+
+/// \brief configures a full screen post processing shader from tmx, like ShaderLayer does for quads.
+///
+/// This mechanism never draws itself. Its pass runs after the level has been composited, so instead
+/// of rendering it hands its shader to the post processing stage, which is why its render stage is
+/// MechanismRenderStage::PostProcessing.
+///
+/// Any tmx property whose name starts with "u_" is forwarded to the shader as a uniform of the
+/// property's tmx type, so an arbitrary shader can be driven without touching cpp. String values
+/// holding comma separated numbers become vec2/vec3/vec4, and string values naming an existing file
+/// are loaded as a texture.
+///
+/// A sized object rectangle acts as a trigger area: the effect is active while the player is inside
+/// it. A zero-sized rectangle leaves the mechanism under script control through setMechanismEnabled.
+struct PostProcessingMechanism : public GameMechanism, public GameNode
+{
+   /// \brief creates a post processing mechanism instance.
+   /// \param parent owning game node in the scene graph.
+   PostProcessingMechanism(GameNode* parent = nullptr);
+
+   /// \brief returns the mechanism type name used by the serialization system.
+   /// \return constant string view containing "PostProcessing".
+   std::string_view objectName() const override;
+
+   /// \brief accumulates elapsed time and evaluates the trigger area.
+   /// \param dt elapsed frame time.
+   void update(const sf::Time& dt) override;
+
+   /// \brief returns the trigger rectangle of this mechanism.
+   /// \return rectangle in pixel space, empty when the mechanism is script driven.
+   std::optional<sf::FloatRect> getBoundingBoxPx() override;
+
+   /// \brief updates the shader uniforms for a full screen pass over the given texture.
+   /// \param texture texture the effect samples from.
+   /// \return shader to draw the full screen sprite with, or nullptr when the shader failed to load.
+   const sf::Shader* prepare(const sf::Texture& texture);
+
+   /// \brief returns which part of the frame this effect is applied to.
+   /// \return configured post processing scope.
+   PostProcessing::Scope getScope() const;
+
+   /// \brief creates and configures a post processing mechanism from tmx object properties.
+   /// \param parent owning game node in the scene graph.
+   /// \param data deserialization data containing shader paths, scope, and uniform properties.
+   /// \return configured instance, or nullptr when no usable shader was given.
+   static std::shared_ptr<PostProcessingMechanism> deserialize(GameNode* parent, const GameDeserializeData& data);
+
+private:
+   //! \brief one uniform parsed from a tmx property, kept in the type it was declared with
+   using UniformValue = std::variant<float, int32_t, bool, sf::Glsl::Vec2, sf::Glsl::Vec3, sf::Glsl::Vec4, std::shared_ptr<sf::Texture>>;
+
+   /// \brief pairs a uniform name with the value read from tmx.
+   struct Uniform
+   {
+      std::string _name;    //!< uniform name as declared in the shader
+      UniformValue _value;  //!< value forwarded on every frame
+   };
+
+   sfcompat::Shader _shader;                                  //!< the configured post processing shader
+   std::vector<Uniform> _uniforms;                            //!< uniforms parsed from the "u_" tmx properties
+   sf::FloatRect _rect;                                       //!< trigger area, empty when script driven
+   bool _has_trigger_area{false};                             //!< whether the rectangle gates the effect
+   PostProcessing::Scope _scope{PostProcessing::Scope::All};  //!< part of the frame the effect covers
+   float _elapsed_s{0.0f};                                    //!< seconds elapsed, fed to u_time
+};

--- a/src/game/rendering/postprocessingpass.cpp
+++ b/src/game/rendering/postprocessingpass.cpp
@@ -1,0 +1,99 @@
+#include "postprocessingpass.h"
+
+#include "framework/tools/log.h"
+#include "game/config/gameconfiguration.h"
+#include "game/shaders/postprocessing.h"
+
+std::shared_ptr<sf::RenderTexture>
+PostProcessingPass::selectLevelTarget(const std::shared_ptr<sf::RenderTexture>& frame_target, bool level_loaded)
+{
+   auto& post_processing = PostProcessing::getInstance();
+
+   _level_scope_active = level_loaded && post_processing.isActive() && post_processing.getScope() == PostProcessing::Scope::Level &&
+                         frame_target && createRenderTexture(frame_target->getSize());
+
+   if (!_level_scope_active)
+   {
+      return frame_target;
+   }
+
+   // Level::draw blits with view_to_texture_scale, which only fills the target when that target
+   // carries the level view. the frame target happens to have it left over from the previous
+   // frame's overlays, a freshly created target does not, so it is set explicitly here rather than
+   // relying on that leftover
+#ifndef __EMSCRIPTEN__
+   const auto& game_configuration = GameConfiguration::getInstance();
+   const sf::View level_view{
+      sf::FloatRect{{0.0f, 0.0f}, {static_cast<float>(game_configuration._view_width), static_cast<float>(game_configuration._view_height)}}
+   };
+   _render_texture->setView(level_view);
+   frame_target->setView(level_view);
+#endif
+
+   _render_texture->clear();
+   return _render_texture;
+}
+
+void PostProcessingPass::resolveLevelTarget(sf::RenderTexture& frame_target, float view_to_texture_scale)
+{
+   if (!_level_scope_active)
+   {
+      return;
+   }
+
+   _render_texture->display();
+
+   const sf::Texture& texture = _render_texture->getTexture();
+   const auto* shader = PostProcessing::getInstance().prepare(texture);
+
+#ifdef __EMSCRIPTEN__
+   sf::Sprite sprite;
+   sprite.textureRect = sf::FloatRect{{0.f, 0.f}, {static_cast<float>(texture.getSize().x), static_cast<float>(texture.getSize().y)}};
+   frame_target.draw(sprite, sf::RenderStates{.texture = &texture, .shader = shader});
+#else
+   // the frame target carries the level's view, so this blit has to use the same scale Level::draw
+   // uses. without it the sprite covers several times the view, only a corner of it stays visible
+   // and the effect sees texture coordinates spanning 0..1/scale, which makes anything resolution
+   // dependent (the game boy grid) come out far too coarse
+   auto sprite = sf::Sprite(texture);
+   sprite.scale({view_to_texture_scale, view_to_texture_scale});
+   frame_target.draw(sprite, shader);
+#endif
+}
+
+const sf::Shader* PostProcessingPass::getFrameShader(const sf::Texture& frame_texture)
+{
+   auto& post_processing = PostProcessing::getInstance();
+
+   // a level-scoped effect has already been resolved, and deliberately does nothing at all while
+   // no level is running
+   if (post_processing.getScope() != PostProcessing::Scope::All)
+   {
+      return nullptr;
+   }
+
+   return post_processing.prepare(frame_texture);
+}
+
+void PostProcessingPass::release()
+{
+   _render_texture.reset();
+   _level_scope_active = false;
+}
+
+bool PostProcessingPass::createRenderTexture(const sf::Vector2u& size)
+{
+   if (_render_texture)
+   {
+      return true;
+   }
+
+#ifndef __EMSCRIPTEN__
+   _render_texture = std::make_shared<sf::RenderTexture>(size);
+#else
+   _render_texture = std::make_shared<sf::RenderTexture>(std::move(*sf::RenderTexture::create(size)));
+#endif
+
+   Log::Info() << "created post processing render texture: " << size.x << " x " << size.y;
+   return true;
+}

--- a/src/game/rendering/postprocessingpass.h
+++ b/src/game/rendering/postprocessingpass.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <SFML/Graphics.hpp>
+
+#include <memory>
+
+/// \brief owns the render target and the blits needed to apply a post processing effect to a frame.
+///
+/// The frame-wide scope needs nothing but a shader on the final blit to the window. The level scope
+/// does: a shader cannot read and write the same target, so the level has to land somewhere before
+/// being resolved into the frame target. This class owns that intermediate target, creates it on
+/// first use and releases it again, so a session that never selects the level scope never pays for
+/// it.
+///
+/// Which effect applies and whether one applies at all is decided by PostProcessing; this class only
+/// deals with where the pixels go.
+class PostProcessingPass
+{
+public:
+   /// \brief picks the target the level should render into this frame.
+   ///
+   /// Call once per frame before drawing the level, then hand the result to Level::draw.
+   /// \param frame_target target the composited frame is assembled in.
+   /// \param level_loaded whether a level is available to draw.
+   /// \return the intermediate target while a level-scoped effect is active, the frame target otherwise.
+   std::shared_ptr<sf::RenderTexture> selectLevelTarget(const std::shared_ptr<sf::RenderTexture>& frame_target, bool level_loaded);
+
+   /// \brief resolves the intermediate target into the frame target through the effect.
+   ///
+   /// Call once per frame after drawing the level and before any overlay is drawn, so the hud ends
+   /// up on top of the processed level. Does nothing when the level rendered straight into the
+   /// frame target.
+   /// \param frame_target target the composited frame is assembled in.
+   /// \param view_to_texture_scale scale Level::draw uses for its own blit.
+   void resolveLevelTarget(sf::RenderTexture& frame_target, float view_to_texture_scale);
+
+   /// \brief returns the shader for the final blit of the composited frame to the window.
+   /// \param frame_texture texture holding the composited frame.
+   /// \return shader to draw with, or nullptr when nothing applies at this stage.
+   const sf::Shader* getFrameShader(const sf::Texture& frame_texture);
+
+   /// \brief releases the intermediate target, for a level change or a resolution change.
+   void release();
+
+private:
+   /// \brief creates the intermediate target on first use.
+   /// \param size size to match, taken from the frame target.
+   /// \return true when the target is available.
+   bool createRenderTexture(const sf::Vector2u& size);
+
+   //! \brief intermediate target the level renders into while a level-scoped effect is active
+   std::shared_ptr<sf::RenderTexture> _render_texture;
+
+   //! \brief whether this frame routes the level through the intermediate target
+   bool _level_scope_active{false};
+};

--- a/src/game/shaders/postprocessing.cpp
+++ b/src/game/shaders/postprocessing.cpp
@@ -1,0 +1,245 @@
+#include "postprocessing.h"
+
+#include "framework/tools/log.h"
+#include "game/config/gameconfiguration.h"
+#include "game/mechanisms/postprocessingmechanism.h"
+
+#include <algorithm>
+#include <iterator>
+#include <string_view>
+#include <utility>
+
+namespace
+{
+
+//! \brief the game boy screen matches the view in each direction, so the quantization snaps to the
+//!        game's own pixel grid and only the palette reduction remains visible. must stay an integer
+//!        divisor of the 640x360 view, otherwise the grid shimmers against the pixel grid
+constexpr auto gameboy_grid_divisor = 1.0f;
+
+//! \brief tone curve mapping scene luminance onto the 4 palette steps of the game boy effect. the
+//!        game is lit far below the palette thresholds, so without it the whole frame collapses
+//!        into the darkest color. the mid grey is the luminance that lands halfway up the palette,
+//!        tuned against the catacombs so the player keeps its shading; raise it to darken
+constexpr auto gameboy_black_point = 0.0f;
+constexpr auto gameboy_mid_grey = 0.17f;
+
+//! \brief horizontal channel separation of the rgb split effect, in game pixels
+constexpr auto rgb_split_offset_px = 2.0f;
+
+struct EffectName
+{
+   PostProcessing::Effect _effect;
+   std::string_view _name;
+};
+
+constexpr EffectName effect_names[] = {
+   {PostProcessing::Effect::None, "none"},
+   {PostProcessing::Effect::GameBoy, "gameboy"},
+   {PostProcessing::Effect::RgbSplit, "rgbsplit"},
+   {PostProcessing::Effect::Glitch, "glitch"},
+};
+
+struct ScopeName
+{
+   PostProcessing::Scope _scope;
+   std::string_view _name;
+};
+
+constexpr ScopeName scope_names[] = {
+   {PostProcessing::Scope::All, "all"},
+   {PostProcessing::Scope::Level, "level"},
+};
+
+//! \brief computes the size of one game pixel in uv space of the composited frame.
+//!        the frame is rendered at an integer multiple of the view, so tying the effect
+//!        parameters to the view keeps them stable across resolutions.
+sf::Glsl::Vec2 getPixelSize()
+{
+   const auto& game_configuration = GameConfiguration::getInstance();
+   return {1.0f / static_cast<float>(game_configuration._view_width), 1.0f / static_cast<float>(game_configuration._view_height)};
+}
+
+}  // namespace
+
+PostProcessing& PostProcessing::getInstance()
+{
+   static PostProcessing __instance;
+   return __instance;
+}
+
+void PostProcessing::initialize()
+{
+   if (_initialized)
+   {
+      return;
+   }
+
+   const std::vector<std::pair<Effect, std::string>> effect_sources = {
+      {Effect::GameBoy, "data/shaders/gameboy.frag"},
+      {Effect::RgbSplit, "data/shaders/rgb_split.frag"},
+      {Effect::Glitch, "data/shaders/glitch.frag"},
+   };
+
+   _effect_shaders.reserve(effect_sources.size());
+
+   for (const auto& [effect, fragment_path] : effect_sources)
+   {
+      EffectShader effect_shader;
+      effect_shader._effect = effect;
+      effect_shader._fragment_path = fragment_path;
+
+      if (!effect_shader._shader.loadFromFragment(fragment_path))
+      {
+         Log::Error() << "error loading post processing shader: " << fragment_path;
+         continue;
+      }
+
+      _effect_shaders.push_back(std::move(effect_shader));
+   }
+
+   _initialized = true;
+}
+
+void PostProcessing::update(const sf::Time& dt)
+{
+   _elapsed_s += dt.asSeconds();
+}
+
+void PostProcessing::setEffect(Effect effect)
+{
+   _effect = effect;
+}
+
+PostProcessing::Effect PostProcessing::getEffect() const
+{
+   return _effect;
+}
+
+void PostProcessing::setScope(Scope scope)
+{
+   _scope = scope;
+}
+
+PostProcessing::Scope PostProcessing::getScope() const
+{
+   if (_effect != Effect::None)
+   {
+      return _scope;
+   }
+
+   const auto level_effect = _level_effect.lock();
+   return level_effect ? level_effect->getScope() : _scope;
+}
+
+void PostProcessing::setLevelEffect(const std::shared_ptr<PostProcessingMechanism>& mechanism)
+{
+   _level_effect = mechanism;
+}
+
+bool PostProcessing::isActive() const
+{
+   if (_effect != Effect::None)
+   {
+      const auto it = std::ranges::find_if(_effect_shaders, [this](const auto& candidate) { return candidate._effect == _effect; });
+      return (it != _effect_shaders.end()) && it->_shader.isLoaded();
+   }
+
+   return !_level_effect.expired();
+}
+
+PostProcessing::EffectShader* PostProcessing::findEffectShader(Effect effect)
+{
+   const auto it = std::ranges::find_if(_effect_shaders, [effect](const auto& candidate) { return candidate._effect == effect; });
+   return (it == _effect_shaders.end()) ? nullptr : &(*it);
+}
+
+const sf::Shader* PostProcessing::prepare(const sf::Texture& texture)
+{
+   if (_effect == Effect::None)
+   {
+      // no console override, so whatever the level configured through a mechanism applies
+      const auto level_effect = _level_effect.lock();
+      return level_effect ? level_effect->prepare(texture) : nullptr;
+   }
+
+   auto* effect_shader = findEffectShader(_effect);
+   if (effect_shader == nullptr || !effect_shader->_shader.isLoaded())
+   {
+      return nullptr;
+   }
+
+   auto& shader = effect_shader->_shader;
+   shader.setUniform("u_texture", texture);
+
+   switch (_effect)
+   {
+      case Effect::GameBoy:
+      {
+         const auto& game_configuration = GameConfiguration::getInstance();
+         shader.setUniform(
+            "u_grid_size",
+            sf::Glsl::Vec2{
+               static_cast<float>(game_configuration._view_width) / gameboy_grid_divisor,
+               static_cast<float>(game_configuration._view_height) / gameboy_grid_divisor
+            }
+         );
+         shader.setUniform("u_black_point", gameboy_black_point);
+         shader.setUniform("u_mid_grey", gameboy_mid_grey);
+         break;
+      }
+      case Effect::RgbSplit:
+      {
+         shader.setUniform("u_pixel_size", getPixelSize());
+         shader.setUniform("u_offset", rgb_split_offset_px);
+         shader.setUniform("u_time", _elapsed_s);
+         break;
+      }
+      case Effect::Glitch:
+      {
+         shader.setUniform("u_pixel_size", getPixelSize());
+         shader.setUniform("u_time", _elapsed_s);
+         break;
+      }
+      case Effect::None:
+      {
+         break;
+      }
+   }
+
+   return &shader.native();
+}
+
+std::optional<PostProcessing::Effect> PostProcessing::effectFromName(const std::string& name)
+{
+   const auto it = std::ranges::find_if(effect_names, [&name](const auto& candidate) { return candidate._name == name; });
+   return (it == std::end(effect_names)) ? std::nullopt : std::optional<Effect>{it->_effect};
+}
+
+std::vector<std::string> PostProcessing::getEffectNames()
+{
+   std::vector<std::string> names;
+   names.reserve(std::size(effect_names));
+   for (const auto& entry : effect_names)
+   {
+      names.emplace_back(entry._name);
+   }
+   return names;
+}
+
+std::optional<PostProcessing::Scope> PostProcessing::scopeFromName(const std::string& name)
+{
+   const auto it = std::ranges::find_if(scope_names, [&name](const auto& candidate) { return candidate._name == name; });
+   return (it == std::end(scope_names)) ? std::nullopt : std::optional<Scope>{it->_scope};
+}
+
+std::vector<std::string> PostProcessing::getScopeNames()
+{
+   std::vector<std::string> names;
+   names.reserve(std::size(scope_names));
+   for (const auto& entry : scope_names)
+   {
+      names.emplace_back(entry._name);
+   }
+   return names;
+}

--- a/src/game/shaders/postprocessing.cpp
+++ b/src/game/shaders/postprocessing.cpp
@@ -12,21 +12,6 @@
 namespace
 {
 
-//! \brief the game boy screen matches the view in each direction, so the quantization snaps to the
-//!        game's own pixel grid and only the palette reduction remains visible. must stay an integer
-//!        divisor of the 640x360 view, otherwise the grid shimmers against the pixel grid
-constexpr auto gameboy_grid_divisor = 1.0f;
-
-//! \brief tone curve mapping scene luminance onto the 4 palette steps of the game boy effect. the
-//!        game is lit far below the palette thresholds, so without it the whole frame collapses
-//!        into the darkest color. the mid grey is the luminance that lands halfway up the palette,
-//!        tuned against the catacombs so the player keeps its shading; raise it to darken
-constexpr auto gameboy_black_point = 0.0f;
-constexpr auto gameboy_mid_grey = 0.17f;
-
-//! \brief horizontal channel separation of the rgb split effect, in game pixels
-constexpr auto rgb_split_offset_px = 2.0f;
-
 struct EffectName
 {
    PostProcessing::Effect _effect;
@@ -51,16 +36,21 @@ constexpr ScopeName scope_names[] = {
    {PostProcessing::Scope::Level, "level"},
 };
 
-//! \brief computes the size of one game pixel in uv space of the composited frame.
-//!        the frame is rendered at an integer multiple of the view, so tying the effect
-//!        parameters to the view keeps them stable across resolutions.
-sf::Glsl::Vec2 getPixelSize()
+}  // namespace
+
+void PostProcessing::applyBuiltInUniforms(sfcompat::Shader& shader, const sf::Texture& texture, float elapsed_s)
 {
    const auto& game_configuration = GameConfiguration::getInstance();
-   return {1.0f / static_cast<float>(game_configuration._view_width), 1.0f / static_cast<float>(game_configuration._view_height)};
-}
+   const auto view_width = static_cast<float>(game_configuration._view_width);
+   const auto view_height = static_cast<float>(game_configuration._view_height);
 
-}  // namespace
+   // set unconditionally: setUniform silently ignores names the shader does not declare, so a
+   // shader only pays for what it actually uses and this stays free of per-effect branching
+   shader.setUniform("u_texture", texture);
+   shader.setUniform("u_time", elapsed_s);
+   shader.setUniform("u_resolution", sf::Glsl::Vec2{view_width, view_height});
+   shader.setUniform("u_pixel_size", sf::Glsl::Vec2{1.0f / view_width, 1.0f / view_height});
+}
 
 PostProcessing& PostProcessing::getInstance()
 {
@@ -170,42 +160,7 @@ const sf::Shader* PostProcessing::prepare(const sf::Texture& texture)
    }
 
    auto& shader = effect_shader->_shader;
-   shader.setUniform("u_texture", texture);
-
-   switch (_effect)
-   {
-      case Effect::GameBoy:
-      {
-         const auto& game_configuration = GameConfiguration::getInstance();
-         shader.setUniform(
-            "u_grid_size",
-            sf::Glsl::Vec2{
-               static_cast<float>(game_configuration._view_width) / gameboy_grid_divisor,
-               static_cast<float>(game_configuration._view_height) / gameboy_grid_divisor
-            }
-         );
-         shader.setUniform("u_black_point", gameboy_black_point);
-         shader.setUniform("u_mid_grey", gameboy_mid_grey);
-         break;
-      }
-      case Effect::RgbSplit:
-      {
-         shader.setUniform("u_pixel_size", getPixelSize());
-         shader.setUniform("u_offset", rgb_split_offset_px);
-         shader.setUniform("u_time", _elapsed_s);
-         break;
-      }
-      case Effect::Glitch:
-      {
-         shader.setUniform("u_pixel_size", getPixelSize());
-         shader.setUniform("u_time", _elapsed_s);
-         break;
-      }
-      case Effect::None:
-      {
-         break;
-      }
-   }
+   applyBuiltInUniforms(shader, texture, _elapsed_s);
 
    return &shader.native();
 }

--- a/src/game/shaders/postprocessing.h
+++ b/src/game/shaders/postprocessing.h
@@ -98,6 +98,18 @@ public:
    /// \return scope names in selection order, starting with "all".
    static std::vector<std::string> getScopeNames();
 
+   /// \brief writes the uniforms that any post processing shader may declare.
+   ///
+   /// These are the values only the engine can know: the frame being processed, elapsed time and
+   /// the size of the game's pixel grid. Everything else is a property of the effect itself and
+   /// belongs in the shader as a constant, or in tmx when it should be configurable per level.
+   /// Nothing here is specific to a particular shader, so both the console-selected effects and
+   /// the mechanism-configured ones share this one implementation.
+   /// \param shader shader to write the uniforms into.
+   /// \param texture texture the effect samples from.
+   /// \param elapsed_s seconds elapsed, written to u_time.
+   static void applyBuiltInUniforms(sfcompat::Shader& shader, const sf::Texture& texture, float elapsed_s);
+
 private:
    PostProcessing() = default;
 

--- a/src/game/shaders/postprocessing.h
+++ b/src/game/shaders/postprocessing.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include "framework/tools/sfmlshader.h"
+
+#include <SFML/Graphics.hpp>
+#include <SFML/System.hpp>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+struct PostProcessingMechanism;
+
+/// \brief full screen post processing applied to the composited frame.
+///
+/// The effect runs on the very last blit, when the window render texture holding the gamma
+/// corrected level plus all overlays goes to the window. That places it on top of the gamma
+/// shader without needing another render target, at the cost of covering the hud as well.
+class PostProcessing
+{
+public:
+   /// \brief identifies the selectable full screen effects.
+   enum class Effect
+   {
+      None,
+      GameBoy,
+      RgbSplit,
+      Glitch
+   };
+
+   /// \brief identifies which part of the frame an effect is applied to.
+   enum class Scope
+   {
+      All,   //!< the composited frame, overlays included
+      Level  //!< the level only, hud and menus stay untouched on top
+   };
+
+   /// \brief retrieves the global post processing singleton.
+   /// \return reference to the shared instance.
+   static PostProcessing& getInstance();
+
+   /// \brief loads all effect shaders, requires an active opengl context.
+   void initialize();
+
+   /// \brief advances the time fed into the animated effects.
+   /// \param dt elapsed frame time.
+   void update(const sf::Time& dt);
+
+   /// \brief selects the active effect.
+   /// \param effect effect to activate, Effect::None to disable post processing.
+   void setEffect(Effect effect);
+
+   /// \brief retrieves the active effect.
+   /// \return currently selected effect.
+   Effect getEffect() const;
+
+   /// \brief selects which part of the frame the effect is applied to.
+   /// \param scope scope to switch to.
+   void setScope(Scope scope);
+
+   /// \brief retrieves the active scope.
+   /// \return currently selected scope.
+   Scope getScope() const;
+
+   /// \brief stores the post processing mechanism the level currently wants applied.
+   ///
+   /// Called once per frame from the render loop. Held as a weak reference so a level unload can
+   /// never leave a dangling mechanism behind. A console-selected effect overrides it, which keeps
+   /// the console usable for testing in levels that configure their own effect.
+   /// \param mechanism active mechanism, or nullptr when the level has none.
+   void setLevelEffect(const std::shared_ptr<PostProcessingMechanism>& mechanism);
+
+   /// \brief tells whether an effect is selected and its shader is usable.
+   /// \return true when a pass should be rendered.
+   bool isActive() const;
+
+   /// \brief updates the active effect's uniforms for a full screen pass over the given texture.
+   /// \param texture texture the effect samples from.
+   /// \return shader to draw the full screen sprite with, or nullptr when no effect is active.
+   const sf::Shader* prepare(const sf::Texture& texture);
+
+   /// \brief maps a console friendly effect name to an effect.
+   /// \param name effect name such as "gameboy".
+   /// \return the matching effect, or nullopt when the name is unknown.
+   static std::optional<Effect> effectFromName(const std::string& name);
+
+   /// \brief lists the console friendly names of all selectable effects.
+   /// \return effect names in selection order, starting with "none".
+   static std::vector<std::string> getEffectNames();
+
+   /// \brief maps a console friendly scope name to a scope.
+   /// \param name scope name such as "level".
+   /// \return the matching scope, or nullopt when the name is unknown.
+   static std::optional<Scope> scopeFromName(const std::string& name);
+
+   /// \brief lists the console friendly names of all scopes.
+   /// \return scope names in selection order, starting with "all".
+   static std::vector<std::string> getScopeNames();
+
+private:
+   PostProcessing() = default;
+
+   /// \brief pairs a selectable effect with the shader implementing it.
+   struct EffectShader
+   {
+      Effect _effect{Effect::None};  //!< effect this shader implements
+      std::string _fragment_path;    //!< fragment shader source path
+      sfcompat::Shader _shader;      //!< loaded shader
+   };
+
+   /// \brief looks up the shader entry belonging to an effect.
+   /// \param effect effect to look up.
+   /// \return pointer to the entry, or nullptr when the effect has no shader.
+   EffectShader* findEffectShader(Effect effect);
+
+   std::vector<EffectShader> _effect_shaders;  //!< one entry per effect that has a shader
+   Effect _effect{Effect::None};               //!< console-selected effect, overrides the level effect
+   Scope _scope{Scope::All};                   //!< part of the frame the console-selected effect is applied to
+
+   //! \brief effect configured by the level through a post processing mechanism
+   std::weak_ptr<PostProcessingMechanism> _level_effect;
+   float _elapsed_s{0.0f};    //!< seconds elapsed, fed to the animated effects
+   bool _initialized{false};  //!< whether the shaders have been loaded
+};


### PR DESCRIPTION
Adds a full screen post processing stage that runs on top of the level's gamma pass, three effects to drive it, and a tmx mechanism to configure arbitrary post processing shaders from level data.

## Scopes

| scope | applies to | cost |
| --- | --- | --- |
| `all` (default) | the composited frame, hud and menus included | no extra render target, it is just a shader on the final blit |
| `level` | the level only, overlays stay untouched on top | one intermediate target, allocated lazily on first use |

`scope: level` is what keeps the hud readable — under `all` the rgb split smears the skull ornament into a rainbow and fringes the health bar.

## Configuring shaders from tmx

Modelled on `ShaderLayer`. Any property named `u_*` becomes a uniform of its tmx type; comma separated strings become `vec2`/`vec3`/`vec4` and file paths become textures. `u_texture`, `u_time`, `u_resolution` and `u_pixel_size` are supplied automatically when the shader declares them.

```xml
<objectgroup name="post_processing">
 <object name="corrupt_zone" x="1000" y="2450" width="600" height="500">
  <properties>
   <property name="fragment_shader" value="data/shaders/gameboy.frag"/>
   <property name="scope" value="level"/>
   <property name="u_grid_size" value="640,360"/>
   <property name="u_mid_grey" type="float" value="0.17"/>
  </properties>
 </object>
</objectgroup>
```

A sized rectangle acts as a trigger area — the effect is active while the player is inside it. A zero sized rectangle leaves the mechanism under script control through `setMechanismEnabled`. When several are enabled at once the highest `z` wins and the others are logged; stacking would need a second full screen target and an extra pass per effect.

## MechanismRenderStage

A post processing pass cannot draw itself from inside the level pass, because it runs after the level is composited. `GameMechanism` therefore gains a `MechanismRenderStage` (`Level` / `PostProcessing`) alongside the existing `isPostLighting()` and `isOverlay()` stage flags. Post processing mechanisms do not draw; they hand their shader to the stage.

## Effects

- **gameboy** — quantizes to a grid derived from the view size, so it snaps to the game's own pixel grid at any window scale, then maps luminance to the 4 colour DMG palette with a 4x4 Bayer dither.
- **rgbsplit** — horizontal channel separation with a slow wobble.
- **glitch** — horizontal band tearing in short bursts, channel separation while a burst is active, constant scanlines.

Two things that needed measurement rather than guessing:

- The tone curve is Reinhard, not a linear window. The catacombs sit far below the palette thresholds (97% of pixels under 0.25 luminance), and a linear window clips everything above its white point to the lightest colour — 17.8% of the player was clipping to flat white, turning it into a silhouette. Reinhard never reaches 1.0, so highlights keep their relative differences and stay shaded.
- Effect parameters are expressed in game pixels rather than screen pixels, so they keep their apparent size across resolutions.

## Console

`postfx <none|gameboy|rgbsplit|glitch>` and `postfx scope <all|level>` remain as an override that wins over mechanisms, which keeps them useful for testing in levels that configure their own effect.

## Testing

Driven headed against the catacombs start position at 1280x720 and 1920x1080:

- all three effects verified under both scopes
- block size measured against the game's own pixel size to confirm the gameboy grid lands exactly on one game pixel at both resolutions
- mechanism verified end to end: effect on inside its trigger rect (100% exact DMG palette pixels), off outside it (0%), on again on return
- `postfx none` confirmed to restore an untouched frame

Desktop builds clean; every changed file also passes `em++ -fsyntax-only` against the VRSFML headers, and all three shaders carry the `#ifdef GL_ES` dual path.
