### PR TITLE
profiling: time every part of Game::draw, not just Level::draw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,7 @@ set(GAME_FILES
     src/game/debug/mechanismschemawriter.h
     src/game/debug/profilingui.cpp
     src/game/debug/profilingui.h
+    src/game/debug/rendersectiontimer.h
     src/game/effects/boomeffect.cpp
     src/game/effects/boomeffect.h
     src/game/effects/boomeffectenvelope.cpp

--- a/src/game/debug/drawcallcounter.h
+++ b/src/game/debug/drawcallcounter.h
@@ -31,6 +31,11 @@ inline int32_t layer_scan_steps = 0;
 //! by tile geometry alone. This is a pure count, so it reads the same on hardware as in an emulator,
 //! which makes it the one way to size a fill problem without a console.
 inline int64_t tilemap_pixels_submitted = 0;
+
+//! Of those, the share coming from fully opaque tiles. An early z pass can only reject fragments
+//! hidden behind something opaque, so this is the part of the overdraw that depth culling could
+//! remove; the remainder is alpha blended and has to be drawn either way.
+inline int64_t tilemap_pixels_opaque = 0;
 }  // namespace DrawCallCounter
 
 #endif  // DEVELOPMENT_MODE

--- a/src/game/debug/drawcallcounter.h
+++ b/src/game/debug/drawcallcounter.h
@@ -25,6 +25,12 @@ inline const void* tilemap_last_target = nullptr;
 //! runs once per z index and rescans every container each time, so this grows with the z range
 //! multiplied by the level's content rather than with what is actually on screen.
 inline int32_t layer_scan_steps = 0;
+
+//! Tile pixels submitted per frame, counted as drawn tiles multiplied by the tile area. Held against
+//! the view area it gives the overdraw factor: how many times the average pixel on screen is written
+//! by tile geometry alone. This is a pure count, so it reads the same on hardware as in an emulator,
+//! which makes it the one way to size a fill problem without a console.
+inline int64_t tilemap_pixels_submitted = 0;
 }  // namespace DrawCallCounter
 
 #endif  // DEVELOPMENT_MODE

--- a/src/game/debug/drawcallcounter.h
+++ b/src/game/debug/drawcallcounter.h
@@ -31,11 +31,6 @@ inline int32_t layer_scan_steps = 0;
 //! by tile geometry alone. This is a pure count, so it reads the same on hardware as in an emulator,
 //! which makes it the one way to size a fill problem without a console.
 inline int64_t tilemap_pixels_submitted = 0;
-
-//! Of those, the share coming from fully opaque tiles. An early z pass can only reject fragments
-//! hidden behind something opaque, so this is the part of the overdraw that depth culling could
-//! remove; the remainder is alpha blended and has to be drawn either way.
-inline int64_t tilemap_pixels_opaque = 0;
 }  // namespace DrawCallCounter
 
 #endif  // DEVELOPMENT_MODE

--- a/src/game/debug/profilingui.cpp
+++ b/src/game/debug/profilingui.cpp
@@ -216,12 +216,10 @@ void ProfilingUi::recordFrame(sf::Time frame_time, sf::Time update_time, sf::Tim
    DrawCallCounter::tilemap_draw_calls = 0;
    _layer_scan_steps[_write_index] = static_cast<float>(DrawCallCounter::layer_scan_steps);
    _tilemap_pixels_submitted[_write_index] = static_cast<float>(DrawCallCounter::tilemap_pixels_submitted);
-   _tilemap_pixels_opaque[_write_index] = static_cast<float>(DrawCallCounter::tilemap_pixels_opaque);
    DrawCallCounter::tilemap_target_switches = 0;
    DrawCallCounter::tilemap_last_target = nullptr;
    DrawCallCounter::layer_scan_steps = 0;
    DrawCallCounter::tilemap_pixels_submitted = 0;
-   DrawCallCounter::tilemap_pixels_opaque = 0;
    _write_index = (_write_index + 1) % sample_count;
    _samples_written = std::min(_samples_written + 1, sample_count);
 }
@@ -350,9 +348,7 @@ void ProfilingUi::draw()
    const auto pixel_summary = summarizeSamples(_tilemap_pixels_submitted.data(), _samples_written);
    if (view_area > 0)
    {
-      const auto opaque_summary = summarizeSamples(_tilemap_pixels_opaque.data(), _samples_written);
-      draw_call_line << " | tile overdraw " << std::setprecision(2) << (pixel_summary.average_ms / static_cast<float>(view_area))
-                     << "x | opaque " << (opaque_summary.average_ms / static_cast<float>(view_area)) << "x";
+      draw_call_line << " | tile overdraw " << std::setprecision(2) << (pixel_summary.average_ms / static_cast<float>(view_area)) << "x";
    }
    Log::Info() << draw_call_line.str();
 
@@ -428,12 +424,10 @@ void ProfilingUi::recordFrame(sf::Time frame_time, sf::Time update_time, sf::Tim
    DrawCallCounter::tilemap_draw_calls = 0;
    _layer_scan_steps[_write_index] = static_cast<float>(DrawCallCounter::layer_scan_steps);
    _tilemap_pixels_submitted[_write_index] = static_cast<float>(DrawCallCounter::tilemap_pixels_submitted);
-   _tilemap_pixels_opaque[_write_index] = static_cast<float>(DrawCallCounter::tilemap_pixels_opaque);
    DrawCallCounter::tilemap_target_switches = 0;
    DrawCallCounter::tilemap_last_target = nullptr;
    DrawCallCounter::layer_scan_steps = 0;
    DrawCallCounter::tilemap_pixels_submitted = 0;
-   DrawCallCounter::tilemap_pixels_opaque = 0;
    _write_index = (_write_index + 1) % sample_count;
    _samples_written = std::min(_samples_written + 1, sample_count);
 }

