### PR TITLE
batch a tile map's visible blocks into a single draw call

### DIFF
--- a/src/game/level/tilemap.cpp
+++ b/src/game/level/tilemap.cpp
@@ -335,6 +335,8 @@ void TileMap::drawVertices(sf::RenderTarget& target, sf::RenderStates states) co
       return;
    }
 
+   _batched_vertices.clear();
+
    const auto block_width_px = static_cast<float>(_tile_size_px.x * tile_count_per_block);
    const auto block_height_px = static_cast<float>(_tile_size_px.y * tile_count_per_block);
 
@@ -360,14 +362,34 @@ void TileMap::drawVertices(sf::RenderTarget& target, sf::RenderStates states) co
       const auto column_end = row.upper_bound(last_block_x);
       for (auto column_it = row.lower_bound(first_block_x); column_it != column_end; ++column_it)
       {
-         target.draw(column_it->second, states);
-#ifdef DEVELOPMENT_MODE
-         DrawCallCounter::tilemap_draw_calls++;
-#endif
+         const auto& block_vertices = column_it->second;
+         const auto block_vertex_count = block_vertices.getVertexCount();
+         if (block_vertex_count > 0)
+         {
+            _batched_vertices.insert(_batched_vertices.end(), &block_vertices[0], &block_vertices[0] + block_vertex_count);
+         }
       }
    }
 
-   target.draw(_vertices_animated, states);
+   // the animated tiles carry the same texture and blend mode as the static blocks, so they join
+   // the same batch rather than paying for a call of their own
+   const auto animated_vertex_count = _vertices_animated.getVertexCount();
+   if (animated_vertex_count > 0)
+   {
+      _batched_vertices.insert(_batched_vertices.end(), &_vertices_animated[0], &_vertices_animated[0] + animated_vertex_count);
+   }
+
+   if (_batched_vertices.empty())
+   {
+      return;
+   }
+
+#ifdef DECEPTUS_VRSFML
+   target.draw(std::span<const sf::Vertex>{_batched_vertices.data(), _batched_vertices.size()}, sf::PrimitiveType::Triangles, states);
+#else
+   target.draw(_batched_vertices.data(), _batched_vertices.size(), sf::PrimitiveType::Triangles, states);
+#endif
+
 #ifdef DEVELOPMENT_MODE
    DrawCallCounter::tilemap_draw_calls++;
 #endif

--- a/src/game/level/tilemap.h
+++ b/src/game/level/tilemap.h
@@ -133,6 +133,11 @@ private:
    mutable std::map<int32_t, std::map<int32_t, sf::VertexArray>> _vertices_static_blocks;
    sf::VertexArray _vertices_animated;
 
+   //!< every visible block plus the animated tiles of one draw, gathered so the lot goes out as a
+   //!< single call. all of it shares one texture and one blend mode, and concatenating in draw
+   //!< order keeps the result identical to drawing the blocks one by one
+   mutable std::vector<sf::Vertex> _batched_vertices;
+
    std::shared_ptr<sf::Texture> _texture_map;
    std::shared_ptr<sf::Texture> _normal_map;
 


### PR DESCRIPTION
Tile geometry is stored one vertex array per 16x16 tile block, and every block intersecting the view was drawn on its own, followed by another call for the animated tiles. That is one call per block, per tile map, per z index — and again for the normal target.

All of it shares one texture, one blend mode and one transform, so the blocks and the animated tiles concatenate into a single call. Concatenating **in draw order** leaves the submitted geometry byte for byte identical, which matters for the layers that blend.

### Measured

Catacombs, desktop release build:

| metric | before | after |
|---|---:|---:|
| tilemap draw calls per frame | 316 | **47** |
| foreground layers section | 0.466 ms | ~0.40 ms |
| tile overdraw (control) | 10.54x | 10.54x |

The unchanged overdraw is the check that no quad was dropped or duplicated — it is derived from the vertex counts actually submitted, so any mistake in the batching would move it.

Verified visually on the catacombs: all layers, ordering, blending and animated tiles unchanged.

### Honest note on the size of the win

Draw calls are cheap on this desktop gl driver (~0.25 µs), so cutting 269 of them only moved the section a little. The call count is what carries over to hardware where each call costs considerably more; that is the reason for the change, and it is not yet confirmed on the console.