### PR TITLE
put the whole glow path behind GLOW_ENABLED

### DIFF
--- a/src/game/level/level.cpp
+++ b/src/game/level/level.cpp
@@ -174,7 +174,9 @@ Level::Level(const RenderTargets& render_targets) : GameNode(nullptr), _render_t
 
    // create shaders (render textures are owned by Game)
    _atmosphere_shader = std::make_unique<AtmosphereShader>();
+#ifdef GLOW_ENABLED
    _blur_shader = std::make_unique<BlurShader>();
+#endif
    _gamma_shader = std::make_unique<GammaShader>();
 
    // load alpha-test shader for occluder stencil rendering
@@ -529,7 +531,9 @@ void Level::initialize()
 
    // initialize shaders with render targets from Game
    _atmosphere_shader->initialize(_render_targets.atmosphere);
+#ifdef GLOW_ENABLED
    _blur_shader->initialize(_render_targets.blur, _render_targets.blur_scaled);
+#endif
    _gamma_shader->initialize();
 
    loadStartPosition();
@@ -1256,6 +1260,7 @@ void Level::drawAtmosphereLayer()
 #endif
 }
 
+#ifdef GLOW_ENABLED
 void Level::drawBlurLayer(sf::RenderTarget& target)
 {
 #ifndef __EMSCRIPTEN__
@@ -1264,7 +1269,6 @@ void Level::drawBlurLayer(sf::RenderTarget& target)
 
    // draw elements that are supposed to glow / to be blurred here
 
-#ifdef GLOW_ENABLED
    // lasers have been removed here because dstar added the glow to the spriteset
 
    const auto pPos = PlayerRegistry::getFirst()->getPixelPositionf();
@@ -1280,8 +1284,8 @@ void Level::drawBlurLayer(sf::RenderTarget& target)
 
       laser->draw(target);
    }
-#endif
 }
+#endif
 
 bool Level::isPhysicsPathClear(const sf::Vector2i& a_tl, const sf::Vector2i& b_tl) const
 {
@@ -1390,19 +1394,19 @@ void Level::displayFinalTextures()
    _render_targets.normal->display();
 }
 
+#ifdef GLOW_ENABLED
 void Level::drawGlowLayer()
 {
-#ifdef GLOW_ENABLED
    _blur_shader->clearTexture();
    drawBlurLayer(*_blur_shader->getRenderTexture().get());
    _blur_shader->getRenderTexture()->display();
    takeScreenshot("screenshot_blur", *_blur_shader->getRenderTexture().get());
-#endif
 }
+#endif
 
+#ifdef GLOW_ENABLED
 void Level::drawGlowSprite()
 {
-#ifdef GLOW_ENABLED
 #ifdef __EMSCRIPTEN__
    const sf::Texture& blur_texture = _blur_shader->getRenderTexture()->getTexture();
    sf::Sprite blur_sprite;
@@ -1458,8 +1462,8 @@ void Level::drawGlowSprite()
    states_add.blendMode = sf::BlendAdd;
    _render_targets.level->draw(blur_scale_sprite, states_add);
 #endif
-#endif
 }