--- a/src/game/debug/profilingui.cpp
+++ b/src/game/debug/profilingui.cpp
@@ -342,8 +342,11 @@ void ProfilingUi::draw()
                   << formatSummary("", summarizeSamples(_tilemap_target_switches.data(), _samples_written)) << " | layer scan steps "
                   << formatSummary("", summarizeSamples(_layer_scan_steps.data(), _samples_written));
 
-   // tile pixels submitted against the view area: how many times the average on screen pixel is
-   // written by tile geometry alone. a pure count, so it reads the same here as on hardware
+   // tile pixels submitted against the view area. this is an upper bound rather than a measurement:
+   // it sums the colour and the normal target, and the animated tiles are gathered around the
+   // player block rather than the view, so both inflate it. use it to watch a change move the
+   // number, not as an absolute - lab/tile_opacity/analyze_opacity.py computes the real figure
+   // offline from the tilesets
    const auto view_area = GameConfiguration::getInstance()._view_width * GameConfiguration::getInstance()._view_height;
    const auto pixel_summary = summarizeSamples(_tilemap_pixels_submitted.data(), _samples_written);
    if (view_area > 0)

--- a/src/game/debug/profilingui.cpp
+++ b/src/game/debug/profilingui.cpp
@@ -215,9 +215,11 @@ void ProfilingUi::recordFrame(sf::Time frame_time, sf::Time update_time, sf::Tim
    _tilemap_target_switches[_write_index] = static_cast<float>(DrawCallCounter::tilemap_target_switches);
    DrawCallCounter::tilemap_draw_calls = 0;
    _layer_scan_steps[_write_index] = static_cast<float>(DrawCallCounter::layer_scan_steps);
+   _tilemap_pixels_submitted[_write_index] = static_cast<float>(DrawCallCounter::tilemap_pixels_submitted);
    DrawCallCounter::tilemap_target_switches = 0;
    DrawCallCounter::tilemap_last_target = nullptr;
    DrawCallCounter::layer_scan_steps = 0;
+   DrawCallCounter::tilemap_pixels_submitted = 0;
    _write_index = (_write_index + 1) % sample_count;
    _samples_written = std::min(_samples_written + 1, sample_count);
 }
@@ -339,14 +341,44 @@ void ProfilingUi::draw()
                   << formatSummary("", draw_call_summary) << " | target switches "
                   << formatSummary("", summarizeSamples(_tilemap_target_switches.data(), _samples_written)) << " | layer scan steps "
                   << formatSummary("", summarizeSamples(_layer_scan_steps.data(), _samples_written));
+
+   // tile pixels submitted against the view area: how many times the average on screen pixel is
+   // written by tile geometry alone. a pure count, so it reads the same here as on hardware
+   const auto view_area = GameConfiguration::getInstance()._view_width * GameConfiguration::getInstance()._view_height;
+   const auto pixel_summary = summarizeSamples(_tilemap_pixels_submitted.data(), _samples_written);
+   if (view_area > 0)
+   {
+      draw_call_line << " | tile overdraw " << std::setprecision(2) << (pixel_summary.average_ms / static_cast<float>(view_area)) << "x";
+   }
    Log::Info() << draw_call_line.str();
 
-   const auto section_frames = std::max(_render_section_frames, 1);
-   for (const auto& sample : _render_section_timings)
+   // one line rather than one per section: on the switch every log line is a write to the sd card,
+   // so a report that grows with the number of sections puts real pressure on that path
+   if (!_render_section_timings.empty())
    {
+      const auto section_frames = std::max(_render_section_frames, 1);
+      auto section_total_ms = 0.0f;
+
       std::ostringstream section_line;
-      section_line << std::fixed << std::setprecision(3) << "profiling: section " << sample.name << " "
-                   << sample.duration_ms / static_cast<float>(section_frames) << " ms avg over " << section_frames << " frames";
+      section_line << std::fixed << std::setprecision(3) << "profiling: sections over " << section_frames << " frames |";
+      for (const auto& sample : _render_section_timings)
+      {
+         const auto average_ms = sample.duration_ms / static_cast<float>(section_frames);
+         section_line << " " << sample.name << " " << average_ms << " |";
+
+         // Level::draw reports its own passes, and "level draw" is the span that contains them, so
+         // counting both would total the level's cost twice and make the remainder come out negative
+         if (sample.name != "level draw")
+         {
+            section_total_ms += average_ms;
+         }
+      }
+
+      // the sections tile the whole of Game::draw, so whatever is left is time the cpu spent inside
+      // a gl call waiting for the gpu rather than submitting work. that distinction decides whether
+      // the frame is worth attacking on the cpu side at all
+      section_line << " TOTAL " << section_total_ms << " | measured draw " << draw_summary.average_ms << " | unaccounted "
+                   << (draw_summary.average_ms - section_total_ms);
       Log::Info() << section_line.str();
    }
 
