### PR TITLE
console commands for judging artwork: lighting bypass and mechanism toggles

### DIFF
--- a/src/game/debug/console.cpp
+++ b/src/game/debug/console.cpp
@@ -458,6 +458,31 @@ Console::Console()
       }
    );
 
+   // lighting
+   _help.registerCommand(
+      "leveldesign",
+      "lighting <enable/disable>: bypass the deferred lighting pass and show the level unlit",
+      {"lighting enable", "lighting disable"}
+   );
+
+   addCommand(
+      "lighting enable",
+      [this](const auto&)
+      {
+         DebugDrawStates::_draw_lighting = true;
+         _log.emplace_back("lighting enabled");
+      }
+   );
+
+   addCommand(
+      "lighting disable",
+      [this](const auto&)
+      {
+         DebugDrawStates::_draw_lighting = false;
+         _log.emplace_back("lighting disabled, level is drawn unlit");
+      }
+   );
+
    // playerlight
    _help.registerCommand(
       "leveldesign",

--- a/src/game/debug/console.cpp
+++ b/src/game/debug/console.cpp
@@ -5,6 +5,7 @@
 #include "game/debug/debugdrawstates.h"
 #include "framework/tools/callbackmap.h"
 #include "game/constants.h"
+#include "game/level/gamemechanismregistry.h"
 #include "game/level/levelregistry.h"
 #include "game/level/levels.h"
 #include "game/level/room.h"
@@ -21,6 +22,7 @@
 
 #include <cctype>
 #include <iostream>
+#include <map>
 #include <ostream>
 #include <ranges>
 #include <sstream>
@@ -458,6 +460,45 @@ Console::Console()
       }
    );
 
+   // mechanisms
+   _help.registerCommand(
+      "leveldesign",
+      "mechanism <list/enable/disable> <type>: enable or disable every mechanism of a type",
+      {"mechanism list", "mechanism disable smoke", "mechanism enable smoke"}
+   );
+
+   addCommand("mechanism list", [this](const auto&) { listMechanismTypes(); });
+
+   addCommand(
+      "mechanism enable",
+      [this](const auto& args)
+      {
+         if (args.size() == 3)
+         {
+            setMechanismTypeEnabled(args.at(2), true);
+         }
+         else
+         {
+            _log.emplace_back("usage: mechanism enable <type>");
+         }
+      }
+   );
+
+   addCommand(
+      "mechanism disable",
+      [this](const auto& args)
+      {
+         if (args.size() == 3)
+         {
+            setMechanismTypeEnabled(args.at(2), false);
+         }
+         else
+         {
+            _log.emplace_back("usage: mechanism disable <type>");
+         }
+      }
+   );
+
    // lighting
    _help.registerCommand(
       "leveldesign",
@@ -870,6 +911,88 @@ void Console::teleportToRoom(const std::string& room_name)
 
    _log.push_back(os.str());
    PlayerRegistry::getFirst()->setBodyViaPixelPosition(target_position.x, target_position.y);
+}
+
+void Console::listMechanismTypes()
+{
+   const auto level = LevelRegistry::getCurrent();
+   if (!level)
+   {
+      _log.emplace_back("no level loaded");
+      return;
+   }
+
+   // sorted so the output is stable, the registry map is unordered
+   std::map<std::string, std::pair<int32_t, int32_t>> counts_by_type;
+   for (const auto& [group, mechanisms] : level->getMechanismRegistry().getMap())
+   {
+      if (mechanisms == nullptr || mechanisms->empty())
+      {
+         continue;
+      }
+
+      auto& counts = counts_by_type[group];
+      counts.first = static_cast<int32_t>(mechanisms->size());
+      counts.second =
+         static_cast<int32_t>(std::ranges::count_if(*mechanisms, [](const auto& mechanism) { return mechanism->isEnabled(); }));
+   }
+
+   if (counts_by_type.empty())
+   {
+      _log.emplace_back("this level has no mechanisms");
+      return;
+   }
+
+   // packed a few per line, a level can easily have more types than the console can show
+   constexpr auto types_per_line = 3;
+   std::ostringstream line;
+   auto column = 0;
+   for (const auto& [group, counts] : counts_by_type)
+   {
+      line << group << " " << counts.second << "/" << counts.first << "   ";
+      if (++column == types_per_line)
+      {
+         _log.push_back(line.str());
+         line.str({});
+         column = 0;
+      }
+   }
+
+   if (column > 0)
+   {
+      _log.push_back(line.str());
+   }
+}
+
+void Console::setMechanismTypeEnabled(const std::string& type_filter, bool enabled)
+{
+   const auto level = LevelRegistry::getCurrent();
+   if (!level)
+   {
+      _log.emplace_back("no level loaded");
+      return;
+   }
+
+   const auto needle = toLowerCase(type_filter);
+   const auto mechanisms = level->getMechanismRegistry().searchMechanismsIf(
+      [&needle](const auto& mechanism, std::string_view group)
+      { return toLowerCase(std::string{group}).contains(needle) || toLowerCase(std::string{mechanism->objectName()}).contains(needle); }
+   );
+
+   if (mechanisms.empty())
+   {
+      _log.emplace_back("no mechanism type matching '" + type_filter + "', try 'mechanism list'");
+      return;
+   }
+
+   for (const auto& mechanism : mechanisms)
+   {
+      mechanism->setEnabled(enabled);
+   }
+
+   std::ostringstream message;
+   message << (enabled ? "enabled " : "disabled ") << mechanisms.size() << " mechanism(s) matching '" << type_filter << "'";
+   _log.push_back(message.str());
 }
 
 void Console::listLevels()