+#endif
 
 const std::vector<std::shared_ptr<Room>>& Level::getRooms() const
 {
@@ -1536,7 +1540,9 @@ void Level::draw(const std::shared_ptr<sf::RenderTexture>& window, bool screensh
 #endif
 
    // render glowing elements
+#ifdef GLOW_ENABLED
    drawGlowLayer();
+#endif
 
    // render layers affected by the atmosphere
    _render_targets.level->clear();
@@ -1570,7 +1576,9 @@ void Level::draw(const std::shared_ptr<sf::RenderTexture>& window, bool screensh
    _render_targets.normal->draw(tmp_sprite, &_atmosphere_shader->getShader());
    takeScreenshot("texture_level_background_normal_dist", *_render_targets.normal.get());
 
+#ifdef GLOW_ENABLED
    drawGlowSprite();
+#endif
 #else
    // WASM: blit level_background to level and normal_tmp to normal without atmosphere distortion
    {

--- a/src/game/level/level.h
+++ b/src/game/level/level.h
@@ -25,7 +25,9 @@
 #include "game/physics/squaremarcher.h"
 #include "game/rendering/rendertargets.h"
 #include "game/shaders/atmosphereshader.h"
+#ifdef GLOW_ENABLED
 #include "game/shaders/blurshader.h"
+#endif
 #include "game/shaders/gammashader.h"
 
 // sfml
@@ -385,7 +387,9 @@ protected:
    std::shared_ptr<LightSystem::LightInstance> _player_light;
    std::unique_ptr<AmbientOcclusion> _ambient_occlusion;
    std::unique_ptr<AtmosphereShader> _atmosphere_shader;
+#ifdef GLOW_ENABLED
    std::unique_ptr<BlurShader> _blur_shader;
+#endif
    std::unique_ptr<GammaShader> _gamma_shader;
    sfcompat::Shader _occluder_shader;  //!< alpha-test shader for light occluder stencil rendering
    bool _screenshot = false;

--- a/src/game/rendering/rendertargets.cpp
+++ b/src/game/rendering/rendertargets.cpp
@@ -26,13 +26,9 @@ void RenderTargets::create(uint32_t video_mode_width, uint32_t video_mode_height
    const sf::RenderTextureCreateSettings stencil_settings{.stencilBits = 8u};
 
    auto make_rt = [](sf::Vector2u size) -> std::shared_ptr<sf::RenderTexture>
-   {
-      return std::make_shared<sf::RenderTexture>(std::move(*sf::RenderTexture::create(size)));
-   };
+   { return std::make_shared<sf::RenderTexture>(std::move(*sf::RenderTexture::create(size))); };
    auto make_rt_stencil = [&stencil_settings](sf::Vector2u size) -> std::shared_ptr<sf::RenderTexture>
-   {
-      return std::make_shared<sf::RenderTexture>(std::move(*sf::RenderTexture::create(size, stencil_settings)));
-   };
+   { return std::make_shared<sf::RenderTexture>(std::move(*sf::RenderTexture::create(size, stencil_settings))); };
 
    level_background = make_rt(texture_size);
    level = make_rt_stencil(texture_size);
@@ -49,9 +45,11 @@ void RenderTargets::create(uint32_t video_mode_width, uint32_t video_mode_height
    normal_tmp = make_rt(texture_size);
    deferred = make_rt(texture_size);
    atmosphere = make_rt(texture_size);
+#ifdef GLOW_ENABLED
    blur = make_rt_stencil(texture_size);
    blur_scaled = make_rt_stencil(sf::Vector2u{960u, 540u});
    blur_scaled->setSmooth(true);
+#endif
 #else
    try
    {
@@ -71,9 +69,11 @@ void RenderTargets::create(uint32_t video_mode_width, uint32_t video_mode_height
       normal_tmp = std::make_shared<sf::RenderTexture>(texture_size);
       deferred = std::make_shared<sf::RenderTexture>(texture_size);
       atmosphere = std::make_shared<sf::RenderTexture>(texture_size);
+#ifdef GLOW_ENABLED
       blur = std::make_shared<sf::RenderTexture>(texture_size, stencil_context_settings);
       blur_scaled = std::make_shared<sf::RenderTexture>(sf::Vector2u{960, 540}, stencil_context_settings);
       blur_scaled->setSmooth(true);
+#endif
    }
    catch (const std::exception& e)
    {
@@ -90,8 +90,10 @@ void RenderTargets::create(uint32_t video_mode_width, uint32_t video_mode_height
    _all_textures.push_back(normal_tmp);
    _all_textures.push_back(deferred);
    _all_textures.push_back(atmosphere);
+#ifdef GLOW_ENABLED
    _all_textures.push_back(blur);
    _all_textures.push_back(blur_scaled);
+#endif
 
    // for (const auto& texture : _all_textures)
    // {
@@ -110,8 +112,10 @@ void RenderTargets::recreateOnResize(uint32_t video_mode_width, uint32_t video_m
    normal_tmp.reset();
    deferred.reset();
    atmosphere.reset();
+#ifdef GLOW_ENABLED
    blur.reset();
    blur_scaled.reset();
+#endif
    _all_textures.clear();
 
    create(video_mode_width, video_mode_height, view_width, view_height);

--- a/src/game/rendering/rendertargets.h
+++ b/src/game/rendering/rendertargets.h
@@ -33,11 +33,13 @@ struct RenderTargets
    /// \brief atmosphere distortion pass texture.
    std::shared_ptr<sf::RenderTexture> atmosphere;
 
+#ifdef GLOW_ENABLED
    /// \brief full-size blur/glow pass texture.
    std::shared_ptr<sf::RenderTexture> blur;
 
    /// \brief downscaled blur texture used by glow upsampling.
    std::shared_ptr<sf::RenderTexture> blur_scaled;
+#endif
 
    /// \brief conversion factor from logical view units to texture-space units.
    float view_to_texture_scale = 1.0f;


### PR DESCRIPTION
The glow effect was replaced by artwork — blurred layers with transparency — and its runtime path was switched off by leaving `GLOW_ENABLED` undefined. A comment in `drawBlurLayer` records the same thing: *"lasers have been removed here because dstar added the glow to the spriteset"*.

Only the **draw calls** were guarded, though. Everything that costs memory stayed live.

## What was still being allocated

| Thing | State before |
|---|---|
| `RenderTargets::blur` (full size, stencil) | allocated every level load, never written |
| `RenderTargets::blur_scaled` (960×540, stencil, smooth) | allocated every level load, never written |
| `BlurShader` + `data/shaders/blur.frag` | constructed and `initialize()`d unconditionally — shader compiled, never used |
| `drawBlurLayer` / `drawGlowLayer` / `drawGlowSprite` | bodies fully inside the guard, so empty functions called every frame |

`Level::Level` and `Level::initialize` sat outside the guard, so the shader really was created and really was handed both targets on every level load. Their only other reference is that `initialize()` call — nothing ever draws into them.

At 1920×1080 that is roughly **10 MB of colour buffers** held permanently for a feature that compiles to nothing, and more once the stencil attachments are counted.

## Change

The guard now covers the render targets, the shader, the member declarations, the function definitions and the call sites, so nothing is allocated or loaded while the effect is off. Redundant nested `#ifdef GLOW_ENABLED` blocks inside the now-wrapped functions were removed; no code or comments were deleted.

## The enclosed code no longer compiles

Worth knowing before anyone tries to switch it back on. It predates both the member naming convention and the SFML 3 migration:

- `PlayerInterface::getPixelPositionf` (now `getPixelPositionFloat`)
- `mLasers` — pre-`_name` convention
- `SfmlMath::lengthSquared` — gone
- `Transformable::scale` called with two arguments
- `sf::Texture` dereferenced with `->`

I verified this by defining `GLOW_ENABLED` and building, **before and after** this change: the error set is identical, so this PR does not make the disabled path any more broken than it already was. But re-enabling means porting it, not flipping a switch — which is why no cmake option is exposed.

## Testing

- Builds clean with glow off; game runs and renders identically at the catacombs start position
- Builds with `GLOW_ENABLED` defined produce exactly the pre-existing error set, no new structural errors from the restructuring
- `level.cpp` and `rendertargets.cpp` pass `em++ -fsyntax-only` against the VRSFML headers
