### PR TITLE
make rain, lightning and water render on the switch and wasm builds

### DIFF
--- a/src/game/layers/rainoverlay.cpp
+++ b/src/game/layers/rainoverlay.cpp
@@ -46,6 +46,19 @@ std::vector<b2Body*> retrieveBodiesOnScreen(const std::shared_ptr<b2World>& worl
    return WorldQuery::queryBodies(world, aabb);
 }
 
+// source: foreground
+// dest:   background
+
+// BlendMode(Factor sourceFactor, Factor destinationFactor, Equation blendEquation = Equation::Add);
+const sf::BlendMode rain_blend_mode(
+   sf::BlendMode::Factor::SrcAlpha,          // colorSourceFactor
+   sf::BlendMode::Factor::OneMinusSrcAlpha,  // colorDestinationFactor
+   sf::BlendMode::Equation::Add,             // colorBlendEquation
+   sf::BlendMode::Factor::SrcAlpha,          // alphaSourceFactor
+   sf::BlendMode::Factor::OneMinusSrcAlpha,  // alphaDestinationFactor
+   sf::BlendMode::Equation::Add              // alphaBlendEquation
+);
+
 }  // namespace
 
 RainOverlay::RainOverlay() : _texture(TexturePool::getInstance().get("data/sprites/rain.png"))
@@ -69,16 +82,10 @@ RainOverlay::~RainOverlay()
    stopPlaying();
 }
 
-void RainOverlay::draw(sf::RenderTarget& target, sf::RenderTarget& /*normal*/)
+void RainOverlay::draw(sf::RenderTarget& target, sf::RenderTarget& normal)
 {
 #ifdef DECEPTUS_VRSFML
-   {
-      const auto screen_view = target.computeView();
-      _screen = {
-         {screen_view.center.x - screen_view.size.x / 2.0f, screen_view.center.y - screen_view.size.y / 2.0f},
-         {screen_view.size.x, screen_view.size.y}
-      };
-   }
+   draw(target, normal, {});
 #else
    const auto& screen_view = target.getView();
 
@@ -86,31 +93,13 @@ void RainOverlay::draw(sf::RenderTarget& target, sf::RenderTarget& /*normal*/)
       {screen_view.getCenter().x - screen_view.getSize().x / 2.0f, screen_view.getCenter().y - screen_view.getSize().y / 2.0f},
       {screen_view.getSize().x, screen_view.getSize().y}
    };
-#endif
-
-   // source: foreground
-   // dest:   background
-
-   // BlendMode(Factor sourceFactor, Factor destinationFactor, Equation blendEquation = Equation::Add);
-   static sf::BlendMode blend_mode(
-      sf::BlendMode::Factor::SrcAlpha,          // colorSourceFactor
-      sf::BlendMode::Factor::OneMinusSrcAlpha,  // colorDestinationFactor
-      sf::BlendMode::Equation::Add,             // colorBlendEquation
-      sf::BlendMode::Factor::SrcAlpha,          // alphaSourceFactor
-      sf::BlendMode::Factor::OneMinusSrcAlpha,  // alphaDestinationFactor
-      sf::BlendMode::Equation::Add              // alphaBlendEquation
-   );
 
    for (auto& d : _drops)
    {
       if (d._age_s >= 0.0f)
       {
          // DebugDraw::drawLine(target, d._origin_px, d._pos_px + sf::Vector2f{0.0f, 96.0f}, {0, 0, 1});
-#ifdef DECEPTUS_VRSFML
-         target.draw(*d._sprite, sf::RenderStates{.blendMode = blend_mode});
-#else
-         target.draw(*d._sprite, blend_mode);
-#endif
+         target.draw(*d._sprite, rain_blend_mode);
       }
    }
 
@@ -122,6 +111,46 @@ void RainOverlay::draw(sf::RenderTarget& target, sf::RenderTarget& /*normal*/)
          target.draw(*hit._sprite);
       }
    }
+#endif
+}
+
+void RainOverlay::draw(sf::RenderTarget& target, sf::RenderTarget& normal, const sf::RenderStates& states)
+{
+#ifdef DECEPTUS_VRSFML
+   // the level view travels in the render states, the render target does not carry one; without it the
+   // drops would be placed with the target's default view and land outside the visible area
+   const auto screen_view = (states.view == sf::View{}) ? target.computeView() : states.view;
+
+   _screen = {
+      {screen_view.center.x - screen_view.size.x / 2.0f, screen_view.center.y - screen_view.size.y / 2.0f},
+      {screen_view.size.x, screen_view.size.y}
+   };
+
+   // the texture has to travel in the render states, vrsfml sprites do not own one
+   const sf::RenderStates drop_states{.blendMode = rain_blend_mode, .view = screen_view, .texture = _texture.get()};
+   const sf::RenderStates hit_states{.view = screen_view, .texture = _texture.get()};
+
+   for (auto& d : _drops)
+   {
+      if (d._age_s >= 0.0f)
+      {
+         // DebugDraw::drawLine(target, d._origin_px, d._pos_px + sf::Vector2f{0.0f, 96.0f}, {0, 0, 1});
+         target.draw(*d._sprite, drop_states);
+      }
+   }
+
+   if (_settings._collide)
+   {
+      for (auto& hit : _hits)
+      {
+         // DebugDraw::drawPoint(target, hit._pos_px, {1, 0, 0});
+         target.draw(*hit._sprite, hit_states);
+      }
+   }
+#else
+   (void)states;
+   draw(target, normal);
+#endif
 }
 
 // rain tileset