--- a/src/game/debug/console.h
+++ b/src/game/debug/console.h
@@ -162,6 +162,17 @@ private:
    /// \brief prints the levels listed in levels.json together with their indices.
    void listLevels();
 
+   /// \brief prints the mechanism types present in the current level with their enabled counts.
+   void listMechanismTypes();
+
+   /// \brief enables or disables every mechanism whose type matches a filter.
+   /// \details the filter is matched case insensitively against both the tmx group name a mechanism
+   ///          was loaded from and its object name, as a substring, so "smoke" reaches the
+   ///          "smoke_effect" group without having to spell it out.
+   /// \param type_filter partial mechanism type name.
+   /// \param enabled true to enable the matching mechanisms, false to disable them.
+   void setMechanismTypeEnabled(const std::string& type_filter, bool enabled);
+
    /// \brief switches to another level listed in levels.json.
    /// \details the level is identified either by its index in the list or by a case insensitive
    ///          substring of its description filename, so "level load graveyard" is enough. this

--- a/src/game/debug/debugdrawstates.cpp
+++ b/src/game/debug/debugdrawstates.cpp
@@ -7,3 +7,4 @@ bool DebugDrawStates::_draw_controller_overlay = false;
 bool DebugDrawStates::_draw_camera_system = false;
 bool DebugDrawStates::_draw_physics_config = false;
 bool DebugDrawStates::_draw_log = false;
+bool DebugDrawStates::_draw_lighting = true;

--- a/src/game/debug/debugdrawstates.h
+++ b/src/game/debug/debugdrawstates.h
@@ -11,6 +11,9 @@ struct DebugDrawStates
    static bool _draw_camera_system;
    static bool _draw_physics_config;
    static bool _draw_log;
+
+   //! \brief when false the deferred lighting pass is bypassed and the level is drawn unlit
+   static bool _draw_lighting;
 };  // namespace DrawStates
 
 #endif  // DEBUGDRAWSTATES_H

--- a/src/game/level/gamemechanismregistry.cpp
+++ b/src/game/level/gamemechanismregistry.cpp
@@ -139,6 +139,11 @@ GameMechanismRegistry::MechanismVectorMap& GameMechanismRegistry::getMap()
    return _mechanisms_map;
 }
 
