### PR TITLE
never lose a fatal message, and stop dereferencing localtime blind

### DIFF
--- a/src/framework/tools/log.cpp
+++ b/src/framework/tools/log.cpp
@@ -1,7 +1,9 @@
 #include "log.h"
 
 #include <chrono>
+#include <ctime>
 #include <filesystem>
+#include <iomanip>
 #include <iostream>
 #include <source_location>
 
@@ -20,6 +22,7 @@ constexpr const char* color_red = "\033[31m";
 constexpr const char* color_bright_red = "\033[91m";
 
 std::vector<Log::ListenerCallback> _log_callbacks;
+std::vector<Log::FlushCallback> _flush_callbacks;
 
 // enable ansi colors on windows console
 void enableWindowsAnsiColors()
@@ -94,6 +97,11 @@ void Log::registerListenerCallback(const ListenerCallback& cb)
    _log_callbacks.push_back(cb);
 }
 
+void Log::registerFlushCallback(const FlushCallback& cb)
+{
+   _flush_callbacks.push_back(cb);
+}
+
 void Log::info(const std::string_view& message, const std::source_location& source_location)
 {
    log(Level::Info, message, source_location);
@@ -112,6 +120,15 @@ void Log::error(const std::string_view& message, const std::source_location& sou
 void Log::fatal(const std::string_view& message, const std::source_location& source_location)
 {
    log(Level::Fatal, message, source_location);
+
+   // flush every sink before leaving. std::exit unwinds the runtime while an asynchronous sink is
+   // still writing, which on the switch surfaces as a null dereference inside armGetTls and loses
+   // the one message that would have explained the exit
+   for (const auto& flush_callback : _flush_callbacks)
+   {
+      flush_callback();
+   }
+
    std::exit(-1);
 }
 
@@ -139,6 +156,28 @@ Log::Error::Error(const std::source_location& source_location) : Message(source_
 
 Log::Fatal::Fatal(const std::source_location& source_location) : Message(source_location, fatal)
 {
+}
+
+std::string Log::formatLocalTime(const SysClockTimePoint& time_point, const std::string& format)
+{
+   const auto time = std::chrono::system_clock::to_time_t(time_point);
+
+   std::tm local_time{};
+#ifdef _WIN32
+   if (localtime_s(&local_time, &time) != 0)
+   {
+      return {};
+   }
+#else
+   if (localtime_r(&time, &local_time) == nullptr)
+   {
+      return {};
+   }
+#endif
+
+   std::ostringstream stream;
+   stream << std::put_time(&local_time, format.c_str());
+   return stream.str();
 }
 
 std::string Log::parseSourceTag(const std::source_location& source_location)

--- a/src/framework/tools/log.h
+++ b/src/framework/tools/log.h
@@ -125,11 +125,32 @@ struct Fatal : public Message
 using SysClockTimePoint = std::chrono::time_point<std::chrono::system_clock>;
 using ListenerCallback = std::function<void(const SysClockTimePoint&, Level, const std::string&, const std::source_location&)>;
 
+using FlushCallback = std::function<void()>;
+
 ///
 /// \brief Registers a listener that receives every emitted log message.
 /// \param cb Listener callback.
 ///
 void registerListenerCallback(const ListenerCallback& cb);
+
+///
+/// \brief Registers a sink flush that fatal() runs before terminating the process.
+/// \param cb Flush callback; must complete the write before it returns.
+/// \note Without this an asynchronous sink loses the very message that explains the exit,
+///       because std::exit tears the runtime down underneath the writing thread.
+///
+void registerFlushCallback(const FlushCallback& cb);
+
+///
+/// \brief Formats a time point as local time in a thread-safe way.
+/// \param time_point Time point to format.
+/// \param format strftime-style format string.
+/// \return Formatted time, or an empty string when the conversion fails.
+/// \note std::localtime hands back a pointer to a shared static tm, so two threads formatting a
+///       timestamp at once corrupt each other. Log sinks do exactly that: one formats on the
+///       thread that emitted the message, another on its own writer thread.
+///
+std::string formatLocalTime(const SysClockTimePoint& time_point, const std::string& format);
 
 ///
 /// \brief Builds a compact `file:function:line` source tag.

--- a/src/framework/tools/logthread.cpp
+++ b/src/framework/tools/logthread.cpp
@@ -28,20 +28,18 @@ LogThread::LogThread()
 {
 #ifdef DECEPTUS_LOG_TO_FILE
    // generate filename with current date
-   const auto now = std::chrono::system_clock::now();
-   const auto now_time = std::chrono::system_clock::to_time_t(now);
-   std::stringstream output_stream;
-   output_stream << std::put_time(std::localtime(&now_time), "%Y-%m-%d__%H-%M.log");
-   const auto filename = output_stream.str();
+   const auto filename = Log::formatLocalTime(std::chrono::system_clock::now(), "%Y-%m-%d__%H-%M.log");
    const auto log_path = GamePaths::getLogDir() / filename;
 
-   _thread = std::make_unique<std::thread>(&LogThread::run, this);
+   // the stream has to exist before the thread runs, or the first flush dereferences a null _out
    _out = std::make_unique<std::ofstream>(log_path, std::ios::out | std::ios::app);
    if (!_out->is_open())
    {
       std::cerr << "failed to create log file: " << log_path << "\n";
       return;
    }
+
+   _thread = std::make_unique<std::thread>(&LogThread::run, this);
 #endif
 }
 
@@ -52,7 +50,12 @@ LogThread::~LogThread()
       std::lock_guard<std::mutex> guard(_mutex);
       _stopped = true;
    }
-   _thread->join();
+   // null when the log file could not be opened, in which case the thread was never started
+   if (_thread)
+   {
+      _thread->join();
+   }
+
    flush();
 #endif
 }
@@ -104,6 +107,8 @@ void LogThread::flush()
       _log_items.clear();
    }
 
