### PR TITLE
read inventory item descriptions after romfs is mounted

### DIFF
--- a/src/game/ingamemenu/ingamemenuinventory.cpp
+++ b/src/game/ingamemenu/ingamemenuinventory.cpp
@@ -258,14 +258,14 @@ InGameMenuInventory::InGameMenuInventory()
 
 void InGameMenuInventory::loadInventoryItems()
 {
-   const auto& inventory_item_descriptions = getInventory()._descriptions;
+   const auto& inventory_item_descriptions = getInventory().getDescriptions();
    _inventory_texture = TexturePool::getInstance().get("data/sprites/inventory_items.png");
 
    std::ranges::for_each(
       inventory_item_descriptions,
       [this](const auto& image)
       {
-         // store sprites
+   // store sprites
 #ifdef DECEPTUS_VRSFML
          std::unique_ptr<sf::Sprite> sprite = std::make_unique<sf::Sprite>();
          sprite->textureRect = sf::FloatRect(

--- a/src/game/layers/infolayer.cpp
+++ b/src/game/layers/infolayer.cpp
@@ -20,6 +20,7 @@
 #include "game/state/savestate.h"
 
 #include <iostream>
+#include <set>
 #include <sstream>
 
 namespace
@@ -263,7 +264,7 @@ InfoLayer::InfoLayer()
 void InfoLayer::loadInventoryItems()
 {
    const auto& inventory = SaveState::getPlayerInfo()._inventory;
-   const auto& inventory_item_descriptions = inventory._descriptions;
+   const auto& inventory_item_descriptions = inventory.getDescriptions();
    _inventory_texture = TexturePool::getInstance().get("data/sprites/inventory_items.png");
 
    std::ranges::for_each(
@@ -316,14 +317,24 @@ void InfoLayer::updateInventoryItems()
          continue;
       }
 
-      const auto& sprite = _sprites[slot];
+      // find rather than operator[], which would insert a null sprite for an unknown slot and leave
+      // the table quietly growing a broken entry every frame
+      const auto sprite_it = _sprites.find(slot);
 
-      if (sprite == nullptr)
+      if (sprite_it == _sprites.end() || sprite_it->second == nullptr)
       {
-         Log::Fatal() << "could not find matching item description for '" << slot << "'. please edit inventory_items.json";
+         // a missing icon is a cosmetic problem, so the item is drawn without one rather than taken
+         // as a reason to end the process. warned once per slot, because this runs every frame
+         static std::set<std::string> warned_slots;
+         if (warned_slots.insert(slot).second)
+         {
+            Log::Error() << "no item description for '" << slot << "', it will have no icon. please edit inventory_items.json";
+         }
+
+         continue;
       }
 
-      sfcompat::setTextureRect(*_inventory_sprites[i], sfcompat::getTextureRect(*sprite));
+      sfcompat::setTextureRect(*_inventory_sprites[i], sfcompat::getTextureRect(*sprite_it->second));
    }
 }
 

--- a/src/game/player/inventory.cpp
+++ b/src/game/player/inventory.cpp
@@ -29,9 +29,16 @@ void removeCallbackFromVector(std::vector<Callback>& callbacks, const Callback& 
 }
 }  // namespace
 
-Inventory::Inventory()
+Inventory::Inventory() = default;
+
+const std::vector<InventoryItemDescriptionReader::InventoryItemDescription>& Inventory::getDescriptions() const
 {
-   _descriptions = InventoryItemDescriptionReader::readItemDescriptions();
+   if (_descriptions.empty())
+   {
+      _descriptions = InventoryItemDescriptionReader::readItemDescriptions();
+   }
+
+   return _descriptions;
 }
 
 void Inventory::add(const std::string& item)
@@ -131,7 +138,7 @@ std::vector<std::string> Inventory::readItemNames() const
 {
    std::vector<std::string> names;
    std::ranges::transform(
-      _descriptions, std::back_inserter(names), [](const auto& description) -> std::string { return description._name; }
+      getDescriptions(), std::back_inserter(names), [](const auto& description) -> std::string { return description._name; }
    );
    return names;
 }
@@ -185,10 +192,12 @@ void Inventory::use(int32_t slot)
          {
             // if the item has a 'consumed after use' property, remove it
             const auto& it = std::find_if(
-               _descriptions.begin(), _descriptions.end(), [item_name](const auto& description) { return description._name == item_name; }
+               getDescriptions().begin(),
+               getDescriptions().end(),
+               [item_name](const auto& description) { return description._name == item_name; }
             );
 
-            if (it != _descriptions.end())
+            if (it != getDescriptions().end())
             {
                if (it->_properties.find("consumed_after_use") != it->_properties.end())
                {

--- a/src/game/player/inventory.h
+++ b/src/game/player/inventory.h
@@ -12,6 +12,16 @@ struct Inventory
    /// \brief creates an inventory and loads item descriptions from data files.
    Inventory();
 
+   ///
+   /// \brief Returns the inventory item descriptions, reading them on first use.
+   ///
+   /// Deliberately not read in the constructor. SaveState keeps its save slots in a static array, so
+   /// every Inventory is constructed during static initialization - before main() has mounted romfs
+   /// and changed into it. On the console the relative path therefore resolved against nothing, the
+   /// descriptions came back empty, and the first item picked up had no icon to show for it.
+   ///
+   const std::vector<InventoryItemDescriptionReader::InventoryItemDescription>& getDescriptions() const;
+
    /// \brief adds an item key, auto-fills a free slot, and notifies updated/added callbacks.
    /// \param item item key to append to the inventory list.
    void add(const std::string&);
@@ -85,7 +95,7 @@ struct Inventory
    std::array<std::string, 2> _slots;
 
    // additional inventory data
-   std::vector<InventoryItemDescriptionReader::InventoryItemDescription> _descriptions;
+   mutable std::vector<InventoryItemDescriptionReader::InventoryItemDescription> _descriptions;  //!< see getDescriptions()
 };
 
 /// \brief serializes inventory items and slot assignments to json.

--- a/src/game/player/inventoryitemdescriptionreader.cpp
+++ b/src/game/player/inventoryitemdescriptionreader.cpp
@@ -44,6 +44,10 @@ std::vector<InventoryItemDescriptionReader::InventoryItemDescription> InventoryI
 
    if (!std::filesystem::exists(json_path))
    {
+      // returning empty without a word cost an afternoon: the game then ran on for another minute
+      // before an item was picked up that had no icon, and reported that as a fatal blaming the
+      // contents of this file, which was neither missing nor wrong - it simply had not been read
+      Log::Error() << "cannot read " << json_path << " from " << std::filesystem::current_path() << ", inventory items will have no icons";
       return {};
    }
 


### PR DESCRIPTION
Picking up the key at the start of the catacombs killed the game on the Switch, with nothing in the log to say why.

## Cause

`SaveState` keeps its three save slots in a **static array**, so every `Inventory` is constructed during static initialization — before `main()` has called `romfsInit()` and changed into it. `Inventory`'s constructor read `data/sprites/inventory_items.json` through a relative path, which at that point resolved against nothing.

The reader returned an empty list, `InfoLayer` built its icon table from that empty list, and the first item picked up a minute later found no icon. Desktop never showed it, because the working directory is already correct before `main()` runs.

Descriptions are now read on first use, which for `InfoLayer` happens in `Game::initialize` — long after romfs is mounted.

## Diagnosability

Three things made this much harder to track down than it should have been, all fixed here:

- a missing icon called `Log::Fatal`, which ends the process. It is a cosmetic problem; the item is now drawn without an icon and the slot reported once.
- that fatal blamed the *contents* of `inventory_items.json`, which was neither missing nor malformed — it had simply never been read.
- the reader returned `{}` silently when the file was absent. It now says so, and names the working directory it looked in.

Worth knowing for the next one: **`Log::Fatal` on the console loses its own message.** It terminates, and `LogThread` then dies flushing to the sd card during teardown, so the crash surfaces as a null dereference inside `armGetTls` with no explanation anywhere — the message that would have explained it was still sitting in the queue.

## Verified

Switch and desktop both build. On the console the descriptions now load at start up with no error, so `"key"` gets its icon from the json rather than tripping the old fatal.