### PR TITLE
batch a light's shadow quads into a single draw call

### DIFF
--- a/src/game/effects/lightsystem.cpp
+++ b/src/game/effects/lightsystem.cpp
@@ -112,6 +112,11 @@ void LightSystem::drawShadowQuads(
    const sf::RenderStates shadow_states{stencil_write_mode};
 #endif
 
+   // every quad used to be a draw call of its own, and the level's solid geometry is one chain
+   // shape, so a light standing next to a wall issued one call per edge in range - times six
+   // lights, every frame. the quads all carry the same state, so they batch into a single call
+   _shadow_vertices.clear();
+
    for (auto* body : candidates)
    {
       // skip bodies that belong to the light's own mechanism
@@ -184,11 +189,7 @@ void LightSystem::drawShadowQuads(
                   sf::Vertex(sf::Vector2f(v1.x, v1.y) * PPM, sf::Color::Black)
                };
 
-#ifdef DECEPTUS_VRSFML
-               target.draw(std::span<const sf::Vertex>{quad.data(), quad.size()}, sf::PrimitiveType::Triangles, shadow_states);
-#else
-               target.draw(quad.data(), quad.size(), sf::PrimitiveType::Triangles, shadow_states);
-#endif
+               _shadow_vertices.insert(_shadow_vertices.end(), quad.begin(), quad.end());
             }
          }
          else if (shape_chain)
@@ -224,11 +225,7 @@ void LightSystem::drawShadowQuads(
                   sf::Vertex(sf::Vector2f(vertex_1.x, vertex_1.y) * PPM, sf::Color::Black)
                };
 
-#ifdef DECEPTUS_VRSFML
-               target.draw(std::span<const sf::Vertex>{quad.data(), quad.size()}, sf::PrimitiveType::Triangles, shadow_states);
-#else
-               target.draw(quad.data(), quad.size(), sf::PrimitiveType::Triangles, shadow_states);
-#endif
+               _shadow_vertices.insert(_shadow_vertices.end(), quad.begin(), quad.end());
             }
          }
          else if (shape_polygon)
@@ -263,15 +260,22 @@ void LightSystem::drawShadowQuads(
                   sf::Vertex(sf::Vector2f(v1.x, v1.y) * PPM, sf::Color::Black)
                };
 
-#ifdef DECEPTUS_VRSFML
-               target.draw(std::span<const sf::Vertex>{quad.data(), quad.size()}, sf::PrimitiveType::Triangles, shadow_states);
-#else
-               target.draw(quad.data(), quad.size(), sf::PrimitiveType::Triangles, shadow_states);
-#endif
+               _shadow_vertices.insert(_shadow_vertices.end(), quad.begin(), quad.end());
             }
          }
       }
    }
+
+   if (_shadow_vertices.empty())
+   {
+      return;
+   }
+
+#ifdef DECEPTUS_VRSFML
+   target.draw(std::span<const sf::Vertex>{_shadow_vertices.data(), _shadow_vertices.size()}, sf::PrimitiveType::Triangles, shadow_states);
+#else
+   target.draw(_shadow_vertices.data(), _shadow_vertices.size(), sf::PrimitiveType::Triangles, shadow_states);
+#endif
 }
 
 sf::Vector2f mapCoordsToPixelNormalized(const sf::Vector2f& point, const sf::View& view)

--- a/src/game/effects/lightsystem.h
+++ b/src/game/effects/lightsystem.h
@@ -161,6 +161,10 @@ private:
    static constexpr auto segment_count = 20;
    std::array<b2Vec2, segment_count> _unit_circle;
 
+   //!< every shadow quad of one light, collected so the whole set goes out as a single draw call.
+   //!< kept as a member rather than a local so the frames after the first reuse its capacity
+   mutable std::vector<sf::Vertex> _shadow_vertices;
+
    OccluderDrawCallback _occluder_callback;
    sf::Clock _clock;  //!< tracks elapsed time for per-light shader uniforms
 };


### PR DESCRIPTION
Every shadow quad went out as its own `target.draw()` of six vertices. A level's solid geometry is a single chain shape, so a light standing next to a wall issued **one draw call per edge within range** — for every light, every frame.

The quads all carry the same stencil mode, blend mode and transform, so they concatenate into one call per light. This cannot change a pixel: the stencil comparison replaces with the same reference value regardless of how the quads are grouped, and no geometry is added or removed.

### Measured

Catacombs, desktop release build, cpu side submit cost:

| section | before | after |
|---|---:|---:|
| lighting | 0.357 ms | **0.145 ms** |
| foreground layers (untouched, control) | 0.465 ms | 0.466 ms |

The untouched section reading the same to the third decimal across two builds is what makes the lighting number trustworthy — frame rate on this machine varies by ±15% between runs and is not a usable signal.

Verified visually on the catacombs: light pools, falloff and shadowing unchanged.

### Why it matters beyond the desktop

Draw calls are cheap on a desktop gl driver. On the Switch each call costs considerably more, so the reduction should pay better there. The call count is a pure count and transfers unchanged.