+   std::lock_guard<std::mutex> write_guard(_write_mutex);
+
    for (const auto& item : copy)
    {
       const auto& timepoint = item._timepoint;
@@ -116,10 +121,7 @@ void LogThread::flush()
                     << ":" << source_location.line();
       const auto source_tag = source_tag_ss.str();
 
-      const auto now_time = std::chrono::system_clock::to_time_t(timepoint);
-      std::stringstream time_ss;
-      time_ss << std::put_time(std::localtime(&now_time), "%Y-%m-%d %H:%M:%S");
-      const auto now_local = time_ss.str();
+      const auto now_local = Log::formatLocalTime(timepoint, "%Y-%m-%d %H:%M:%S");
 
       std::stringstream log_ss;
       log_ss << "[" << static_cast<char>(level) << "] " << now_local << " | " << source_tag << ": " << message;
@@ -128,3 +130,10 @@ void LogThread::flush()
    }
 }
 #endif
+
+void LogThread::flushSynchronously()
+{
+#ifdef DECEPTUS_LOG_TO_FILE
+   flush();
+#endif
+}

--- a/src/framework/tools/logthread.h
+++ b/src/framework/tools/logthread.h
@@ -38,6 +38,13 @@ public:
    ///
    void log(const SysClockTimePoint& time_point, Log::Level level, const std::string& message, const std::source_location& location);
 
+   ///
+   /// \brief writes every queued record to disk before returning.
+   /// \note registered as Log's flush callback so a fatal message reaches the file before
+   ///       std::exit tears the runtime down under the background thread.
+   ///
+   void flushSynchronously();
+
 private:
    ///
    /// \brief one queued log record.
@@ -61,6 +68,7 @@ private:
    void flush();
 
    std::mutex _mutex;
+   std::mutex _write_mutex;  //!< serializes the file write, which flushSynchronously does from another thread
    std::vector<LogItem> _log_items;
 
    std::unique_ptr<std::thread> _thread;

--- a/src/game/debug/logui.cpp
+++ b/src/game/debug/logui.cpp
@@ -108,10 +108,7 @@ void LogUi::draw()
       ImVec4 color = getLogLevelColor(item._level);
       ImGui::PushStyleColor(ImGuiCol_Text, color);
 
-      const auto now_time = std::chrono::system_clock::to_time_t(item._timepoint);
-      std::stringstream time_ss;
-      time_ss << std::put_time(std::localtime(&now_time), "%Y-%m-%d %H:%M:%S");
-      const auto now_local = time_ss.str();
+      const auto now_local = Log::formatLocalTime(item._timepoint, "%Y-%m-%d %H:%M:%S");
 
       std::stringstream log_ss;
       log_ss << now_local << " " << Log::parseSourceTag(item._source_location) << ": " << item._message;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,6 +126,16 @@ int main(int /*argc*/, char** /*argv*/)
       }
    );
 
+   Log::registerFlushCallback(
+      [log_thread_weak]
+      {
+         if (auto log_thread = log_thread_weak.lock())
+         {
+            log_thread->flushSynchronously();
+         }
+      }
+   );
+
 #ifdef DEVELOPMENT_MODE
    Log::registerListenerCallback([](const auto& time_point, auto level, const auto& message, const auto& location)
                                  { LogUiBuffer::log(time_point, level, message, location); });


### PR DESCRIPTION
Three defects in the logging path, found while chasing the switch catacombs load crash. **None of them fixes that crash** — see the note at the bottom — so these stand on their own merits.

## A fatal can no longer lose its own message

`Log::fatal` logged and then called `std::exit` immediately. `std::exit` unwinds the runtime while the asynchronous sink is still writing, so on the switch the message that would have explained the exit stayed in the queue and the process died with a null dereference inside `armGetTls` instead. `3c602b47`'s commit message describes exactly this.

`Log::registerFlushCallback` lets a sink register a synchronous flush, and `fatal` runs every registered flush before exiting. `main` registers `LogThread::flushSynchronously`.

This is not theoretical: it is what let this session **rule the fatal path out** of the catacombs crash. With the flush in place, no `[f]` line appears in the sd log, so no fatal was being raised — which eliminated `luanode.cpp`'s "tried to set an invalid weapon" and every other fatal site in one run.

## localtime was dereferenced unchecked

`std::localtime` returns a pointer to a shared static `tm` and can return null. `std::put_time` dereferences it with no check, in both log sinks and in the log file name.

`Log::formatLocalTime` wraps `localtime_r` / `localtime_s`, writes into a caller-owned `tm`, and returns an empty string when the conversion fails. Both sinks use it. This also removes the shared-static hazard, since the two sinks format timestamps on different threads.

## LogThread published its stream after starting its reader

The constructor created the writer thread and *then* assigned `_out`, so an early flush could dereference a null `unique_ptr` — and publishing it without synchronisation is a data race besides. The stream is created first, its `is_open` check happens before the thread starts, and the destructor no longer joins a thread that was never created.

## Verification

- Switch build: runs clean, four catacombs loads with the sd log intact.
- Desktop: builds and links clean (176/176).

## What this does not do

It does not fix the catacombs load crash. That crash stopped reproducing on its own — 5/5 failures one evening, then 4/4 clean runs the next morning **including a rebuild of the exact configuration that had failed five times**, with zero hardening applied. Every candidate here was tested with a single-variable control and none of them was the difference. The cause remains unknown and the bug should be treated as dormant, not solved.