### PR TITLE
batch the ambient occlusion quads into a single draw call

### DIFF
--- a/src/game/debug/drawcallcounter.h
+++ b/src/game/debug/drawcallcounter.h
@@ -21,6 +21,12 @@ inline int32_t tilemap_draw_calls = 0;  //!< reset once per frame by the profile
 inline int32_t tilemap_target_switches = 0;
 inline const void* tilemap_last_target = nullptr;
 
+//! Draw calls the ambient occlusion layer issues. Kept apart from the tile map count because they
+//! come from a different system: ao is a chunked set of quads sharing one atlas, and it used to
+//! submit one call per quad - a median of 230 per frame in the catacombs against 50 for every tile
+//! map put together. That went unnoticed for as long as the counter only described tile maps.
+inline int32_t ambient_occlusion_draw_calls = 0;
+
 //! Candidates examined by Level::drawLayers while looking for things to draw at a z index. The loop
 //! runs once per z index and rescans every container each time, so this grows with the z range
 //! multiplied by the level's content rather than with what is actually on screen.

--- a/src/game/debug/profilingui.cpp
+++ b/src/game/debug/profilingui.cpp
@@ -90,7 +90,13 @@ void logRenderSections(const std::vector<RenderSectionSample>& samples, int32_t 
 
 // draw call counts carry over to other hardware unchanged, unlike a timing, so they belong next to
 // the sections rather than only in the imgui window
-void logDrawCounts(const float* draw_calls, const float* target_switches, const float* scan_steps, int32_t count)
+void logDrawCounts(
+   const float* draw_calls,
+   const float* ambient_occlusion_draw_calls,
+   const float* target_switches,
+   const float* scan_steps,
+   int32_t count
+)
 {
    if (count <= 0)
    {
@@ -101,7 +107,8 @@ void logDrawCounts(const float* draw_calls, const float* target_switches, const 
 
    std::ostringstream counts_line;
    counts_line << std::fixed << std::setprecision(1) << "profiling: tilemap draw calls per frame " << average(draw_calls)
-               << " | target switches " << average(target_switches) << " | layer scan steps " << average(scan_steps);
+               << " | ao draw calls " << average(ambient_occlusion_draw_calls) << " | target switches " << average(target_switches)
+               << " | layer scan steps " << average(scan_steps);
    Log::Info() << counts_line.str();
 }
 }  // namespace
@@ -181,7 +188,13 @@ void ProfilingUi::draw()
       {
          _log_clock.restart();
          logRenderSections(_render_section_timings, section_frames);
-         logDrawCounts(_tilemap_draw_calls.data(), _tilemap_target_switches.data(), _layer_scan_steps.data(), _samples_written);
+         logDrawCounts(
+            _tilemap_draw_calls.data(),
+            _ambient_occlusion_draw_calls.data(),
+            _tilemap_target_switches.data(),
+            _layer_scan_steps.data(),
+            _samples_written
+         );
          _render_section_timings.clear();
          _render_section_frames = 0;
       }
@@ -270,6 +283,8 @@ void ProfilingUi::recordFrame(sf::Time frame_time, sf::Time update_time, sf::Tim
    _update_times_ms[_write_index] = update_time.asSeconds() * 1000.0f;
    _draw_times_ms[_write_index] = draw_time.asSeconds() * 1000.0f;
    _tilemap_draw_calls[_write_index] = static_cast<float>(DrawCallCounter::tilemap_draw_calls);
+   _ambient_occlusion_draw_calls[_write_index] = static_cast<float>(DrawCallCounter::ambient_occlusion_draw_calls);
+   DrawCallCounter::ambient_occlusion_draw_calls = 0;
    _tilemap_target_switches[_write_index] = static_cast<float>(DrawCallCounter::tilemap_target_switches);
    DrawCallCounter::tilemap_draw_calls = 0;
    _layer_scan_steps[_write_index] = static_cast<float>(DrawCallCounter::layer_scan_steps);
@@ -409,7 +424,8 @@ void ProfilingUi::draw()
    const auto draw_call_summary = summarizeSamples(_tilemap_draw_calls.data(), _samples_written);
    std::ostringstream draw_call_line;
    draw_call_line << std::fixed << std::setprecision(1) << "profiling: tilemap draw calls per frame "
-                  << formatSummary("", draw_call_summary) << " | target switches "
+                  << formatSummary("", draw_call_summary) << " | ao draw calls "
+                  << formatSummary("", summarizeSamples(_ambient_occlusion_draw_calls.data(), _samples_written)) << " | target switches "
                   << formatSummary("", summarizeSamples(_tilemap_target_switches.data(), _samples_written)) << " | layer scan steps "
                   << formatSummary("", summarizeSamples(_layer_scan_steps.data(), _samples_written));
 
@@ -494,6 +510,8 @@ void ProfilingUi::recordFrame(sf::Time frame_time, sf::Time update_time, sf::Tim
    _update_times_ms[_write_index] = update_time.asSeconds() * 1000.0f;
    _draw_times_ms[_write_index] = draw_time.asSeconds() * 1000.0f;
    _tilemap_draw_calls[_write_index] = static_cast<float>(DrawCallCounter::tilemap_draw_calls);
+   _ambient_occlusion_draw_calls[_write_index] = static_cast<float>(DrawCallCounter::ambient_occlusion_draw_calls);
+   DrawCallCounter::ambient_occlusion_draw_calls = 0;
    _tilemap_target_switches[_write_index] = static_cast<float>(DrawCallCounter::tilemap_target_switches);
    DrawCallCounter::tilemap_draw_calls = 0;
    _layer_scan_steps[_write_index] = static_cast<float>(DrawCallCounter::layer_scan_steps);

--- a/src/game/debug/profilingui.h
+++ b/src/game/debug/profilingui.h
@@ -47,10 +47,11 @@ private:
    std::array<float, sample_count> _update_times_ms{};
    std::array<float, sample_count> _draw_times_ms{};
    std::array<float, sample_count> _window_display_times_ms{};
-   std::array<float, sample_count> _tilemap_draw_calls{};        //!< tile map draw calls issued in that frame
-   std::array<float, sample_count> _tilemap_target_switches{};   //!< render target changes between those draws
-   std::array<float, sample_count> _layer_scan_steps{};          //!< candidates the z loop examined that frame
-   std::array<float, sample_count> _tilemap_pixels_submitted{};  //!< tile pixels submitted that frame, for the overdraw factor
+   std::array<float, sample_count> _tilemap_draw_calls{};            //!< tile map draw calls issued in that frame
+   std::array<float, sample_count> _tilemap_target_switches{};       //!< render target changes between those draws
+   std::array<float, sample_count> _ambient_occlusion_draw_calls{};  //!< ao draw calls issued in that frame
+   std::array<float, sample_count> _layer_scan_steps{};              //!< candidates the z loop examined that frame
+   std::array<float, sample_count> _tilemap_pixels_submitted{};      //!< tile pixels submitted that frame, for the overdraw factor
    sf::Clock _wall_clock;
    bool _wall_clock_primed{false};
    int32_t _write_index{0};

--- a/src/game/layers/ambientocclusion.cpp
+++ b/src/game/layers/ambientocclusion.cpp
@@ -1,12 +1,12 @@
 #include "ambientocclusion.h"
 
+#include <array>
 #include <cstdio>
 #include <fstream>
 #include <iostream>
 #include <sstream>
 
 #include "framework/tools/log.h"
-#include "framework/tools/sfmlcompat.h"
 #include "game/io/texturepool.h"
 #include "game/player/playerregistry.h"
 
@@ -67,17 +67,45 @@ void AmbientOcclusion::load(const std::filesystem::path& path, const std::string
          y_index_px += height_px;
       }
 
-#ifdef DECEPTUS_VRSFML
-      sf::Sprite sprite;
-#else
-      sf::Sprite sprite(*_texture);
-#endif
-      sfcompat::setPosition(sprite, {static_cast<float>(x_px - _config._offset_x_px), static_cast<float>(y_px - _config._offset_y_px)});
-      sfcompat::setTextureRect(sprite, sf::IntRect({x_index_px, y_index_px}, {width_px, height_px}));
+      const auto left_px = static_cast<float>(x_px - _config._offset_x_px);
+      const auto top_px = static_cast<float>(y_px - _config._offset_y_px);
+      const auto right_px = left_px + static_cast<float>(width_px);
+      const auto bottom_px = top_px + static_cast<float>(height_px);
+
+      const auto texture_left_px = static_cast<float>(x_index_px);
+      const auto texture_top_px = static_cast<float>(y_index_px);
+      const auto texture_right_px = texture_left_px + static_cast<float>(width_px);
+      const auto texture_bottom_px = texture_top_px + static_cast<float>(height_px);
+
+      // clang-format off
+      std::array<sf::Vertex, 4> quad;
+      quad[0].position = sf::Vector2f(left_px,  top_px);
+      quad[1].position = sf::Vector2f(right_px, top_px);
+      quad[2].position = sf::Vector2f(right_px, bottom_px);
+      quad[3].position = sf::Vector2f(left_px,  bottom_px);
+
+      quad[0].texCoords = sf::Vector2f(texture_left_px,  texture_top_px);
+      quad[1].texCoords = sf::Vector2f(texture_right_px, texture_top_px);
+      quad[2].texCoords = sf::Vector2f(texture_right_px, texture_bottom_px);
+      quad[3].texCoords = sf::Vector2f(texture_left_px,  texture_bottom_px);
+
+      quad[0].color = sf::Color::White;
+      quad[1].color = sf::Color::White;
+      quad[2].color = sf::Color::White;
+      quad[3].color = sf::Color::White;
+      // clang-format on
 
       group_x = (x_px >> 8);
       group_y = (y_px >> 8);
-      _sprite_map[group_y][group_x].push_back(sprite);
+
+      auto& chunk_vertices = _vertex_map[group_y][group_x];
+      chunk_vertices.push_back(quad[0]);
+      chunk_vertices.push_back(quad[1]);
+      chunk_vertices.push_back(quad[2]);
+
+      chunk_vertices.push_back(quad[0]);
+      chunk_vertices.push_back(quad[2]);
+      chunk_vertices.push_back(quad[3]);
    }
 
    uv_file.close();
@@ -94,10 +122,15 @@ void AmbientOcclusion::draw(sf::RenderTarget& window, const sf::RenderStates& st
    draw_states.texture = _texture.get();
    draw_states.blendMode = sf::BlendAlpha;
 
+   // every quad carries the same texture, blend mode and transform, so the visible chunks
+   // concatenate into a single call. drawing them one sprite at a time cost a draw call per quad -
+   // a median of 230 per frame in the catacombs, and up to 444
+   _batched_vertices.clear();
+
    for (auto y = player_chunk_y - chunk_range_y_left; y < player_chunk_y + chunk_range_y_right; y++)
    {
-      const auto& y_it = _sprite_map.find(y);
-      if (y_it == _sprite_map.end())
+      const auto& y_it = _vertex_map.find(y);
+      if (y_it == _vertex_map.end())
       {
          continue;
       }
@@ -112,12 +145,21 @@ void AmbientOcclusion::draw(sf::RenderTarget& window, const sf::RenderStates& st
 
          // Log::Info() << "draw " << x_it->second.size() << " sprites";
 
-         for (const auto& sprite : x_it->second)
-         {
-            window.draw(sprite, draw_states);
-         }
+         const auto& chunk_vertices = x_it->second;
+         _batched_vertices.insert(_batched_vertices.end(), chunk_vertices.begin(), chunk_vertices.end());
       }
    }
+
+   if (_batched_vertices.empty())
+   {
+      return;
+   }
+
+#ifdef DECEPTUS_VRSFML
+   window.draw(std::span<const sf::Vertex>{_batched_vertices.data(), _batched_vertices.size()}, sf::PrimitiveType::Triangles, draw_states);
+#else
+   window.draw(_batched_vertices.data(), _batched_vertices.size(), sf::PrimitiveType::Triangles, draw_states);
+#endif
 }
 
 int32_t AmbientOcclusion::getZ() const

--- a/src/game/layers/ambientocclusion.cpp
+++ b/src/game/layers/ambientocclusion.cpp
@@ -8,6 +8,9 @@
 
 #include "framework/tools/log.h"
 #include "game/io/texturepool.h"
+#ifdef DEVELOPMENT_MODE
+#include "game/debug/drawcallcounter.h"
+#endif
 #include "game/player/playerregistry.h"
 
 namespace
@@ -159,6 +162,10 @@ void AmbientOcclusion::draw(sf::RenderTarget& window, const sf::RenderStates& st
    window.draw(std::span<const sf::Vertex>{_batched_vertices.data(), _batched_vertices.size()}, sf::PrimitiveType::Triangles, draw_states);
 #else
    window.draw(_batched_vertices.data(), _batched_vertices.size(), sf::PrimitiveType::Triangles, draw_states);
+#endif
+
+#ifdef DEVELOPMENT_MODE
+   DrawCallCounter::ambient_occlusion_draw_calls++;
 #endif
 }
 

--- a/src/game/layers/ambientocclusion.h
+++ b/src/game/layers/ambientocclusion.h
@@ -51,5 +51,12 @@ public:
 private:
    Config _config;
    std::shared_ptr<sf::Texture> _texture;
-   std::map<int32_t, std::map<int32_t, std::vector<sf::Sprite>>> _sprite_map;
+
+   //!< two triangles per ao quad, bucketed by chunk. built once at load rather than kept as
+   //!< sprites, because every quad shares one texture and one blend mode and so the whole visible
+   //!< set can go out as a single draw call
+   std::map<int32_t, std::map<int32_t, std::vector<sf::Vertex>>> _vertex_map;
+
+   //!< the visible chunks of one frame, gathered so the lot goes out as one call
+   std::vector<sf::Vertex> _batched_vertices;
 };


### PR DESCRIPTION
`AmbientOcclusion` kept an `sf::Sprite` per quad and drew them one at a time:

```cpp
for (const auto& sprite : x_it->second)
{
   window.draw(sprite, draw_states);
}
```

over a chunk neighbourhood of 8 by 6. Counted from the catacombs uv table across every player position:

| AO draw calls / frame | |
|---|---:|
| median | **230** |
| p95 | 391 |
| max | 444 |

That is roughly **five times the entire tile map draw call count** (50 after the earlier batching), and it never showed up in any measurement because `DrawCallCounter` only counts tile maps — ambient occlusion is not a `TileMap`.

## The change

Every quad carries the same texture, the same blend mode and the same transform, so the visible chunks concatenate into one call. The quads become two triangles each **at load time** rather than staying as sprites, so nothing per frame builds geometry — the draw only concatenates the chunks in range, walking them in exactly the order used before, which keeps the alpha blending order identical.

This also removes a `DECEPTUS_VRSFML` branch, since raw vertices need no sprite construction.

## Measured

Catacombs at checkpoint 3, desktop release, cpu side submit cost. Four rounds, run in **both orders** (master-first and batched-first) so that machine drift cannot systematically favour either build:

| section | master | batched |
|---|---:|---:|
| foreground layers | 0.5215 ms | **0.4713 ms** (−9.6%) |
| TOTAL submit | 1.1228 ms | **1.0568 ms** (−5.9%) |
| lighting *(untouched — control)* | 0.150 ms | 0.151 ms |

## Verified visually

Pixel diffs on this scene are dominated by animation (waterfalls, torch flicker, dust), so the numbers only mean something against a same-build baseline:

| region | same-build master | master vs batched |
|---|---:|---:|
| brick wall | 5.17% | 4.50% |
| clock | 12.22% | 11.51% |
| floor | 16.81% | 14.85% |

The cross-build difference is **below** the same-build noise in every region.

Since that test is too blunt to prove ao is still being drawn at all, mean scene luminance was checked as well — removing ao would brighten the scene systematically. Master averages **21.141** across four runs (range 21.087–21.183), batched **21.154** (range 21.133–21.186): inside master's own run-to-run spread.

## Note

Ambient occlusion draw calls are still not counted by `DrawCallCounter`, which is how this stayed hidden. Worth adding if the counter is meant to reflect the frame rather than just tile maps.