@@ -391,9 +423,11 @@ void ProfilingUi::recordFrame(sf::Time frame_time, sf::Time update_time, sf::Tim
    _tilemap_target_switches[_write_index] = static_cast<float>(DrawCallCounter::tilemap_target_switches);
    DrawCallCounter::tilemap_draw_calls = 0;
    _layer_scan_steps[_write_index] = static_cast<float>(DrawCallCounter::layer_scan_steps);
+   _tilemap_pixels_submitted[_write_index] = static_cast<float>(DrawCallCounter::tilemap_pixels_submitted);
    DrawCallCounter::tilemap_target_switches = 0;
    DrawCallCounter::tilemap_last_target = nullptr;
    DrawCallCounter::layer_scan_steps = 0;
+   DrawCallCounter::tilemap_pixels_submitted = 0;
    _write_index = (_write_index + 1) % sample_count;
    _samples_written = std::min(_samples_written + 1, sample_count);
 }

--- a/src/game/debug/profilingui.cpp
+++ b/src/game/debug/profilingui.cpp
@@ -216,10 +216,12 @@ void ProfilingUi::recordFrame(sf::Time frame_time, sf::Time update_time, sf::Tim
    DrawCallCounter::tilemap_draw_calls = 0;
    _layer_scan_steps[_write_index] = static_cast<float>(DrawCallCounter::layer_scan_steps);
    _tilemap_pixels_submitted[_write_index] = static_cast<float>(DrawCallCounter::tilemap_pixels_submitted);
+   _tilemap_pixels_opaque[_write_index] = static_cast<float>(DrawCallCounter::tilemap_pixels_opaque);
    DrawCallCounter::tilemap_target_switches = 0;
    DrawCallCounter::tilemap_last_target = nullptr;
    DrawCallCounter::layer_scan_steps = 0;
    DrawCallCounter::tilemap_pixels_submitted = 0;
+   DrawCallCounter::tilemap_pixels_opaque = 0;
    _write_index = (_write_index + 1) % sample_count;
    _samples_written = std::min(_samples_written + 1, sample_count);
 }
@@ -348,7 +350,9 @@ void ProfilingUi::draw()
    const auto pixel_summary = summarizeSamples(_tilemap_pixels_submitted.data(), _samples_written);
    if (view_area > 0)
    {
-      draw_call_line << " | tile overdraw " << std::setprecision(2) << (pixel_summary.average_ms / static_cast<float>(view_area)) << "x";
+      const auto opaque_summary = summarizeSamples(_tilemap_pixels_opaque.data(), _samples_written);
+      draw_call_line << " | tile overdraw " << std::setprecision(2) << (pixel_summary.average_ms / static_cast<float>(view_area))
+                     << "x | opaque " << (opaque_summary.average_ms / static_cast<float>(view_area)) << "x";
    }
    Log::Info() << draw_call_line.str();
 
@@ -424,10 +428,12 @@ void ProfilingUi::recordFrame(sf::Time frame_time, sf::Time update_time, sf::Tim
    DrawCallCounter::tilemap_draw_calls = 0;
    _layer_scan_steps[_write_index] = static_cast<float>(DrawCallCounter::layer_scan_steps);
    _tilemap_pixels_submitted[_write_index] = static_cast<float>(DrawCallCounter::tilemap_pixels_submitted);
+   _tilemap_pixels_opaque[_write_index] = static_cast<float>(DrawCallCounter::tilemap_pixels_opaque);
    DrawCallCounter::tilemap_target_switches = 0;
    DrawCallCounter::tilemap_last_target = nullptr;
    DrawCallCounter::layer_scan_steps = 0;
    DrawCallCounter::tilemap_pixels_submitted = 0;
+   DrawCallCounter::tilemap_pixels_opaque = 0;
    _write_index = (_write_index + 1) % sample_count;
    _samples_written = std::min(_samples_written + 1, sample_count);
 }

--- a/src/game/debug/profilingui.h
+++ b/src/game/debug/profilingui.h
@@ -47,10 +47,12 @@ private:
    std::array<float, sample_count> _update_times_ms{};
    std::array<float, sample_count> _draw_times_ms{};
    std::array<float, sample_count> _window_display_times_ms{};
-   std::array<float, sample_count> _tilemap_draw_calls{};        //!< tile map draw calls issued in that frame
-   std::array<float, sample_count> _tilemap_target_switches{};   //!< render target changes between those draws
-   std::array<float, sample_count> _layer_scan_steps{};          //!< candidates the z loop examined that frame
-   std::array<float, sample_count> _tilemap_pixels_submitted{};  //!< tile pixels submitted that frame, for the overdraw factor
+   std::array<float, sample_count> _tilemap_draw_calls{};       //!< tile map draw calls issued in that frame
+   std::array<float, sample_count> _tilemap_target_switches{};  //!< render target changes between those draws
+   std::array<float, sample_count> _layer_scan_steps{};         //!< candidates the z loop examined that frame
+   std::array<float, sample_count> _tilemap_pixels_submitted{};
+   std::array<float, sample_count> _tilemap_pixels_opaque{
+   };  //!< of those, the fully opaque share  //!< tile pixels submitted that frame, for the overdraw factor
    sf::Clock _wall_clock;
    bool _wall_clock_primed{false};
    int32_t _write_index{0};

--- a/src/game/debug/profilingui.h
+++ b/src/game/debug/profilingui.h
@@ -47,9 +47,10 @@ private:
    std::array<float, sample_count> _update_times_ms{};
    std::array<float, sample_count> _draw_times_ms{};
    std::array<float, sample_count> _window_display_times_ms{};
