### PR TITLE
stop clearing the window render texture twice per frame

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -711,7 +711,6 @@ void Game::draw()
 {
    _fps++;
 
-   _window_render_texture->clear();
    _window->clear(sf::Color::Black);
 #ifndef DECEPTUS_VRSFML
    _window->pushGLStates();


### PR DESCRIPTION
`Game::draw` cleared `_window_render_texture`, cleared the window, then cleared `_window_render_texture` again:

```cpp
_window_render_texture->clear();
_window->clear(sf::Color::Black);
#ifndef DECEPTUS_VRSFML
   _window->pushGLStates();
#endif
_window_render_texture->clear();   // same target, nothing drawn in between
```

Nothing is drawn between the two, and the only statement separating them is a `pushGLStates` that is compiled out on the VRSFML targets, so the first clear is always overwritten by the second. One of them is dead work every frame.

A clear of a 1280x720 target is a full screen write, which is not free on a tiler.

## Verification

Switch build, catacombs: HUD, water, waterfalls, lighting and the submerged geometry all render identically to before, with no trails and no uncleared regions. Desktop code path is unaffected apart from the removed call.

## Note on the size of the win

Found while instrumenting `Game::draw` for the 60 fps work. The section that covers these clears first measured 6.3 ms, but that turned out to be the vsync wait parking on the frame's first GL call — with vsync off the whole clear section is 0.31 ms. So this is a small, free win rather than a big one, and it is worth taking on its own merits rather than as a performance fix.