### PR TITLE
fix the switch level load crash

### DIFF
--- a/src/framework/tools/log.cpp
+++ b/src/framework/tools/log.cpp
@@ -117,6 +117,14 @@ void Log::error(const std::string_view& message, const std::source_location& sou
    log(Level::Error, message, source_location);
 }
 
+void Log::flush()
+{
+   for (const auto& flush_callback : _flush_callbacks)
+   {
+      flush_callback();
+   }
+}
+
 void Log::fatal(const std::string_view& message, const std::source_location& source_location)
 {
    log(Level::Fatal, message, source_location);
@@ -124,10 +132,7 @@ void Log::fatal(const std::string_view& message, const std::source_location& sou
    // flush every sink before leaving. std::exit unwinds the runtime while an asynchronous sink is
    // still writing, which on the switch surfaces as a null dereference inside armGetTls and loses
    // the one message that would have explained the exit
-   for (const auto& flush_callback : _flush_callbacks)
-   {
-      flush_callback();
-   }
+   flush();
 
    std::exit(-1);
 }

--- a/src/framework/tools/log.h
+++ b/src/framework/tools/log.h
@@ -142,6 +142,13 @@ void registerListenerCallback(const ListenerCallback& cb);
 void registerFlushCallback(const FlushCallback& cb);
 
 ///
+/// \brief Runs every registered sink flush.
+/// \note Anything that leaves through std::exit has to call this first, or the process tears the
+///       runtime down while an asynchronous sink is still writing into it.
+///
+void flush();
+
+///
 /// \brief Formats a time point as local time in a thread-safe way.
 /// \param time_point Time point to format.
 /// \param format strftime-style format string.

--- a/src/game/level/levelfiles.cpp
+++ b/src/game/level/levelfiles.cpp
@@ -1,6 +1,7 @@
 #include "levelfiles.h"
 
 #include <filesystem>
+#include <system_error>
 
 void LevelFiles::clean(const LevelDescription& level_description)
 {
@@ -21,8 +22,14 @@ void LevelFiles::clean(const LevelDescription& level_description)
       crc_path,
    };
 
+   // the error_code overload rather than the throwing one: on the switch and in the browser the
+   // level lives on a read-only filesystem, so every one of these removes fails with EROFS. That
+   // came out as an uncaught filesystem_error which took the whole process down mid level load.
+   // Dropping generated files is best effort anyway - if they cannot be removed there is nothing
+   // stale to remove in the first place.
    for (const auto& filename : filenames)
    {
-      std::filesystem::remove(path / filename);
+      std::error_code remove_error;
+      std::filesystem::remove(path / filename, remove_error);
    }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <cstdlib>
 #include <iostream>
 #include <memory>
 #include <sstream>
@@ -135,6 +136,16 @@ int main(int /*argc*/, char** /*argv*/)
          }
       }
    );
+
+   // main() is not the only way out: Game::shutdown, the lua error handlers and a handful of
+   // unrecoverable asset failures all call exit() directly. That skips log_thread's destructor,
+   // so the writer thread is still flushing every 100 ms while the runtime tears itself down
+   // around it - and on the switch it dies inside that write, taking every queued message with
+   // it. The log then ends mid-startup and the reason for the exit is never written, which is
+   // exactly the situation the log exists for. Registering here rather than at static init time
+   // is deliberate: exit handlers run in reverse order of registration, so this one runs before
+   // the statics that logging itself depends on are gone.
+   std::atexit([] { Log::flush(); });
 
 #ifdef DEVELOPMENT_MODE
    Log::registerListenerCallback([](const auto& time_point, auto level, const auto& message, const auto& location)


### PR DESCRIPTION
Loading a level on the switch killed the process. `LevelFiles::clean` deletes the generated
physics and checksum files with the throwing overload of `std::filesystem::remove`, and on the
switch the level lives in romfs, which is read-only: every remove fails with `EROFS` and the
resulting `filesystem_error` was never caught. The removes are best effort, so this switches to
the `error_code` overload, which is what `gamepaths.cpp` already does for the same reason. The
browser build reads its level data from a read-only preloaded filesystem too.

The uncaught exception is also why the guest log always stopped at `created window render
texture`. It reaches `std::terminate` and `abort()`, which tears the statics down while the log
writer thread is still running, and the thread dies inside its own write - fault at address 0 in
`std::__basic_file<char>::xsputn`, taking every queued message with it. That is what made this
look like a spontaneous null dereference in `LogThread` for a day: the truncation was never the
crash site.

Finding it needed `-Wl,--wrap=__cxa_throw`, because ryujinx cannot translate the block in
libgcc's unwinder that reads `gcspr_el0` and so kills the guest thread before any handler runs.
Real hardware treats the `chkfeat` guard in front of it as a hint nop and branches around it, so
this is an emulator limitation rather than something the game hits on a console - but it does
mean no `catch` and no terminate handler can be relied on to report anything under ryujinx.

### Commits

- `stop the level load from throwing on a read-only filesystem` - the fix.
- `flush the log sinks from an exit handler as well` - latent hardening for the paths that leave
  through `exit()` (`Game::shutdown`, the lua error handlers). It does **not** fix the crash
  above, which leaves through `abort()` and runs no exit handlers, so it is a separate commit and
  can be dropped on its own.

### Verified

- master reproduces on demand: exit a few seconds after the level load, null dereference right
  after, guest log 8 lines.
- with the fix the catacombs load and render in ryujinx over two runs of 60 s and 90 s, 214 and
  274 log lines, no crash.
- desktop (`build_rel`, MSVC/ninja) still compiles and links.
