### PR TITLE
make DEVELOPMENT_MODE optional, default off for switch and web

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1186,7 +1186,23 @@ target_include_directories(
     ${CMAKE_BINARY_DIR}/_deps/sfml-src/include
     ${SDL3_INCLUDE_DIRS})
 
-target_compile_definitions(deceptus PRIVATE DEVELOPMENT_MODE USE_GL _USE_MATH_DEFINES)
+# DEVELOPMENT_MODE carries the whole diagnostic apparatus: the profiling ui, the per mechanism
+# timers, the draw call counters, the render section timers, and on the console a log write to the
+# sd card every five seconds. All of it is useful while measuring and all of it is overhead in a
+# build meant to run fast, so it can be switched off without touching the sources.
+# The console and the web build ship without it: neither has a window to show the profiling ui in,
+# and on the switch every report is a write to the sd card. Both can still be built with it by
+# passing -DDECEPTUS_DEVELOPMENT_MODE=ON, which is what a profiling run does.
+if(EMSCRIPTEN OR NINTENDO_SWITCH)
+    option(DECEPTUS_DEVELOPMENT_MODE "build with the profiling and debug instrumentation" OFF)
+else()
+    option(DECEPTUS_DEVELOPMENT_MODE "build with the profiling and debug instrumentation" ON)
+endif()
+
+target_compile_definitions(deceptus PRIVATE USE_GL _USE_MATH_DEFINES)
+if(DECEPTUS_DEVELOPMENT_MODE)
+    target_compile_definitions(deceptus PRIVATE DEVELOPMENT_MODE)
+endif()
 
 # Selects the VRSFML API rather than vanilla SFML's. Both the Emscripten and the Switch
 # target build against VRSFML, so this is what the SFML-flavour guards key off; plain


### PR DESCRIPTION
`DEVELOPMENT_MODE` was compiled into **every** build unconditionally — including the Switch NRO and the web build. It carries the whole diagnostic apparatus: the profiling ui, the per-mechanism timers, the draw call counters, the render section timers, and on the console a log write to the SD card every five seconds.

It is an option now, so the off path is a real configuration rather than a theory:

- **Switch and web default to off.** Neither has a window to show the profiling ui in, and on the console every report is an SD card write.
- **Desktop defaults to on**, where F10 makes it useful.
- Either can be flipped with `-DDECEPTUS_DEVELOPMENT_MODE=ON|OFF`, which is what a profiling run does.

### Verified

- Switch target with it off: configures, compiles and links `deceptus.nro`, 0 errors.
- Desktop target with it off: configures, compiles and links. Binary is **137 kB smaller** (6 507 520 vs 6 645 248 bytes).

### What this is worth in frame time

Unknown, and I would not want the PR read as claiming a win. The one part I could measure is the *gated* half — the profiler alternates its per-mechanism and section timers on and off every five seconds, which makes an A/B within a single run possible. Over 39 in-level reports in the emulator that came to **+0.080 ms of a 9.4 ms draw (0.9%), at 0.5 sigma** — statistically indistinguishable from noise, bounding it below roughly 0.35 ms.

The ungated parts (draw call counters, the overdraw arithmetic per visible tile block) and the SD card writes are not covered by that measurement. Turning the whole thing off is what this PR makes possible; measuring it properly needs a hardware run.