-   std::array<float, sample_count> _tilemap_draw_calls{};       //!< tile map draw calls issued in that frame
-   std::array<float, sample_count> _tilemap_target_switches{};  //!< render target changes between those draws
-   std::array<float, sample_count> _layer_scan_steps{};         //!< candidates the z loop examined that frame
+   std::array<float, sample_count> _tilemap_draw_calls{};        //!< tile map draw calls issued in that frame
+   std::array<float, sample_count> _tilemap_target_switches{};   //!< render target changes between those draws
+   std::array<float, sample_count> _layer_scan_steps{};          //!< candidates the z loop examined that frame
+   std::array<float, sample_count> _tilemap_pixels_submitted{};  //!< tile pixels submitted that frame, for the overdraw factor
    sf::Clock _wall_clock;
    bool _wall_clock_primed{false};
    int32_t _write_index{0};

--- a/src/game/debug/profilingui.h
+++ b/src/game/debug/profilingui.h
@@ -47,12 +47,10 @@ private:
    std::array<float, sample_count> _update_times_ms{};
    std::array<float, sample_count> _draw_times_ms{};
    std::array<float, sample_count> _window_display_times_ms{};
-   std::array<float, sample_count> _tilemap_draw_calls{};       //!< tile map draw calls issued in that frame
-   std::array<float, sample_count> _tilemap_target_switches{};  //!< render target changes between those draws
-   std::array<float, sample_count> _layer_scan_steps{};         //!< candidates the z loop examined that frame
-   std::array<float, sample_count> _tilemap_pixels_submitted{};
-   std::array<float, sample_count> _tilemap_pixels_opaque{
-   };  //!< of those, the fully opaque share  //!< tile pixels submitted that frame, for the overdraw factor
+   std::array<float, sample_count> _tilemap_draw_calls{};        //!< tile map draw calls issued in that frame
+   std::array<float, sample_count> _tilemap_target_switches{};   //!< render target changes between those draws
+   std::array<float, sample_count> _layer_scan_steps{};          //!< candidates the z loop examined that frame
+   std::array<float, sample_count> _tilemap_pixels_submitted{};  //!< tile pixels submitted that frame, for the overdraw factor
    sf::Clock _wall_clock;
    bool _wall_clock_primed{false};
    int32_t _write_index{0};

