### PR TITLE
skip drawing water surfaces and smoke effects that are off screen

### DIFF
--- a/src/game/mechanisms/smokeeffect.cpp
+++ b/src/game/mechanisms/smokeeffect.cpp
@@ -28,6 +28,32 @@ std::string_view SmokeEffect::objectName() const
    return "SmokeEffect";
 }
 
+namespace
+{
+// mechanisms are culled by chunk distance to the player, which is coarse: one a couple of chunks
+// away is still drawn in full even when the camera cannot see any of it. that is worth avoiding
+// here because drawing this mechanism is not cheap, so the bounding box is checked against the
+// view first
+bool isOnScreen(const sf::View& view, const std::optional<sf::FloatRect>& bounding_box)
+{
+   if (!bounding_box.has_value())
+   {
+      return true;
+   }
+
+   const auto view_center = sfcompat::getViewCenter(view);
+   const auto view_size = sfcompat::getViewSize(view);
+   if (view_size.x <= 0.0f || view_size.y <= 0.0f)
+   {
+      return true;
+   }
+
+   const sf::FloatRect view_rect{{view_center.x - view_size.x * 0.5f, view_center.y - view_size.y * 0.5f}, {view_size.x, view_size.y}};
+
+   return sfcompat::findIntersection(view_rect, bounding_box.value()).has_value();
+}
+}  // namespace
+
 #ifdef DECEPTUS_VRSFML
 void SmokeEffect::draw(sf::RenderTarget& color, sf::RenderTarget& normal)
 {
@@ -36,6 +62,11 @@ void SmokeEffect::draw(sf::RenderTarget& color, sf::RenderTarget& normal)
 
 void SmokeEffect::draw(sf::RenderTarget& color, sf::RenderTarget& /*normal*/, const sf::RenderStates& states)
 {
+   if (!isOnScreen(states.view, _bounding_box_px))
+   {
+      return;
+   }
+
    if (!isEnabled())
    {
       return;
@@ -79,6 +110,11 @@ void SmokeEffect::draw(sf::RenderTarget& color, sf::RenderTarget& /*normal*/, co
 #else
 void SmokeEffect::draw(sf::RenderTarget& color, sf::RenderTarget& /*normal*/)
 {
+   if (!isOnScreen(color.getView(), _bounding_box_px))
+   {
+      return;
+   }
+
    if (!isEnabled())
    {
       return;

--- a/src/game/mechanisms/watersurface.cpp
+++ b/src/game/mechanisms/watersurface.cpp
@@ -78,6 +78,32 @@ std::vector<WaterSurface::SplashEmitter> emitters;
 
 // #define DEBUG_WATERSURFACE 1
 
+namespace
+{
+// mechanisms are culled by chunk distance to the player, which is coarse: one a couple of chunks
+// away is still drawn in full even when the camera cannot see any of it. that is worth avoiding
+// here because drawing this mechanism is not cheap, so the bounding box is checked against the
+// view first
+bool isOnScreen(const sf::View& view, const std::optional<sf::FloatRect>& bounding_box)
+{
+   if (!bounding_box.has_value())
+   {
+      return true;
+   }
+
+   const auto view_center = sfcompat::getViewCenter(view);
+   const auto view_size = sfcompat::getViewSize(view);
+   if (view_size.x <= 0.0f || view_size.y <= 0.0f)
+   {
+      return true;
+   }
+
+   const sf::FloatRect view_rect{{view_center.x - view_size.x * 0.5f, view_center.y - view_size.y * 0.5f}, {view_size.x, view_size.y}};
+
+   return sfcompat::findIntersection(view_rect, bounding_box.value()).has_value();
+}
+}  // namespace
+
 #ifdef DECEPTUS_VRSFML
 void WaterSurface::draw(sf::RenderTarget& color, sf::RenderTarget& normal)
 {
@@ -86,6 +112,11 @@ void WaterSurface::draw(sf::RenderTarget& color, sf::RenderTarget& normal)
 
 void WaterSurface::draw(sf::RenderTarget& color, sf::RenderTarget& /*normal*/, const sf::RenderStates& incoming_states)
 {
+   if (!isOnScreen(incoming_states.view, _bounding_box))
+   {
+      return;
+   }
+
    //
    //         __--4
    //   __- 2-    |
@@ -147,6 +178,11 @@ void WaterSurface::draw(sf::RenderTarget& color, sf::RenderTarget& /*normal*/, c
 #else
 void WaterSurface::draw(sf::RenderTarget& color, sf::RenderTarget& /*normal*/)
 {
+   if (!isOnScreen(color.getView(), _bounding_box))
+   {
+      return;
+   }
+
    //
    //         __--4
    //   __- 2-    |


### PR DESCRIPTION
Mechanisms are culled by **chunk distance to the player**, which is coarse: one a couple of chunks away is still drawn in full even when the camera cannot see any of it.

For most mechanisms that costs a few sprites. For these two it costs more — a `WaterSurface` renders into a render target of its own, calls `display()` on it and composites the result back, so every instance pays a render target switch whether or not it is visible.

Both now test their bounding box against the view before drawing. The visibility test is the same one `TileMap::drawVertices` already uses for its block window (`view_center - view_size * 0.5`).

### Measured

Catacombs, desktop release build, roughly 3000 frames, counted with temporary instrumentation that is not part of this PR:

| | draws skipped | per frame |
|---|---:|---:|
| `WaterSurface` | 1902 | ~0.6 |
| `SmokeEffect` | 9510 | ~3.2 |

For scale, the emulator's per-mechanism profile puts those instances at ~0.3 ms and ~0.2 ms of draw each — they are the two heaviest mechanisms in the catacombs by a factor of 5-10 over anything else.

### Verification

- Desktop release builds and links.
- `watersurface.cpp` and `smokeeffect.cpp` both pass a VRSFML syntax check, which is the flavour the Switch and web builds compile.
- Frames captured before and after at the same checkpoint: waterfalls, water body, both splash plumes, torches and candle all still present.

**What is not verified:** I have no frame-exact visual proof. The two captures differ in 42% of pixels, but that is animation — the mace has visibly swung between them and water, flames and smoke all animate — so a pixel diff cannot separate a culling bug from a moving scene here. The argument that nothing visible is lost rests on the visibility test being the same one the tile map already relies on, plus the eyeball check above.

**Not measured:** the frame-time win itself. The skip counts and the per-mechanism costs are both measured, but I have not run an A/B of total draw time, and emulator runs on this machine currently drift by more than the effect would be.