### PR TITLE
stop the logging thread before std::exit tears the runtime down

### DIFF
--- a/src/framework/tools/logthread.cpp
+++ b/src/framework/tools/logthread.cpp
@@ -50,8 +50,9 @@ LogThread::~LogThread()
       std::lock_guard<std::mutex> guard(_mutex);
       _stopped = true;
    }
-   // null when the log file could not be opened, in which case the thread was never started
-   if (_thread)
+   // null when the log file could not be opened, in which case the thread was never started, and
+   // already joined when a fatal message came through stop() first
+   if (_thread && _thread->joinable())
    {
       _thread->join();
    }
@@ -134,6 +135,29 @@ void LogThread::flush()
 void LogThread::flushSynchronously()
 {
 #ifdef DECEPTUS_LOG_TO_FILE
+   // Log::fatal calls this and then std::exit, which unwinds the runtime - including the locale
+   // facets basic_filebuf converts through on its way to the file - while this thread is still
+   // looping every 100 ms and flushing into it. Flushing alone left that race open: the sink kept
+   // writing into a half destroyed runtime and died inside the write, taking the queued messages
+   // with it. Stopping and joining the thread first is what closes it.
+   stop();
    flush();
+#endif
+}
+
+void LogThread::stop()
+{
+#ifdef DECEPTUS_LOG_TO_FILE
+   {
+      std::lock_guard<std::mutex> guard(_mutex);
+      _stopped = true;
+   }
+
+   // joining from the logging thread itself would deadlock, and a fatal logged from that thread is
+   // exactly the case where that would happen
+   if (_thread && _thread->joinable() && _thread->get_id() != std::this_thread::get_id())
+   {
+      _thread->join();
+   }
 #endif
 }

--- a/src/framework/tools/logthread.h
+++ b/src/framework/tools/logthread.h
@@ -58,6 +58,13 @@ private:
    };
 
    ///
+   /// \brief stops the background loop and joins it.
+   /// \note called before std::exit so the runtime cannot be torn down under a thread that is
+   ///       still writing to the file.
+   ///
+   void stop();
+
+   ///
    /// \brief runs the background loop and flushes periodically.
    ///
    void run();


### PR DESCRIPTION
## The crash

A guest stack from the Switch, symbolised against `deceptus.elf` (the frames are module-relative offsets against the NRO base `0x08500000`):

```
std::__basic_file<char>::xsputn
std::basic_filebuf::_M_convert_to_external
std::basic_filebuf::overflow / sync
std::ostream::flush
LogThread::flush              logthread.cpp:129
LogThread::run                logthread.cpp:96
execute_native_thread_routine
```

The logging thread died inside the file write. `_M_convert_to_external` goes through the stream's locale facets — which is the giveaway.

## Why

`Log::fatal` flushes every sink and then calls `std::exit`, which runs the static destructors — those facets among them — **while the logging thread is still looping every 100 ms and flushing into the same stream**. The existing comment already names this hazard; the mitigation was incomplete. Flushing synchronously got the fatal message into the queue's hands but left the thread running straight into the teardown.

That also explains a symptom that has been misleading us for days: **a crashed run's log stops several lines short of where the game actually got to.** The message that would have explained the exit is exactly the one the thread was writing when it died. In the run that prompted this, the SD log ended at `created window render texture` while the registers held a log line stamped three seconds later.

## The fix

`flushSynchronously` now stops and joins the thread before flushing. Two details:

- the join is skipped when it would be made **from the logging thread itself** — a fatal logged from that thread is exactly the case that would deadlock
- the destructor checks `joinable()`, so its own join becomes a no-op once `stop()` has run

`log()` already returns early once `_stopped` is set, and `Log::fatal` queues its message *before* invoking the flush callbacks, so the fatal line is still written.

## Verification, honestly

**Not verified against a live reproduction.** The crash is intermittent: the same NRO that crashed twice for the user booted cleanly **5/5** for me — three plain boots and two with the window closed mid-run, which was my best guess at the trigger. This matches a crash already recorded in this project as "stopped reproducing, cause unknown".

So this fixes the mechanism the stack indicts, by inspection, and cannot be shown to fix that particular run. Desktop builds and links clean.