--- a/src/game/debug/rendersectiontimer.h
+++ b/src/game/debug/rendersectiontimer.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#ifdef DEVELOPMENT_MODE
+
+#include "game/debug/rendersectionsample.h"
+
+#include <chrono>
+#include <vector>
+
+/// \brief accumulates cpu side durations between named marks within one frame's draw.
+///
+/// Level::draw and Game::draw both carve their work into sections and feed the same report, so the
+/// sum of every section can be held against the measured draw time. Whatever is left over is the
+/// part of the frame that nothing accounts for, which is what tells a gpu stall apart from work
+/// that simply is not instrumented yet.
+class RenderSectionTimer
+{
+public:
+   /// \brief drops the previous frame's samples and starts a new measurement.
+   /// \param enabled when false the timer stays inert, so callers can gate on a profiling flag
+   ///        without branching around every mark.
+   void begin(bool enabled)
+   {
+      _samples.clear();
+      _enabled = enabled;
+
+      if (!_enabled)
+      {
+         return;
+      }
+
+      _mark = std::chrono::high_resolution_clock::now();
+   }
+
+   /// \brief closes the running section under the given name and opens the next one.
+   /// \param name label the elapsed time is recorded under; must outlive the report.
+   void mark(const char* name)
+   {
+      if (!_enabled)
+      {
+         return;
+      }
+
+      const auto now = std::chrono::high_resolution_clock::now();
+      _samples.push_back({name, std::chrono::duration<float, std::milli>(now - _mark).count()});
+      _mark = now;
+   }
+
+   /// \brief returns the sections recorded since the last begin(), in call order.
+   const std::vector<RenderSectionSample>& samples() const
+   {
+      return _samples;
+   }
+
+private:
+   std::vector<RenderSectionSample> _samples;             //!< one entry per mark, in call order
+   std::chrono::high_resolution_clock::time_point _mark;  //!< when the currently open section started
+   bool _enabled{false};                                  //!< whether begin() armed the timer
+};
+
+#endif  // DEVELOPMENT_MODE

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -711,6 +711,10 @@ void Game::draw()
 {
    _fps++;
 
+#ifdef DEVELOPMENT_MODE
+   _draw_section_timer.begin((_profiling_ui != nullptr) && _profiling_ui->isMechanismProfilingWanted());
+#endif
+
    _window->clear(sf::Color::Black);
 #ifndef DECEPTUS_VRSFML
    _window->pushGLStates();
@@ -724,10 +728,19 @@ void Game::draw()
 
    const auto level_target = _post_processing_pass.selectLevelTarget(_window_render_texture, _level_loading_finished);
 
+#ifdef DEVELOPMENT_MODE
+   _draw_section_timer.mark("game clear targets");
+#endif
+
    if (_level_loading_finished)
    {
       _level->draw(level_target, _screenshot);
    }
+
+#ifdef DEVELOPMENT_MODE
+   // the level's own passes are reported separately, so this mark only closes the gap around them
+   _draw_section_timer.mark("level draw");
+#endif
 
    _post_processing_pass.resolveLevelTarget(*_window_render_texture.get(), _render_targets.view_to_texture_scale);
 
@@ -735,7 +748,15 @@ void Game::draw()
 
    ScreenTransitionHandler::getInstance().draw(_window_render_texture);
 
+#ifdef DEVELOPMENT_MODE
+   _draw_section_timer.mark("post processing resolve");
+#endif
+
    _info_layer->draw(*_window_render_texture.get());
+
+#ifdef DEVELOPMENT_MODE
+   _draw_section_timer.mark("hud");
+#endif
 
    if (DebugDrawStates::_draw_debug_info)
    {
@@ -794,7 +815,15 @@ void Game::draw()
 #endif
    MessageBox::draw(*_window_render_texture.get());
 
+#ifdef DEVELOPMENT_MODE
+   _draw_section_timer.mark("menu and overlays");
+#endif
+
    _window_render_texture->display();
+
+#ifdef DEVELOPMENT_MODE
+   _draw_section_timer.mark("window texture display");
+#endif
 #ifdef DECEPTUS_VRSFML
    _window->setActive(true);
 #endif
@@ -841,6 +870,10 @@ void Game::draw()
 #endif
 #ifndef DECEPTUS_VRSFML
    _window->popGLStates();
+#endif
+
+#ifdef DEVELOPMENT_MODE
+   _draw_section_timer.mark("window blit");
 #endif
 
 #ifdef DEVELOPMENT_MODE
@@ -1147,10 +1180,18 @@ void Game::timedDraw()
    {
       const auto mechanism_profiling_enabled = (_profiling_ui != nullptr) && _profiling_ui->isMechanismProfilingWanted();
       _level->setMechanismProfilingEnabled(mechanism_profiling_enabled);
-      if (mechanism_profiling_enabled)
+      // no level means no passes worth reporting, and the sections would otherwise be written every
+      // few seconds from the menu for nothing
+      if (mechanism_profiling_enabled && _level_loading_finished)
       {
          _profiling_ui->updateMechanismTimings(_level->getMechanismTimings(32));
-         _profiling_ui->updateRenderSectionTimings(_level->getRenderSectionTimings());
+
+         // Level::draw's passes plus everything else Game::draw does, so the report can hold the
+         // total against the measured draw time and show what is left unaccounted for
+         auto section_timings = _level->getRenderSectionTimings();
+         const auto& draw_sections = _draw_section_timer.samples();
+         section_timings.insert(section_timings.end(), draw_sections.begin(), draw_sections.end());
+         _profiling_ui->updateRenderSectionTimings(std::move(section_timings));
       }
    }
 #endif

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -13,6 +13,7 @@
 #endif
 #ifdef DEVELOPMENT_MODE
 #include "game/debug/profilingui.h"
+#include "game/debug/rendersectiontimer.h"
 #endif
 #include "game/ingamemenu/ingamemenu.h"
 #include "game/io/eventserializer.h"
@@ -195,6 +196,11 @@ private:
 #ifdef DEVELOPMENT_MODE
    std::unique_ptr<ProfilingUi> _profiling_ui;
    sf::Time _profiling_update_elapsed;
+#ifdef DEVELOPMENT_MODE
+   //! Level::draw reports its own passes; this covers everything else Game::draw does, so the
+   //! sections add up to the measured draw time instead of leaving an unexplained remainder
+   RenderSectionTimer _draw_section_timer;
+#endif
 #endif
 
    std::shared_ptr<EventSerializer> _global_event_serializer;

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -196,11 +196,10 @@ private:
 #ifdef DEVELOPMENT_MODE
    std::unique_ptr<ProfilingUi> _profiling_ui;
    sf::Time _profiling_update_elapsed;
-#ifdef DEVELOPMENT_MODE
+
    //! Level::draw reports its own passes; this covers everything else Game::draw does, so the
    //! sections add up to the measured draw time instead of leaving an unexplained remainder
    RenderSectionTimer _draw_section_timer;
-#endif
 #endif
 
    std::shared_ptr<EventSerializer> _global_event_serializer;

--- a/src/game/level/level.cpp
+++ b/src/game/level/level.cpp
@@ -2116,33 +2116,21 @@ void Level::setMechanismProfilingEnabled(bool enabled)
 
 std::vector<RenderSectionSample> Level::getRenderSectionTimings() const
 {
-   return _render_section_timings;
+   return _render_section_timer.samples();
 }
 #endif
 
 void Level::beginRenderSectionTiming()
 {
 #ifdef DEVELOPMENT_MODE
-   _render_section_timings.clear();
-   if (!_mechanism_profiling_enabled)
-   {
-      return;
-   }
-   _render_section_mark = std::chrono::high_resolution_clock::now();
+   _render_section_timer.begin(_mechanism_profiling_enabled);
 #endif
 }
 
 void Level::markRenderSection(const char* name)
 {
 #ifdef DEVELOPMENT_MODE
-   if (!_mechanism_profiling_enabled)
-   {
-      return;
-   }
-   const auto now = std::chrono::high_resolution_clock::now();
-   const auto elapsed_ms = std::chrono::duration<float, std::milli>(now - _render_section_mark).count();
-   _render_section_timings.push_back({name, elapsed_ms});
-   _render_section_mark = now;
+   _render_section_timer.mark(name);
 #else
    (void)name;
 #endif

--- a/src/game/level/level.h
+++ b/src/game/level/level.h
@@ -51,6 +51,7 @@
 #include <vector>
 #include "game/debug/mechanismsample.h"
 #include "game/debug/rendersectionsample.h"
+#include "game/debug/rendersectiontimer.h"
 #endif
 
 class Bouncer;
@@ -442,7 +443,6 @@ protected:
 
 #ifdef DEVELOPMENT_MODE
    bool _mechanism_profiling_enabled{false};
-   std::vector<RenderSectionSample> _render_section_timings;
-   std::chrono::high_resolution_clock::time_point _render_section_mark;
+   RenderSectionTimer _render_section_timer;
 #endif
 };

--- a/src/game/level/tilemap.cpp
+++ b/src/game/level/tilemap.cpp
@@ -123,37 +123,6 @@ void TileMap::storeStaticVertices(const std::array<sf::Vertex, 4>& quad, float p
    vertex_array.append(quad[3]);
 }
 
-#ifdef DEVELOPMENT_MODE
-namespace
-{
-//! rief true when every pixel of the tile at (tu, tv) is fully opaque.
-bool isTileOpaque(const sf::Image& image, uint32_t tu, uint32_t tv, const sf::Vector2u& tile_size_px)
-{
-   const auto image_size = image.getSize();
-   const auto origin_x = tu * tile_size_px.x;
-   const auto origin_y = tv * tile_size_px.y;
-
-   if (origin_x + tile_size_px.x > image_size.x || origin_y + tile_size_px.y > image_size.y)
-   {
-      return false;
-   }
-
-   for (auto y = origin_y; y < origin_y + tile_size_px.y; y++)
-   {
-      for (auto x = origin_x; x < origin_x + tile_size_px.x; x++)
-      {
-         if (image.getPixel({x, y}).a != 255)
-         {
-            return false;
-         }
-      }
-   }
-
-   return true;
-}
-}  // namespace
-#endif
-
 bool TileMap::load(
    const std::shared_ptr<TmxLayer>& layer,
    const std::shared_ptr<TmxTileSet>& tileset,
@@ -171,11 +140,6 @@ bool TileMap::load(
    auto path = (base_path / tileset->_image->_source);
 
    _texture_map = TexturePool::getInstance().get(path);
-
-#ifdef DEVELOPMENT_MODE
-   // one copy per tile map at load, so the per tile opacity test below stays cheap
-   const auto tileset_image = _texture_map->copyToImage();
-#endif
 
    // check if we have a bumpmap and, if so, load it
    const auto normal_map_filename = (path.stem().string() + "_normals" + path.extension().string());
@@ -232,16 +196,6 @@ bool TileMap::load(
          // find its position in the tileset texture
          const auto tu = (tile_number - tileset->_first_gid) % (_texture_map->getSize().x / _tile_size_px.x);
          const auto tv = (tile_number - tileset->_first_gid) / (_texture_map->getSize().x / _tile_size_px.x);
-
-#ifdef DEVELOPMENT_MODE
-         // only a fully opaque tile can occlude what is behind it, so only those are candidates for
-         // early z rejection. counted here, where the tileset image is already at hand
-         _tile_count_total++;
-         if (isTileOpaque(tileset_image, tu, tv, _tile_size_px))
-         {
-            _tile_count_opaque++;
-         }
-#endif
          const auto tx = static_cast<int32_t>(pos_x);
          const auto ty = static_cast<int32_t>(pos_y);
          const auto tile_x_px = tx * static_cast<int32_t>(_tile_size_px.x) + layer->_position_x_px;
@@ -430,14 +384,8 @@ void TileMap::drawVertices(sf::RenderTarget& target, sf::RenderStates states) co
 
          // four vertices per tile, so the quad count is the tile count
          const auto tile_count = static_cast<float>(column_it->second.getVertexCount() / 4);
-         const auto submitted = static_cast<int64_t>(tile_count * visible_fraction * static_cast<float>(_tile_size_px.x * _tile_size_px.y));
-         DrawCallCounter::tilemap_pixels_submitted += submitted;
-
-         // attributed by this layer's opaque ratio: only opaque pixels can be rejected by an early
-         // z pass, so this is the share of the overdraw that depth culling could actually remove
-         const auto opaque_ratio =
-            (_tile_count_total > 0) ? static_cast<float>(_tile_count_opaque) / static_cast<float>(_tile_count_total) : 0.0f;
-         DrawCallCounter::tilemap_pixels_opaque += static_cast<int64_t>(static_cast<float>(submitted) * opaque_ratio);
+         DrawCallCounter::tilemap_pixels_submitted +=
+            static_cast<int64_t>(tile_count * visible_fraction * static_cast<float>(_tile_size_px.x * _tile_size_px.y));
 #endif
       }
    }

--- a/src/game/level/tilemap.cpp
+++ b/src/game/level/tilemap.cpp
@@ -382,8 +382,9 @@ void TileMap::drawVertices(sf::RenderTarget& target, sf::RenderStates states) co
          );
          const auto visible_fraction = (visible_width_px * visible_height_px) / (block_width_px * block_height_px);
 
-         // four vertices per tile, so the quad count is the tile count
-         const auto tile_count = static_cast<float>(column_it->second.getVertexCount() / 4);
+         // tiles are stored as two triangles, so six vertices make one tile - not four. dividing by
+         // four overstated every count by 1.5x
+         const auto tile_count = static_cast<float>(column_it->second.getVertexCount() / 6);
          DrawCallCounter::tilemap_pixels_submitted +=
             static_cast<int64_t>(tile_count * visible_fraction * static_cast<float>(_tile_size_px.x * _tile_size_px.y));
 #endif
@@ -393,8 +394,10 @@ void TileMap::drawVertices(sf::RenderTarget& target, sf::RenderStates states) co
    target.draw(_vertices_animated, states);
 #ifdef DEVELOPMENT_MODE
    DrawCallCounter::tilemap_draw_calls++;
+   // the animated tiles are collected around the player block rather than around the view, so this
+   // adds tiles that are off screen. it is an upper bound, unlike the block term above
    DrawCallCounter::tilemap_pixels_submitted +=
-      static_cast<int64_t>(_vertices_animated.getVertexCount() / 4) * _tile_size_px.x * _tile_size_px.y;
+      static_cast<int64_t>(_vertices_animated.getVertexCount() / 6) * _tile_size_px.x * _tile_size_px.y;
 #endif
 }
 

--- a/src/game/level/tilemap.cpp
+++ b/src/game/level/tilemap.cpp
@@ -123,6 +123,37 @@ void TileMap::storeStaticVertices(const std::array<sf::Vertex, 4>& quad, float p
    vertex_array.append(quad[3]);
 }
 
+#ifdef DEVELOPMENT_MODE
+namespace
+{
+//! rief true when every pixel of the tile at (tu, tv) is fully opaque.
+bool isTileOpaque(const sf::Image& image, uint32_t tu, uint32_t tv, const sf::Vector2u& tile_size_px)
+{
+   const auto image_size = image.getSize();
+   const auto origin_x = tu * tile_size_px.x;
+   const auto origin_y = tv * tile_size_px.y;
+
+   if (origin_x + tile_size_px.x > image_size.x || origin_y + tile_size_px.y > image_size.y)
+   {
+      return false;
+   }
+
+   for (auto y = origin_y; y < origin_y + tile_size_px.y; y++)
+   {
+      for (auto x = origin_x; x < origin_x + tile_size_px.x; x++)
+      {
+         if (image.getPixel({x, y}).a != 255)
+         {
+            return false;
+         }
+      }
+   }
+
+   return true;
+}
+}  // namespace
+#endif
+
 bool TileMap::load(
    const std::shared_ptr<TmxLayer>& layer,
    const std::shared_ptr<TmxTileSet>& tileset,
@@ -140,6 +171,11 @@ bool TileMap::load(
    auto path = (base_path / tileset->_image->_source);
 
    _texture_map = TexturePool::getInstance().get(path);
+
+#ifdef DEVELOPMENT_MODE
+   // one copy per tile map at load, so the per tile opacity test below stays cheap
+   const auto tileset_image = _texture_map->copyToImage();
+#endif
 
    // check if we have a bumpmap and, if so, load it
    const auto normal_map_filename = (path.stem().string() + "_normals" + path.extension().string());
@@ -196,6 +232,16 @@ bool TileMap::load(
          // find its position in the tileset texture
          const auto tu = (tile_number - tileset->_first_gid) % (_texture_map->getSize().x / _tile_size_px.x);
          const auto tv = (tile_number - tileset->_first_gid) / (_texture_map->getSize().x / _tile_size_px.x);
+
+#ifdef DEVELOPMENT_MODE
+         // only a fully opaque tile can occlude what is behind it, so only those are candidates for
+         // early z rejection. counted here, where the tileset image is already at hand
+         _tile_count_total++;
+         if (isTileOpaque(tileset_image, tu, tv, _tile_size_px))
+         {
+            _tile_count_opaque++;
+         }
+#endif
          const auto tx = static_cast<int32_t>(pos_x);
          const auto ty = static_cast<int32_t>(pos_y);
          const auto tile_x_px = tx * static_cast<int32_t>(_tile_size_px.x) + layer->_position_x_px;
@@ -384,8 +430,14 @@ void TileMap::drawVertices(sf::RenderTarget& target, sf::RenderStates states) co
 
          // four vertices per tile, so the quad count is the tile count
          const auto tile_count = static_cast<float>(column_it->second.getVertexCount() / 4);
-         DrawCallCounter::tilemap_pixels_submitted +=
-            static_cast<int64_t>(tile_count * visible_fraction * static_cast<float>(_tile_size_px.x * _tile_size_px.y));
+         const auto submitted = static_cast<int64_t>(tile_count * visible_fraction * static_cast<float>(_tile_size_px.x * _tile_size_px.y));
+         DrawCallCounter::tilemap_pixels_submitted += submitted;
+
+         // attributed by this layer's opaque ratio: only opaque pixels can be rejected by an early
+         // z pass, so this is the share of the overdraw that depth culling could actually remove
+         const auto opaque_ratio =
+            (_tile_count_total > 0) ? static_cast<float>(_tile_count_opaque) / static_cast<float>(_tile_count_total) : 0.0f;
+         DrawCallCounter::tilemap_pixels_opaque += static_cast<int64_t>(static_cast<float>(submitted) * opaque_ratio);
 #endif
       }
    }

--- a/src/game/level/tilemap.cpp
+++ b/src/game/level/tilemap.cpp
@@ -1,6 +1,7 @@
 #include "tilemap.h"
 
 #include <math.h>
+#include <algorithm>
 #include <iostream>
 #include <map>
 
@@ -363,6 +364,28 @@ void TileMap::drawVertices(sf::RenderTarget& target, sf::RenderStates states) co
          target.draw(column_it->second, states);
 #ifdef DEVELOPMENT_MODE
          DrawCallCounter::tilemap_draw_calls++;
+
+         // blocks are drawn whole but only partly on screen, so scale the block's tile area by how
+         // much of the block the view actually covers. counting the whole block would report fill
+         // that the rasteriser never pays for
+         const auto block_left_px = static_cast<float>(column_it->first) * block_width_px;
+         const auto block_top_px = static_cast<float>(row_it->first) * block_height_px;
+         const auto visible_width_px = std::max(
+            0.0f,
+            std::min(block_left_px + block_width_px, view_center.x + view_size.x * 0.5f) -
+               std::max(block_left_px, view_center.x - view_size.x * 0.5f)
+         );
+         const auto visible_height_px = std::max(
+            0.0f,
+            std::min(block_top_px + block_height_px, view_center.y + view_size.y * 0.5f) -
+               std::max(block_top_px, view_center.y - view_size.y * 0.5f)
+         );
+         const auto visible_fraction = (visible_width_px * visible_height_px) / (block_width_px * block_height_px);
+
+         // four vertices per tile, so the quad count is the tile count
+         const auto tile_count = static_cast<float>(column_it->second.getVertexCount() / 4);
+         DrawCallCounter::tilemap_pixels_submitted +=
+            static_cast<int64_t>(tile_count * visible_fraction * static_cast<float>(_tile_size_px.x * _tile_size_px.y));
 #endif
       }
    }
