### PR TITLE
profiling: write the desktop profiler's numbers to the log

### DIFF
--- a/src/game/debug/profilingui.cpp
+++ b/src/game/debug/profilingui.cpp
@@ -11,7 +11,10 @@
 #include "imgui/imgui.h"
 #pragma warning(pop)
 
+#include "framework/tools/log.h"
+
 #include <algorithm>
+#include <iomanip>
 #include <numeric>
 #include <sstream>
 
@@ -55,6 +58,45 @@ void drawTimingGraph(const char* label, const float* values, int32_t count, int3
       label, values, count, offset, overlay_text.str().c_str(), 0.0f, std::max(target_ms * 2.0f, max_ms * 1.1f), ImVec2(graph_width, 80.0f)
    );
    ImGui::Text("  min: %.2f ms   avg: %.2f ms   max: %.2f ms   target: %.2f ms", min_ms, average_ms, max_ms, target_ms);
+}
+
+constexpr auto section_report_interval_s = 5.0f;
+
+// the imgui window is fine to look at but a benchmark cannot read it, so the same numbers go into
+// the log as one line. that is what makes two desktop runs comparable to each other, and to the
+// line the console build already writes
+void logRenderSections(const std::vector<RenderSectionSample>& samples, int32_t frames)
+{
+   auto section_total_ms = 0.0f;
+
+   std::ostringstream section_line;
+   section_line << std::fixed << std::setprecision(3) << "profiling: sections over " << frames << " frames |";
+   for (const auto& sample : samples)
+   {
+      const auto average_ms = sample.duration_ms / static_cast<float>(frames);
+      section_line << " " << sample.name << " " << average_ms << " |";
+      section_total_ms += average_ms;
+   }
+
+   section_line << " TOTAL " << section_total_ms;
+   Log::Info() << section_line.str();
+}
+
+// draw call counts carry over to other hardware unchanged, unlike a timing, so they belong next to
+// the sections rather than only in the imgui window
+void logDrawCounts(const float* draw_calls, const float* target_switches, const float* scan_steps, int32_t count)
+{
+   if (count <= 0)
+   {
+      return;
+   }
+
+   const auto average = [count](const float* values) { return std::accumulate(values, values + count, 0.0f) / static_cast<float>(count); };
+
+   std::ostringstream counts_line;
+   counts_line << std::fixed << std::setprecision(1) << "profiling: tilemap draw calls per frame " << average(draw_calls)
+               << " | target switches " << average(target_switches) << " | layer scan steps " << average(scan_steps);
+   Log::Info() << counts_line.str();
 }
 }  // namespace
 
@@ -123,9 +165,19 @@ void ProfilingUi::draw()
       ImGui::Separator();
       ImGui::Text("render sections   (cpu side submit cost, in draw order)");
       ImGui::Spacing();
+      const auto section_frames = std::max(_render_section_frames, 1);
       for (const auto& sample : _render_section_timings)
       {
-         ImGui::Text("%.3f ms  %s", sample.duration_ms, sample.name.c_str());
+         ImGui::Text("%.3f ms  %s", sample.duration_ms / static_cast<float>(section_frames), sample.name.c_str());
+      }
+
+      if (_log_clock.getElapsedTime().asSeconds() >= section_report_interval_s)
+      {
+         _log_clock.restart();
+         logRenderSections(_render_section_timings, section_frames);
+         logDrawCounts(_tilemap_draw_calls.data(), _tilemap_target_switches.data(), _layer_scan_steps.data(), _samples_written);
+         _render_section_timings.clear();
+         _render_section_frames = 0;
       }
    }
 
@@ -239,7 +291,20 @@ void ProfilingUi::updateMechanismTimings(std::vector<MechanismSample> timings)
 
 void ProfilingUi::updateRenderSectionTimings(std::vector<RenderSectionSample> timings)
 {
-   _render_section_timings = std::move(timings);
+   // a single frame's sections are far too noisy to compare between two runs, so they are summed
+   // here and divided by the frame count on reporting, the same way the log flavour does it
+   if (_render_section_timings.size() != timings.size())
+   {
+      _render_section_timings = std::move(timings);
+      _render_section_frames = 1;
+      return;
+   }
+
+   for (size_t section_index = 0; section_index < timings.size(); section_index++)
+   {
+      _render_section_timings[section_index].duration_ms += timings[section_index].duration_ms;
+   }
+   _render_section_frames++;
 }
 
 bool ProfilingUi::isMechanismProfilingWanted() const

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -264,7 +264,11 @@ void Game::initializeWindow()
 
 #ifndef DECEPTUS_VRSFML
    _window->setVerticalSyncEnabled(game_config._vsync_enabled);
-   _window->setFramerateLimit(60);
+
+   // switching vsync off is how a profiling run asks to see the headroom above 60, so the limiter
+   // has to step aside with it - otherwise it caps the run at the very number being measured. this
+   // matches what the console branch below already does
+   _window->setFramerateLimit(game_config._vsync_enabled ? 60 : 0);
 #elif defined(__SWITCH__)
    // the console's panel runs at 60 Hz in both modes and paces the loop by itself, so vsync is all
    // that is wanted here and no frame rate limiter goes on top: a limiter would also cap a profiling
@@ -1262,7 +1266,7 @@ void Game::toggleFullScreen()
 
 #ifndef DECEPTUS_VRSFML
    _window->setVerticalSyncEnabled(config._vsync_enabled);
-   _window->setFramerateLimit(60);
+   _window->setFramerateLimit(config._vsync_enabled ? 60 : 0);
 #elif defined(__SWITCH__)
    _window->setVerticalSyncEnabled(config._vsync_enabled);
 #endif


### PR DESCRIPTION
**What this is for:** letting a script read the desktop profiler, so two runs can be compared to each other. `DEVELOPMENT_MODE` only, except for one behaviour change noted below.

## The problem

The desktop profiler draws its per-section submit costs into an imgui window. A benchmark script cannot read a window, so there was no way to answer "did that change help?" on desktop — the only comparable numbers came from the Switch build, whose log the console flavour already writes.

## What it contains

**1. The same one-line report on desktop** (`profilingui.cpp`)

Sections and draw counts now go to the log every 5 s, in the format the console build already uses:

```
profiling: sections over 3098 frames | atmosphere 0.006 | background layers 0.145 | foreground layers 0.370 | lighting 0.119 | ... | TOTAL 0.738
profiling: tilemap draw calls per frame 47.0 | target switches 39.0 | layer scan steps 9189.0
```

**2. The desktop flavour now averages its sections instead of replacing them**

It overwrote its section samples every frame. That is fine for a live graph but far too noisy to compare between runs, so it now accumulates and divides by the frame count on reporting — matching what the console flavour already did. The imgui window shows the average too.

**3. `setFramerateLimit` follows vsync** (`game.cpp`) — the one real behaviour change

It was a hard `setFramerateLimit(60)`. Switching vsync off is how a profiling run asks to see the headroom above 60, so the limiter was capping the run at exactly the number being measured: two different builds both reported "60 fps" and looked identical when one was 30% faster than the other. It now passes `0` when vsync is off. The console branch immediately below already documents this reasoning; this makes desktop agree with it.

Verified: catacombs with vsync off reports **637 fps** instead of 61.

## Why it was worth doing

Frame rate on this machine varies ±15% between runs, and I read a 1.49x speedup out of that noise once. These section timings reproduce to the third decimal across different builds, which makes an untouched section usable as a control. Both merged batching PRs were measured with exactly this.

## Note

Touches `profilingui.cpp` and `game.cpp`, which #427 also touches — whichever lands second will need a small rebase.