### PR TITLE
count the ambient occlusion draw calls too

### DIFF
--- a/src/game/debug/drawcallcounter.h
+++ b/src/game/debug/drawcallcounter.h
@@ -21,6 +21,12 @@ inline int32_t tilemap_draw_calls = 0;  //!< reset once per frame by the profile
 inline int32_t tilemap_target_switches = 0;
 inline const void* tilemap_last_target = nullptr;
 
+//! Draw calls the ambient occlusion layer issues. Kept apart from the tile map count because they
+//! come from a different system: ao is a chunked set of quads sharing one atlas, and it used to
+//! submit one call per quad - a median of 230 per frame in the catacombs against 50 for every tile
+//! map put together. That went unnoticed for as long as the counter only described tile maps.
+inline int32_t ambient_occlusion_draw_calls = 0;
+
 //! Candidates examined by Level::drawLayers while looking for things to draw at a z index. The loop
 //! runs once per z index and rescans every container each time, so this grows with the z range
 //! multiplied by the level's content rather than with what is actually on screen.

--- a/src/game/debug/profilingui.cpp
+++ b/src/game/debug/profilingui.cpp
@@ -90,7 +90,13 @@ void logRenderSections(const std::vector<RenderSectionSample>& samples, int32_t 
 
 // draw call counts carry over to other hardware unchanged, unlike a timing, so they belong next to
 // the sections rather than only in the imgui window
-void logDrawCounts(const float* draw_calls, const float* target_switches, const float* scan_steps, int32_t count)
+void logDrawCounts(
+   const float* draw_calls,
+   const float* ambient_occlusion_draw_calls,
+   const float* target_switches,
+   const float* scan_steps,
+   int32_t count
+)
 {
    if (count <= 0)
    {
@@ -101,7 +107,8 @@ void logDrawCounts(const float* draw_calls, const float* target_switches, const 
 
    std::ostringstream counts_line;
    counts_line << std::fixed << std::setprecision(1) << "profiling: tilemap draw calls per frame " << average(draw_calls)
-               << " | target switches " << average(target_switches) << " | layer scan steps " << average(scan_steps);
+               << " | ao draw calls " << average(ambient_occlusion_draw_calls) << " | target switches " << average(target_switches)
+               << " | layer scan steps " << average(scan_steps);
    Log::Info() << counts_line.str();
 }
 }  // namespace
@@ -181,7 +188,13 @@ void ProfilingUi::draw()
       {
          _log_clock.restart();
          logRenderSections(_render_section_timings, section_frames);
-         logDrawCounts(_tilemap_draw_calls.data(), _tilemap_target_switches.data(), _layer_scan_steps.data(), _samples_written);
+         logDrawCounts(
+            _tilemap_draw_calls.data(),
+            _ambient_occlusion_draw_calls.data(),
+            _tilemap_target_switches.data(),
+            _layer_scan_steps.data(),
+            _samples_written
+         );
          _render_section_timings.clear();
          _render_section_frames = 0;
       }
@@ -270,6 +283,8 @@ void ProfilingUi::recordFrame(sf::Time frame_time, sf::Time update_time, sf::Tim
    _update_times_ms[_write_index] = update_time.asSeconds() * 1000.0f;
    _draw_times_ms[_write_index] = draw_time.asSeconds() * 1000.0f;
    _tilemap_draw_calls[_write_index] = static_cast<float>(DrawCallCounter::tilemap_draw_calls);
+   _ambient_occlusion_draw_calls[_write_index] = static_cast<float>(DrawCallCounter::ambient_occlusion_draw_calls);
+   DrawCallCounter::ambient_occlusion_draw_calls = 0;
    _tilemap_target_switches[_write_index] = static_cast<float>(DrawCallCounter::tilemap_target_switches);
    DrawCallCounter::tilemap_draw_calls = 0;
    _layer_scan_steps[_write_index] = static_cast<float>(DrawCallCounter::layer_scan_steps);
@@ -409,7 +424,8 @@ void ProfilingUi::draw()
    const auto draw_call_summary = summarizeSamples(_tilemap_draw_calls.data(), _samples_written);
    std::ostringstream draw_call_line;
    draw_call_line << std::fixed << std::setprecision(1) << "profiling: tilemap draw calls per frame "
-                  << formatSummary("", draw_call_summary) << " | target switches "
+                  << formatSummary("", draw_call_summary) << " | ao draw calls "
+                  << formatSummary("", summarizeSamples(_ambient_occlusion_draw_calls.data(), _samples_written)) << " | target switches "
                   << formatSummary("", summarizeSamples(_tilemap_target_switches.data(), _samples_written)) << " | layer scan steps "
                   << formatSummary("", summarizeSamples(_layer_scan_steps.data(), _samples_written));
 
@@ -494,6 +510,8 @@ void ProfilingUi::recordFrame(sf::Time frame_time, sf::Time update_time, sf::Tim
    _update_times_ms[_write_index] = update_time.asSeconds() * 1000.0f;
    _draw_times_ms[_write_index] = draw_time.asSeconds() * 1000.0f;
    _tilemap_draw_calls[_write_index] = static_cast<float>(DrawCallCounter::tilemap_draw_calls);
+   _ambient_occlusion_draw_calls[_write_index] = static_cast<float>(DrawCallCounter::ambient_occlusion_draw_calls);
+   DrawCallCounter::ambient_occlusion_draw_calls = 0;
    _tilemap_target_switches[_write_index] = static_cast<float>(DrawCallCounter::tilemap_target_switches);
    DrawCallCounter::tilemap_draw_calls = 0;
    _layer_scan_steps[_write_index] = static_cast<float>(DrawCallCounter::layer_scan_steps);

--- a/src/game/debug/profilingui.h
+++ b/src/game/debug/profilingui.h
@@ -47,10 +47,11 @@ private:
    std::array<float, sample_count> _update_times_ms{};
    std::array<float, sample_count> _draw_times_ms{};
    std::array<float, sample_count> _window_display_times_ms{};
-   std::array<float, sample_count> _tilemap_draw_calls{};        //!< tile map draw calls issued in that frame
-   std::array<float, sample_count> _tilemap_target_switches{};   //!< render target changes between those draws
-   std::array<float, sample_count> _layer_scan_steps{};          //!< candidates the z loop examined that frame
-   std::array<float, sample_count> _tilemap_pixels_submitted{};  //!< tile pixels submitted that frame, for the overdraw factor
+   std::array<float, sample_count> _tilemap_draw_calls{};            //!< tile map draw calls issued in that frame
+   std::array<float, sample_count> _tilemap_target_switches{};       //!< render target changes between those draws
+   std::array<float, sample_count> _ambient_occlusion_draw_calls{};  //!< ao draw calls issued in that frame
+   std::array<float, sample_count> _layer_scan_steps{};              //!< candidates the z loop examined that frame
+   std::array<float, sample_count> _tilemap_pixels_submitted{};      //!< tile pixels submitted that frame, for the overdraw factor
    sf::Clock _wall_clock;
    bool _wall_clock_primed{false};
    int32_t _write_index{0};

--- a/src/game/layers/ambientocclusion.cpp
+++ b/src/game/layers/ambientocclusion.cpp
@@ -8,6 +8,9 @@
 
 #include "framework/tools/log.h"
 #include "game/io/texturepool.h"
+#ifdef DEVELOPMENT_MODE
+#include "game/debug/drawcallcounter.h"
+#endif
 #include "game/player/playerregistry.h"
 
 namespace
@@ -159,6 +162,10 @@ void AmbientOcclusion::draw(sf::RenderTarget& window, const sf::RenderStates& st
    window.draw(std::span<const sf::Vertex>{_batched_vertices.data(), _batched_vertices.size()}, sf::PrimitiveType::Triangles, draw_states);
 #else
    window.draw(_batched_vertices.data(), _batched_vertices.size(), sf::PrimitiveType::Triangles, draw_states);
+#endif
+
+#ifdef DEVELOPMENT_MODE
+   DrawCallCounter::ambient_occlusion_draw_calls++;
 #endif
 }
 


### PR DESCRIPTION
**Stacked on #436** — targets `perf/batch-ambient-occlusion`, so merge that one first (or retarget this to master afterwards).

`DrawCallCounter` only ever described tile maps. That is precisely how ambient occlusion came to issue a **median of 230 draw calls per frame** — against 50 for every tile map put together — while I spent a day optimising the 50. It was found by counting the uv table offline, not by the profiler, which is the gap this closes.

## What it adds

- `DrawCallCounter::ambient_occlusion_draw_calls`, incremented where the draw is actually issued
- a sample slot in `ProfilingUi`, recorded and reset alongside the tile map counters
- the value printed by **both** report flavours, so the desktop log and the console log stay comparable

Ambient occlusion gets its own counter rather than being folded into the tile map total: the two come from different systems, and a combined number would hide which of them moved.

```
profiling: tilemap draw calls per frame 47.0 | ao draw calls 1.0 | target switches 39.0 | layer scan steps 9189.0
```

## Honest note on verification

The counter reads **1.0**, which is what one batched call per frame should look like — but that is consistency, not proof. I did not rebuild the pre-batching code with this counter in it to watch it report ~230, so the instrument itself has been sanity-checked rather than validated against a known value. The increment sits immediately beside the single `window.draw`, so there is not much room for it to be wrong, but the 230 figure in the commit message comes from the offline uv analysis, not from this counter.

Given a previous counter in this codebase reported a number that turned out to be inflated ~3x and cost a session of wrong conclusions, that distinction seemed worth stating rather than glossing.