@@ -370,6 +393,8 @@ void TileMap::drawVertices(sf::RenderTarget& target, sf::RenderStates states) co
    target.draw(_vertices_animated, states);
 #ifdef DEVELOPMENT_MODE
    DrawCallCounter::tilemap_draw_calls++;
+   DrawCallCounter::tilemap_pixels_submitted +=
+      static_cast<int64_t>(_vertices_animated.getVertexCount() / 4) * _tile_size_px.x * _tile_size_px.y;
 #endif
 }
 

--- a/src/game/level/tilemap.h
+++ b/src/game/level/tilemap.h
@@ -134,12 +134,6 @@ private:
    sf::VertexArray _vertices_animated;
 
    std::shared_ptr<sf::Texture> _texture_map;
-#ifdef DEVELOPMENT_MODE
-   //! how many of this layer's tiles are fully opaque. only those can occlude what is behind them,
-   //! so the ratio is what an early z pass could actually reject
-   int64_t _tile_count_total{0};
-   int64_t _tile_count_opaque{0};
-#endif
    std::shared_ptr<sf::Texture> _normal_map;
 
    std::vector<AnimatedTile*> _animations;

--- a/src/game/level/tilemap.h
+++ b/src/game/level/tilemap.h
@@ -134,6 +134,12 @@ private:
    sf::VertexArray _vertices_animated;
 
    std::shared_ptr<sf::Texture> _texture_map;