+const GameMechanismRegistry::MechanismVectorMap& GameMechanismRegistry::getMap() const
+{
+   return _mechanisms_map;
+}
+
 const GameMechanismRegistry::MechanismVector& GameMechanismRegistry::getDoors() const
 {
    return _mechanism_doors;

--- a/src/game/level/gamemechanismregistry.h
+++ b/src/game/level/gamemechanismregistry.h
@@ -21,6 +21,10 @@ public:
    /// \return mechanism group map used during deserialization and lookup.
    MechanismVectorMap& getMap();
 
+   /// \brief returns the map from mechanism layer names to mechanism vectors for inspection.
+   /// \return mechanism group map, keyed by the tmx layer name.
+   const MechanismVectorMap& getMap() const;
+
    /// \brief returns all mechanism vectors as a flat list of group pointers.
    /// \return list of mechanism groups for bulk iteration.
    std::vector<MechanismVector*>& getList();

--- a/src/game/level/level.cpp
+++ b/src/game/level/level.cpp
@@ -21,6 +21,7 @@
 #include "game/config/tweaks.h"
 #include "game/constants.h"
 #include "game/debug/debugdraw.h"
+#include "game/debug/debugdrawstates.h"
 #include "game/ingamemenu/ingamemenumap.h"
 #include "game/io/gamedeserializedata.h"
 #include "game/io/meshtools.h"
@@ -1655,11 +1656,30 @@ void Level::draw(const std::shared_ptr<sf::RenderTexture>& window, bool screensh
 
    displayFinalTextures();
 
-   drawLightMap();
+   if (DebugDrawStates::_draw_lighting)
+   {
+      drawLightMap();
 
-   _light_system->draw(
-      *_render_targets.deferred.get(), _render_targets.level, _render_targets.lighting, _render_targets.lighting2, _render_targets.normal
-   );
+      _light_system->draw(
+         *_render_targets.deferred.get(), _render_targets.level, _render_targets.lighting, _render_targets.lighting2, _render_targets.normal
+      );
+   }
+   else
+   {
+      // the deferred pass is what puts the level into the deferred target in the first place, so
+      // switching lighting off has to blit the unlit color map instead of merely skipping the pass,
+      // otherwise the frame stays black. the result is the artwork at full brightness.
+      const sf::Texture& unlit_texture = _render_targets.level->getTexture();
+#ifdef __EMSCRIPTEN__
+      sf::Sprite unlit_sprite;
+      unlit_sprite.textureRect =
+         sf::FloatRect{{0.0f, 0.0f}, {static_cast<float>(unlit_texture.getSize().x), static_cast<float>(unlit_texture.getSize().y)}};
+      _render_targets.deferred->draw(unlit_sprite, sf::RenderStates{.texture = &unlit_texture});
+#else
+      sf::Sprite unlit_sprite(unlit_texture);
+      _render_targets.deferred->draw(unlit_sprite);
+#endif
+   }
 
    drawPostLightingLayers(*_render_targets.deferred.get());
 

--- a/src/game/mechanisms/smokeeffect.cpp
+++ b/src/game/mechanisms/smokeeffect.cpp
@@ -36,6 +36,11 @@ void SmokeEffect::draw(sf::RenderTarget& color, sf::RenderTarget& normal)
 
 void SmokeEffect::draw(sf::RenderTarget& color, sf::RenderTarget& /*normal*/, const sf::RenderStates& states)
 {
+   if (!isEnabled())
+   {
+      return;
+   }
+
    _render_texture->clear();
 
    // old expensive approach, instead all particles are now drawn as one huge triangle list
@@ -74,6 +79,11 @@ void SmokeEffect::draw(sf::RenderTarget& color, sf::RenderTarget& /*normal*/, co
 #else
 void SmokeEffect::draw(sf::RenderTarget& color, sf::RenderTarget& /*normal*/)
 {
+   if (!isEnabled())
+   {
+      return;
+   }
+
    _render_texture->clear();
 
    // old expensive approach, instead all particles are now drawn as one huge triangle list
@@ -105,6 +115,11 @@ void SmokeEffect::draw(sf::RenderTarget& color, sf::RenderTarget& /*normal*/)
 
 void SmokeEffect::update(const sf::Time& dt)
 {
+   if (!isEnabled())
+   {
+      return;
+   }
+
    _elapsed += dt;
    const auto dt_scaled = dt.asSeconds() * _velocity;
 


### PR DESCRIPTION
Two debug console commands for level design work, both on top of the merged post-processing branch.

## `lighting <enable/disable>`

Bypasses the deferred lighting pass so the level is drawn unlit, which is useful for judging artwork without lighting on top of it.

It cannot simply skip the pass — the deferred draw is what puts the level into the deferred target in the first place, so skipping leaves a black frame. It blits the unlit colour map instead, and skips building the light map while off.

Measured against the lit frame at the catacombs start:

| | |
|---|---|
| frame affected by lighting | 18.3% of pixels |
| hanging lamp region | 54% of its brightness came from the lighting pass |
| doorway glow | only 2% removed — that one is painted into the artwork |

Worth knowing what "unlit" means here: the colour map already holds the artwork, ambient occlusion and the additive lights, so what disappears is the raycast light contribution and the normal-mapped shading. It is **not** a full-bright view, because the artwork itself is painted dark.

## `mechanism <list/enable/disable> <type>`

```
> mechanism list
  ...  smoke 31/31   sound_emitters 3/3   spike_balls 7/7
  spike_blocks 12/12   static_lights 287/287   treasure_chests 3/3
> mechanism disable smoke
  disabled 31 mechanism(s) matching 'smoke'
```

The filter is matched case-insensitively as a substring against both the TMX group a mechanism was loaded from and its `objectName()`, so `smoke` reaches the `smoke_effect` group without spelling it out. Unknown types point back at `mechanism list`. `mechanism list` packs three types per line so it stays inside the console log.

Adds a const overload of `GameMechanismRegistry::getMap()` for the listing; the enable/disable path uses the existing `searchMechanismsIf`.

## SmokeEffect ignored its enabled flag

Disabling it reported success while the smoke kept drawing and updating. It now returns early from `update()` and both `draw()` overloads.

Verified at checkpoint 2, controlling for camera drift between captures: two consecutive frames with smoke on differ by 1.17%, smoke on versus off differs by 2.14%.

Note this is a **per-mechanism convention rather than a central one** — `Level` does not filter by `isEnabled()` before update or draw, and only 16 of the 60 mechanisms check the flag themselves. So the same gap likely exists for others; this PR only fixes smoke.

## Testing

Driven headed against the catacombs. Desktop builds clean; `level.cpp` passes `em++ -fsyntax-only` against the VRSFML headers.
