### PR TITLE
capture the emulator's stdout and stderr to a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ build_*/*
 /lab/record_gameplay/.pytest_cache
 lab/switch_smoke/out/
 lab/switch_smoke/__pycache__
+
+# emulator stdout captured by run_switch.bat
+logs/

--- a/run_switch.bat
+++ b/run_switch.bat
@@ -31,8 +31,36 @@ if not exist "%NRO%" (
     exit /b 1
 )
 
+rem Everything the emulator writes goes to a file as well as to the console. A guest crash prints
+rem its stack trace and register dump to stderr and nowhere else - Ryujinx keeps no file log of its
+rem own by default - so without this the only copy of a crash scrolls past and is gone with the
+rem window. Both streams are merged, because the interesting lines are split across them.
+set LOG_DIRECTORY=%~dp0logs
+if not exist "%LOG_DIRECTORY%" mkdir "%LOG_DIRECTORY%"
+
+for /f "delims=" %%t in ('powershell -NoProfile -Command "Get-Date -Format yyyy-MM-dd__HH-mm-ss"') do set STAMP=%%t
+set LOG_FILE=%LOG_DIRECTORY%\ryujinx_%STAMP%.txt
+yujinx_%STAMP%.txt
+
 echo launching %NRO%
-"%RYUJINX%" "%NRO%"
+echo emulator output: %LOG_FILE%
+echo.
+
+rem Plain redirection rather than a tee: powershell wraps a native program's stderr
+rem as NativeCommandError noise and Tee-Object writes utf-16, which findstr cannot
+rem search. The console stays quiet during the run; the file has everything.
+"%RYUJINX%" "%NRO%" > "%LOG_FILE%" 2>&1
+
+rem A run that ends in a guest crash looks like a normal exit from the outside, so say so plainly
+rem rather than leaving it to be spotted in the scrollback.
+findstr /C:"InvalidAccessHandler" /C:"PrintGuestStackTrace" "%LOG_FILE%" >nul 2>&1
+if not errorlevel 1 (
+    echo.
+    echo *** THE GUEST CRASHED - stack trace and registers are in:
+    echo ***   %LOG_FILE%
+    echo.
+    findstr /C:"InvalidAccessHandler" "%LOG_FILE%"
+)
 
 rem The guest writes its own log to the emulated sd card, and on real hardware that log is the
 rem only artefact a run leaves behind, so it is worth knowing where it lands.


### PR DESCRIPTION
A guest crash prints a stack trace and register dump — and nothing else marks it. From the outside the run looks like a clean exit. Ryujinx keeps no file log of its own by default (`EnableFileLog: True` notwithstanding, the `Logs` directory is empty), so the only copy of that output scrolled past in the console and vanished with the window.

Both streams now go to `logs/ryujinx_<timestamp>.txt`, and the script says so plainly when a run ended in a guest crash:

```
*** THE GUEST CRASHED - stack trace and registers are in:
***   ...\logs\ryujinx_2026-08-19__12-12-38.txt
```

## Why plain redirection and not a tee

Tried `Tee-Object` first so the console would stay live. It is worse in two ways, both of which I only found by testing it:

- PowerShell wraps a native program's stderr as `NativeCommandError`, so the crash text arrives buried in `At line:1 char:36` noise and caret decorations.
- `Tee-Object` writes **UTF-16**, which `findstr` cannot search — the crash detection silently never fired.

`> file 2>&1` gives plain ANSI containing both streams, exactly as the console shows. The trade is that the console stays quiet during the run; the file has everything.

`logs/` is gitignored.