+#ifdef DEVELOPMENT_MODE
+   //! how many of this layer's tiles are fully opaque. only those can occlude what is behind them,
+   //! so the ratio is what an early z pass could actually reject
+   int64_t _tile_count_total{0};
+   int64_t _tile_count_opaque{0};
+#endif
    std::shared_ptr<sf::Texture> _normal_map;
 
    std::vector<AnimatedTile*> _animations;


### PR DESCRIPTION
**What this is for:** making the frame profiler tell the truth about where draw time goes, so the 60 fps work has something reliable to aim at. `DEVELOPMENT_MODE` only — no behaviour change in a shipping build.

## What it contains

Two things, both instrumentation:

**1. Section timing for the whole of `Game::draw`** (`rendersectiontimer.h`, `game.cpp/.h`, `level.cpp/.h`, `profilingui.*`)

The profiler timed all of `Game::draw` but its per-section breakdown only covered `Level::draw`. Everything else was untimed: the post-processing resolve, the HUD, three render-target clears, `_window_render_texture->display()` and the final window blit. So the sections never added up to the measured draw and the difference was anyone's guess.

`RenderSectionTimer` is now shared by `Level` and `Game`, both feed one report, and the report ends with `TOTAL | measured draw | unaccounted` so a gap can't reappear unnoticed.