--- a/src/game/layers/rainoverlay.h
+++ b/src/game/layers/rainoverlay.h
@@ -68,6 +68,12 @@ public:
    /// \param normal unused normal-map target required by the weather overlay interface.
    void draw(sf::RenderTarget& target, sf::RenderTarget& /*normal*/) override;
 
+   /// \brief draws active rain streaks and optional splash sprites with explicit render states.
+   /// \param target SFML render target used for rain rendering.
+   /// \param normal unused normal-map target required by the weather overlay interface.
+   /// \param states render states carrying the level view and, under vrsfml, the rain texture.
+   void draw(sf::RenderTarget& target, sf::RenderTarget& normal, const sf::RenderStates& states) override;
+
    /// \brief updates drop motion, surface intersections, and splash lifetimes.
    /// \param dt elapsed frame time since the previous update.
    void update(const sf::Time& dt) override;

--- a/src/game/layers/thunderstormoverlay.cpp
+++ b/src/game/layers/thunderstormoverlay.cpp
@@ -7,7 +7,12 @@
 #include <cstdlib>
 #include <iostream>
 
-void ThunderstormOverlay::draw(sf::RenderTarget& target, sf::RenderTarget& /*normal*/)
+void ThunderstormOverlay::draw(sf::RenderTarget& target, sf::RenderTarget& normal)
+{
+   draw(target, normal, sf::RenderStates{});
+}
+
+void ThunderstormOverlay::draw(sf::RenderTarget& target, sf::RenderTarget& /*normal*/, const sf::RenderStates& states)
 {
    const auto val = static_cast<uint8_t>(_value * 255);
    const auto col = sf::Color{val, val, val, val};
@@ -27,12 +32,16 @@ void ThunderstormOverlay::draw(sf::RenderTarget& target, sf::RenderTarget& /*nor
       sf::Vertex(top_right, col)
    };
 
-   sf::RenderStates states;
-   states.blendMode = sf::BlendAlpha;
+   sf::RenderStates quad_states;
+   quad_states.blendMode = sf::BlendAlpha;
 #ifdef DECEPTUS_VRSFML
-   target.draw(quad, sf::PrimitiveType::Triangles, states);
+   // the level view travels in the render states, the render target does not carry one; without it the
+   // lightning quad would be placed with the target's default view and land outside the visible area
+   quad_states.view = (states.view == sf::View{}) ? target.computeView() : states.view;
+   target.draw(quad, sf::PrimitiveType::Triangles, quad_states);
 #else
-   target.draw(quad, 6, sf::PrimitiveType::Triangles, states);
+   (void)states;
+   target.draw(quad, 6, sf::PrimitiveType::Triangles, quad_states);
 #endif
 }
 

--- a/src/game/layers/thunderstormoverlay.h
+++ b/src/game/layers/thunderstormoverlay.h
@@ -28,6 +28,12 @@ public:
    /// \param normal unused normal-map target required by the weather overlay interface.
    void draw(sf::RenderTarget& target, sf::RenderTarget& normal) override;
 
+   /// \brief draws the lightning quad with explicit render states.
+   /// \param target SFML render target used for weather output.
+   /// \param normal unused normal-map target required by the weather overlay interface.
+   /// \param states render states carrying the level view.
+   void draw(sf::RenderTarget& target, sf::RenderTarget& normal, const sf::RenderStates& states) override;
+
    /// \brief advances lightning/silence state timers and flash intensity factor.
    /// \param dt elapsed frame time since the previous update.
    void update(const sf::Time& dt) override;

--- a/src/game/level/level.cpp
+++ b/src/game/level/level.cpp
@@ -1292,7 +1292,6 @@ void Level::drawLayers(sf::RenderTarget& target, sf::RenderTarget& normal, int32
 
 void Level::drawAtmosphereLayer()
 {
-#ifndef DECEPTUS_VRSFML
    if (!_atmosphere._tile_map)
    {
       return;
@@ -1300,11 +1299,14 @@ void Level::drawAtmosphereLayer()
 
    _atmosphere_shader->getRenderTexture()->clear();
    _atmosphere._tile_map->setVisible(true);
+#ifdef DECEPTUS_VRSFML
+   _atmosphere_shader->getRenderTexture()->draw(*_atmosphere._tile_map, sf::RenderStates{.view = *_level_view});
+#else
    _atmosphere_shader->getRenderTexture()->setView(*_level_view);
    _atmosphere_shader->getRenderTexture()->draw(*_atmosphere._tile_map);
+#endif
    _atmosphere._tile_map->setVisible(false);
    _atmosphere_shader->getRenderTexture()->display();
-#endif
 }
 
 #ifdef GLOW_ENABLED
@@ -1668,15 +1670,20 @@ void Level::draw(const std::shared_ptr<sf::RenderTexture>& window, bool screensh
    drawGlowSprite();
 #endif
 #else
-   // WASM: blit level_background to level and normal_tmp to normal without atmosphere distortion
    {
-      sf::Sprite blit_sprite;
-      const sf::Vector2u blit_size = _render_targets.level_background->getSize();
-      blit_sprite.textureRect = sf::FloatRect{{0.f, 0.f}, {static_cast<float>(blit_size.x), static_cast<float>(blit_size.y)}};
-      const sf::Texture& blit_bg_texture = _render_targets.level_background->getTexture();
-      _render_targets.level->draw(blit_sprite, sf::RenderStates{.texture = &blit_bg_texture});
-      const sf::Texture& blit_normal_texture = _render_targets.normal_tmp->getTexture();
-      _render_targets.normal->draw(blit_sprite, sf::RenderStates{.texture = &blit_normal_texture});
+      sf::Sprite atmosphere_sprite;
+      const sf::Vector2u atmosphere_sprite_size = _render_targets.level_background->getSize();
+      atmosphere_sprite.textureRect =
+         sf::FloatRect{{0.f, 0.f}, {static_cast<float>(atmosphere_sprite_size.x), static_cast<float>(atmosphere_sprite_size.y)}};
+
+      _atmosphere_shader->update();
+      const sf::Shader& atmosphere_shader = _atmosphere_shader->getShader();
+
+      const sf::Texture& level_background_texture = _render_targets.level_background->getTexture();
+      _render_targets.level->draw(atmosphere_sprite, sf::RenderStates{.texture = &level_background_texture, .shader = &atmosphere_shader});
+
+      const sf::Texture& normal_tmp_texture = _render_targets.normal_tmp->getTexture();
+      _render_targets.normal->draw(atmosphere_sprite, sf::RenderStates{.texture = &normal_tmp_texture, .shader = &atmosphere_shader});
    }
 #endif
    markRenderSection("atmosphere resolve");


### PR DESCRIPTION
Three weather and water effects were missing on the VRSFML targets (Switch and WASM). Two separate causes, both invisible on desktop.

## Rain and lightning carried no view

`RainOverlay` and `ThunderstormOverlay` only overrode the two argument `WeatherOverlay::draw`. `Weather` hands them render states, but the base class default drops them. Under VRSFML the active view lives in `sf::RenderStates::view` rather than on the target, so the drops and the lightning quad were placed with the render target's default view and landed outside the camera rect. The rain sprites also had no texture, which VRSFML expects to arrive in the states as well.

Both overlays now implement the three argument draw and take the view from it, falling back to the target's computed view when the states carry none, which is what VRSFML's own `RenderTarget` does internally.

Desktop is untouched: the two argument path keeps its own body, and only the view, texture and blend mode are read from the states, so the stencil mode the layer loops set is still ignored exactly as before.

## The atmosphere pass was compiled out

Water rendered flat, with no depth gradient and no distortion. `Level::drawAtmosphereLayer` was wrapped in `#ifndef DECEPTUS_VRSFML`, so the physics texture that `water.frag` branches on was never rendered, and the resolve step in `Level::draw` took an `#else` branch that blitted `level_background` to `level` and `normal_tmp` to `normal` with no shader at all. `water.frag` was never reached on these targets.

The pass now runs on both. The atmosphere tile map is drawn with the level view carried in the render states, since a VRSFML render texture has no `setView`, and the resolve draws `water.frag` over both targets with the source texture and shader in the states.

`water.frag` needed no change. Its GL ES branch was already written against `sf_v_texCoord`, and since every render target is created at the same size, the shared normalized coordinate is correct for all three samplers, the same way `gl_TexCoord[0]` is on desktop.

## Verification

Switch build driven in Ryujinx.

**Rain and lightning**, graveyard: streaks render, and the lightning flash cycles. Mean frame luminance moves 15.2 to 25.3 and back, three times across 24 frames, matching the 3 s lightning / 5 s silence timing.

**Water**, catacombs at checkpoint 3, the only checkpoint in the game with water on screen: the water body renders and animates. Measuring the water region against the first frame, 2.5% of pixels differ after one sample and 30% after six, with deltas up to 48 levels. That is `water.frag`'s time driven distortion running, which it never did before this change.

**No regression where there is no water**: the graveyard's atmosphere layer is empty, so the shader takes its pass through branch there and the frame is unchanged against a capture from before this change. Enabling the pass costs nothing in levels without water.

Desktop builds clean and its code paths are unchanged; the catacombs also load and render correctly there.