Result: sections **7.868 ms** against a measured draw of **7.960 ms** — **0.09 ms unaccounted**. The draw is fully tiled.

**2. A tile overdraw counter** (`drawcallcounter.h`, `tilemap.cpp`)

Counts tile pixels submitted per frame against the view area.

## Corrections since this PR was opened

I originally justified part 1 by saying the untimed gap was **15.4 ms of GPU wait** on hardware. That framing was wrong — the gap was mostly *instrument* gap, which is exactly what this PR closes. The section work stands on its own; the GPU-wait story does not.

The overdraw counter needs a health warning, and it is why this PR is worth a careful look rather than a rubber stamp:

- It divided the vertex count by 4 to get a tile count, but tiles are stored as two triangles — **6** vertices. Every count was 1.5x too high. Fixed in this PR.
- It still sums the **colour and the normal target**, and the animated tiles are gathered around the player block rather than around the view, so both inflate it further.

It reported 10.54x for the catacombs. An offline check that classifies every tileset and walks the layers per screen cell (`lab/tile_opacity/analyze_opacity.py`, not in this PR) puts the real tile geometry overdraw at **1.29x**. So the counter is an upper bound, roughly 2-3x high, and it should **not** be compared against the "2-4x for a healthy 2D renderer" figure I quoted earlier.

Treat it as something to watch move when a change lands, not as an absolute. If you would rather this PR carried only the section timing, say so and I will strip the counter out.

## Verification

- Desktop: builds and links clean.
- Switch: catacombs loads and renders correctly; both the accounting and the counter report.
- The earlier claim that this branch crashed the console on level load was **wrong** — those runs never got past the menu. Five runs reached `level loading complete` and ran normally.