### PR TITLE
split the overdraw counter by what submits the pixels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,6 +208,8 @@ set(GAME_FILES
     src/game/debug/debugdraw.h
     src/game/debug/debugdrawstates.cpp
     src/game/debug/debugdrawstates.h
+    src/game/debug/drawcallcounter.cpp
+    src/game/debug/drawcallcounter.h
     src/game/debug/logui.cpp
     src/game/debug/logui.h
     src/game/debug/mechanismsample.h

--- a/src/game/debug/drawcallcounter.cpp
+++ b/src/game/debug/drawcallcounter.cpp
@@ -1,0 +1,95 @@
+#include "drawcallcounter.h"
+
+#ifdef DEVELOPMENT_MODE
+
+#include <algorithm>
+
+#include "framework/tools/sfmlcompat.h"
+
+namespace
+{
+
+///
+/// \brief Resolves the view a draw actually went through.
+/// \param target render target the draw went to.
+/// \param states render states the draw was made with.
+/// \return the view in effect for that draw.
+/// \note VRSFML carries the view in the render states rather than on the target, and a parallax
+///       layer is drawn through a view of its own, so neither source alone is right everywhere.
+///
+const sf::View& resolveView(const sf::RenderTarget& target, const sf::RenderStates& states)
+{
+#ifdef DECEPTUS_VRSFML
+   (void)target;
+   return states.view;
+#else
+   (void)states;
+   return target.getView();
+#endif
+}
+
+///
+/// \brief Area of an axis aligned rectangle clipped to the view, in pixels.
+/// \param view_center centre of the view being rendered through.
+/// \param view_size size of the view being rendered through.
+/// \param left_px left edge of the rectangle.
+/// \param top_px top edge of the rectangle.
+/// \param right_px right edge of the rectangle.
+/// \param bottom_px bottom edge of the rectangle.
+/// \return the visible area, or zero when the rectangle is off screen.
+///
+int64_t
+visibleArea(const sf::Vector2f& view_center, const sf::Vector2f& view_size, float left_px, float top_px, float right_px, float bottom_px)
+{
+   const auto view_left_px = view_center.x - view_size.x * 0.5f;
+   const auto view_top_px = view_center.y - view_size.y * 0.5f;
+   const auto view_right_px = view_center.x + view_size.x * 0.5f;
+   const auto view_bottom_px = view_center.y + view_size.y * 0.5f;
+
+   const auto visible_width_px = std::max(0.0f, std::min(right_px, view_right_px) - std::max(left_px, view_left_px));
+   const auto visible_height_px = std::max(0.0f, std::min(bottom_px, view_bottom_px) - std::max(top_px, view_top_px));
+
+   return static_cast<int64_t>(visible_width_px * visible_height_px);
+}
+
+}  // namespace
+
+void DrawCallCounter::countAmbientOcclusionPixels(
+   const sf::RenderTarget& target,
+   const sf::RenderStates& states,
+   const std::vector<sf::Vertex>& batched_vertices
+)
+{
+   const auto& view = resolveView(target, states);
+   const auto view_center = sfcompat::getViewCenter(view);
+   const auto view_size = sfcompat::getViewSize(view);
+
+   // the chunks are gathered around the player rather than around the view, so a good part of the
+   // batch never reaches the screen. clipping each quad is what keeps this comparable to the tile
+   // count, which is measured the same way.
+   //
+   // two triangles per quad, so six vertices: top left, top right, bottom right, then top left,
+   // bottom right, bottom left - see how AmbientOcclusion::load builds them
+   for (auto vertex_index = 0u; vertex_index + 6 <= batched_vertices.size(); vertex_index += 6)
+   {
+      const auto& top_left = batched_vertices[vertex_index].position;
+      const auto& bottom_right = batched_vertices[vertex_index + 2].position;
+
+      ambient_occlusion_pixels_submitted += visibleArea(view_center, view_size, top_left.x, top_left.y, bottom_right.x, bottom_right.y);
+   }
+}
+
+void DrawCallCounter::countImageLayerPixels(const sf::RenderTarget& target, const sf::RenderStates& states, const sf::Sprite& sprite)
+{
+   const auto& view = resolveView(target, states);
+   const auto view_center = sfcompat::getViewCenter(view);
+   const auto view_size = sfcompat::getViewSize(view);
+
+   const auto bounds = sprite.getGlobalBounds();
+
+   image_layer_pixels_submitted += visibleArea(
+      view_center, view_size, bounds.position.x, bounds.position.y, bounds.position.x + bounds.size.x, bounds.position.y + bounds.size.y
+   );
+}
+
+#endif  // DEVELOPMENT_MODE

--- a/src/game/debug/drawcallcounter.cpp
+++ b/src/game/debug/drawcallcounter.cpp
@@ -52,7 +52,21 @@ visibleArea(const sf::Vector2f& view_center, const sf::Vector2f& view_size, floa
    return static_cast<int64_t>(visible_width_px * visible_height_px);
 }
 
+//! tilemap_pixels_submitted as it stood when the normal pass started, so the pass can be measured
+//! without threading a flag through TileMap::drawVertices
+int64_t tilemap_pixels_before_normal_pass = 0;
+
 }  // namespace
+
+void DrawCallCounter::beginTileMapNormalPass()
+{
+   tilemap_pixels_before_normal_pass = tilemap_pixels_submitted;
+}
+
+void DrawCallCounter::endTileMapNormalPass()
+{
+   tilemap_normal_pixels_submitted += tilemap_pixels_submitted - tilemap_pixels_before_normal_pass;
+}
 
 void DrawCallCounter::countAmbientOcclusionPixels(
    const sf::RenderTarget& target,

--- a/src/game/debug/drawcallcounter.cpp
+++ b/src/game/debug/drawcallcounter.cpp
@@ -3,6 +3,7 @@
 #ifdef DEVELOPMENT_MODE
 
 #include <algorithm>
+#include <ranges>
 
 #include "framework/tools/sfmlcompat.h"
 
@@ -56,7 +57,51 @@ visibleArea(const sf::Vector2f& view_center, const sf::Vector2f& view_size, floa
 //! without threading a flag through TileMap::drawVertices
 int64_t tilemap_pixels_before_normal_pass = 0;
 
+//! the same trick one level up, for the layer currently being drawn. held by value: the caller
+//! may well pass a temporary, and a pointer to one dangles the moment the call returns
+int64_t tilemap_pixels_before_layer = 0;
+std::string current_layer_name;
+bool layer_attribution_active = false;
+
 }  // namespace
+
+void DrawCallCounter::beginTileMapLayer(const std::string& layer_name)
+{
+   current_layer_name = layer_name;
+   layer_attribution_active = true;
+   tilemap_pixels_before_layer = tilemap_pixels_submitted;
+}
+
+void DrawCallCounter::endTileMapLayer()
+{
+   if (!layer_attribution_active)
+   {
+      return;
+   }
+
+   const auto layer_name = current_layer_name;
+   layer_attribution_active = false;
+
+   const auto submitted = tilemap_pixels_submitted - tilemap_pixels_before_layer;
+   if (submitted == 0)
+   {
+      return;
+   }
+
+   // a level has a few dozen layers, so a linear scan beats a map, and appending in first-drawn
+   // order keeps two reports comparable line by line
+   const auto layer_it =
+      std::ranges::find_if(tilemap_layer_pixels, [&layer_name](const auto& entry) { return entry._layer_name == layer_name; });
+
+   if (layer_it == tilemap_layer_pixels.end())
+   {
+      tilemap_layer_pixels.push_back({layer_name, submitted, 1});
+      return;
+   }
+
+   layer_it->_pixels_submitted += submitted;
+   layer_it->_draw_count++;
+}
 
 void DrawCallCounter::beginTileMapNormalPass()
 {

--- a/src/game/debug/drawcallcounter.h
+++ b/src/game/debug/drawcallcounter.h
@@ -50,6 +50,21 @@ inline int64_t ambient_occlusion_pixels_submitted = 0;
 //! each one that is visible writes roughly a whole screen; the catacombs carry 21 of them.
 inline int64_t image_layer_pixels_submitted = 0;
 
+//! The part of tilemap_pixels_submitted that went to the normal target. Tile maps carrying a normal
+//! map are drawn a second time, so these pixels are shaded twice for one visible result - on a fill
+//! bound machine that is the difference between the two passes, whatever the draw call count says.
+inline int64_t tilemap_normal_pixels_submitted = 0;
+
+///
+/// \brief Starts attributing submitted tile pixels to the normal pass.
+///
+void beginTileMapNormalPass();
+
+///
+/// \brief Stops attributing submitted tile pixels to the normal pass.
+///
+void endTileMapNormalPass();
+
 ///
 /// \brief Adds the on-screen area of a batch of ambient occlusion quads.
 /// \param target render target the batch went to.

--- a/src/game/debug/drawcallcounter.h
+++ b/src/game/debug/drawcallcounter.h
@@ -2,7 +2,10 @@
 
 #ifdef DEVELOPMENT_MODE
 
+#include "SFML/Graphics.hpp"
+
 #include <cstdint>
+#include <vector>
 
 ///
 /// \brief Counts the draw calls tile maps issue, so the profiler can report them per frame.
@@ -37,6 +40,35 @@ inline int32_t layer_scan_steps = 0;
 //! by tile geometry alone. This is a pure count, so it reads the same on hardware as in an emulator,
 //! which makes it the one way to size a fill problem without a console.
 inline int64_t tilemap_pixels_submitted = 0;
+
+//! Ambient occlusion pixels submitted per frame, each quad clipped to the view. Kept apart from the
+//! tile count because ao is a full screen overlay of thousands of alpha blended quads, so it costs
+//! fill out of proportion to the single draw call it now takes.
+inline int64_t ambient_occlusion_pixels_submitted = 0;
+
+//! Image layer pixels submitted per frame. The parallax backdrops are drawn to fill the view, so
+//! each one that is visible writes roughly a whole screen; the catacombs carry 21 of them.
+inline int64_t image_layer_pixels_submitted = 0;
+
+///
+/// \brief Adds the on-screen area of a batch of ambient occlusion quads.
+/// \param target render target the batch went to.
+/// \param states render states the batch was drawn with.
+/// \param batched_vertices the batch itself, two triangles per quad.
+///
+void countAmbientOcclusionPixels(
+   const sf::RenderTarget& target,
+   const sf::RenderStates& states,
+   const std::vector<sf::Vertex>& batched_vertices
+);
+
+///
+/// \brief Adds the on-screen area of one image layer sprite.
+/// \param target render target the sprite went to.
+/// \param states render states the sprite was drawn with; carries the parallax view when there is one.
+/// \param sprite the sprite that was drawn.
+///
+void countImageLayerPixels(const sf::RenderTarget& target, const sf::RenderStates& states, const sf::Sprite& sprite);
 }  // namespace DrawCallCounter
 
 #endif  // DEVELOPMENT_MODE

--- a/src/game/debug/drawcallcounter.h
+++ b/src/game/debug/drawcallcounter.h
@@ -5,6 +5,7 @@
 #include "SFML/Graphics.hpp"
 
 #include <cstdint>
+#include <string>
 #include <vector>
 
 ///
@@ -54,6 +55,32 @@ inline int64_t image_layer_pixels_submitted = 0;
 //! map are drawn a second time, so these pixels are shaded twice for one visible result - on a fill
 //! bound machine that is the difference between the two passes, whatever the draw call count says.
 inline int64_t tilemap_normal_pixels_submitted = 0;
+
+///
+/// \brief One tile map layer and the pixels it has submitted since the last report.
+///
+struct TileMapLayerPixels
+{
+   std::string _layer_name;
+   int64_t _pixels_submitted{0};
+   int32_t _draw_count{0};  //!< times the layer was drawn over the window, colour and normal pass each counting once
+};
+
+//! Per layer breakdown of the tile fill, accumulated across the report window rather than reset
+//! every frame. Answers whether a handful of layers own the overdraw or it is spread evenly across
+//! all of them, which is what decides between dropping layers and rejecting hidden fragments.
+inline std::vector<TileMapLayerPixels> tilemap_layer_pixels;
+
+///
+/// \brief Starts attributing submitted tile pixels to one layer.
+/// \param layer_name name of the tile map layer being drawn.
+///
+void beginTileMapLayer(const std::string& layer_name);
+
+///
+/// \brief Stops attributing submitted tile pixels to a layer.
+///
+void endTileMapLayer();
 
 ///
 /// \brief Starts attributing submitted tile pixels to the normal pass.

--- a/src/game/debug/profilingui.cpp
+++ b/src/game/debug/profilingui.cpp
@@ -99,6 +99,7 @@ void logDrawCounts(
    const float* tilemap_pixels,
    const float* ambient_occlusion_pixels,
    const float* image_layer_pixels,
+   const float* tilemap_normal_pixels,
    int32_t count
 )
 {
@@ -119,9 +120,9 @@ void logDrawCounts(
    const auto view_area = static_cast<float>(GameConfiguration::getInstance()._view_width * GameConfiguration::getInstance()._view_height);
    if (view_area > 0.0f)
    {
-      counts_line << std::setprecision(2) << " | overdraw tiles " << (average(tilemap_pixels) / view_area) << "x, ao "
-                  << (average(ambient_occlusion_pixels) / view_area) << "x, image layers " << (average(image_layer_pixels) / view_area)
-                  << "x, total "
+      counts_line << std::setprecision(2) << " | overdraw tiles " << (average(tilemap_pixels) / view_area) << "x (normal pass "
+                  << (average(tilemap_normal_pixels) / view_area) << "x), ao " << (average(ambient_occlusion_pixels) / view_area)
+                  << "x, image layers " << (average(image_layer_pixels) / view_area) << "x, total "
                   << ((average(tilemap_pixels) + average(ambient_occlusion_pixels) + average(image_layer_pixels)) / view_area) << "x";
    }
    Log::Info() << counts_line.str();
@@ -211,6 +212,7 @@ void ProfilingUi::draw()
             _tilemap_pixels_submitted.data(),
             _ambient_occlusion_pixels_submitted.data(),
             _image_layer_pixels_submitted.data(),
+            _tilemap_normal_pixels_submitted.data(),
             _samples_written
          );
          _render_section_timings.clear();
@@ -308,12 +310,14 @@ void ProfilingUi::recordFrame(sf::Time frame_time, sf::Time update_time, sf::Tim
    _layer_scan_steps[_write_index] = static_cast<float>(DrawCallCounter::layer_scan_steps);
    _tilemap_pixels_submitted[_write_index] = static_cast<float>(DrawCallCounter::tilemap_pixels_submitted);
    _ambient_occlusion_pixels_submitted[_write_index] = static_cast<float>(DrawCallCounter::ambient_occlusion_pixels_submitted);
+   _tilemap_normal_pixels_submitted[_write_index] = static_cast<float>(DrawCallCounter::tilemap_normal_pixels_submitted);
    _image_layer_pixels_submitted[_write_index] = static_cast<float>(DrawCallCounter::image_layer_pixels_submitted);
    DrawCallCounter::tilemap_target_switches = 0;
    DrawCallCounter::tilemap_last_target = nullptr;
    DrawCallCounter::layer_scan_steps = 0;
    DrawCallCounter::tilemap_pixels_submitted = 0;
    DrawCallCounter::ambient_occlusion_pixels_submitted = 0;
+   DrawCallCounter::tilemap_normal_pixels_submitted = 0;
    DrawCallCounter::image_layer_pixels_submitted = 0;
    _write_index = (_write_index + 1) % sample_count;
    _samples_written = std::min(_samples_written + 1, sample_count);
@@ -459,6 +463,7 @@ void ProfilingUi::draw()
    const auto view_area = GameConfiguration::getInstance()._view_width * GameConfiguration::getInstance()._view_height;
    const auto pixel_summary = summarizeSamples(_tilemap_pixels_submitted.data(), _samples_written);
    const auto ambient_occlusion_pixel_summary = summarizeSamples(_ambient_occlusion_pixels_submitted.data(), _samples_written);
+   const auto tilemap_normal_pixel_summary = summarizeSamples(_tilemap_normal_pixels_submitted.data(), _samples_written);
    const auto image_layer_pixel_summary = summarizeSamples(_image_layer_pixels_submitted.data(), _samples_written);
    if (view_area > 0)
    {
@@ -466,7 +471,8 @@ void ProfilingUi::draw()
       // average pixel. splitting them by source is what turns "the frame is fill bound" into a
       // sorted list of what to cut
       const auto view_area_f = static_cast<float>(view_area);
-      draw_call_line << std::setprecision(2) << " | overdraw tiles " << (pixel_summary.average_ms / view_area_f) << "x, ao "
+      draw_call_line << std::setprecision(2) << " | overdraw tiles " << (pixel_summary.average_ms / view_area_f) << "x (normal pass "
+                     << (tilemap_normal_pixel_summary.average_ms / view_area_f) << "x), ao "
                      << (ambient_occlusion_pixel_summary.average_ms / view_area_f) << "x, image layers "
                      << (image_layer_pixel_summary.average_ms / view_area_f) << "x, total "
                      << ((pixel_summary.average_ms + ambient_occlusion_pixel_summary.average_ms + image_layer_pixel_summary.average_ms) /
@@ -550,12 +556,14 @@ void ProfilingUi::recordFrame(sf::Time frame_time, sf::Time update_time, sf::Tim
    _layer_scan_steps[_write_index] = static_cast<float>(DrawCallCounter::layer_scan_steps);
    _tilemap_pixels_submitted[_write_index] = static_cast<float>(DrawCallCounter::tilemap_pixels_submitted);
    _ambient_occlusion_pixels_submitted[_write_index] = static_cast<float>(DrawCallCounter::ambient_occlusion_pixels_submitted);
+   _tilemap_normal_pixels_submitted[_write_index] = static_cast<float>(DrawCallCounter::tilemap_normal_pixels_submitted);
    _image_layer_pixels_submitted[_write_index] = static_cast<float>(DrawCallCounter::image_layer_pixels_submitted);
    DrawCallCounter::tilemap_target_switches = 0;
    DrawCallCounter::tilemap_last_target = nullptr;
    DrawCallCounter::layer_scan_steps = 0;
    DrawCallCounter::tilemap_pixels_submitted = 0;
    DrawCallCounter::ambient_occlusion_pixels_submitted = 0;
+   DrawCallCounter::tilemap_normal_pixels_submitted = 0;
    DrawCallCounter::image_layer_pixels_submitted = 0;
    _write_index = (_write_index + 1) % sample_count;
    _samples_written = std::min(_samples_written + 1, sample_count);

--- a/src/game/debug/profilingui.cpp
+++ b/src/game/debug/profilingui.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <iomanip>
 #include <numeric>
+#include <ranges>
 #include <sstream>
 
 ProfilingUi::ProfilingUi() : _render_window(std::make_unique<sf::RenderWindow>(sf::VideoMode({900, 900}), "deceptus profiling"))
@@ -127,6 +128,35 @@ void logDrawCounts(
    }
    Log::Info() << counts_line.str();
 }
+// the per layer fill breakdown, worst first. one line rather than one per layer: on the console
+// every log line is a write to the sd card. the window is the report interval, so the totals
+// are divided by the frames in it before being held against the view
+void logTileMapLayerFill(int32_t frames, float view_area)
+{
+   if (DrawCallCounter::tilemap_layer_pixels.empty() || frames <= 0 || view_area <= 0.0f)
+   {
+      return;
+   }
+
+   auto layers = DrawCallCounter::tilemap_layer_pixels;
+   std::ranges::sort(layers, [](const auto& lhs, const auto& rhs) { return lhs._pixels_submitted > rhs._pixels_submitted; });
+
+   constexpr auto reported_layer_count = 8u;
+   std::ostringstream layer_line;
+   layer_line << std::fixed << std::setprecision(2) << "profiling: tile fill per layer |";
+   for (auto layer_index = 0u; layer_index < std::min<size_t>(reported_layer_count, layers.size()); layer_index++)
+   {
+      const auto& layer = layers[layer_index];
+      const auto overdraw = static_cast<float>(layer._pixels_submitted) / static_cast<float>(frames) / view_area;
+      const auto draws_per_frame = static_cast<float>(layer._draw_count) / static_cast<float>(frames);
+      layer_line << " " << layer._layer_name << " " << overdraw << "x in " << draws_per_frame << " draws |";
+   }
+   layer_line << " " << layers.size() << " layers total";
+   Log::Info() << layer_line.str();
+
+   DrawCallCounter::tilemap_layer_pixels.clear();
+}
+
 }  // namespace
 
 void ProfilingUi::draw()
@@ -214,6 +244,9 @@ void ProfilingUi::draw()
             _image_layer_pixels_submitted.data(),
             _tilemap_normal_pixels_submitted.data(),
             _samples_written
+         );
+         logTileMapLayerFill(
+            section_frames, static_cast<float>(GameConfiguration::getInstance()._view_width * GameConfiguration::getInstance()._view_height)
          );
          _render_section_timings.clear();
          _render_section_frames = 0;
@@ -374,6 +407,7 @@ bool ProfilingUi::isMechanismProfilingWanted() const
 #include <algorithm>
 #include <iomanip>
 #include <numeric>
+#include <ranges>
 #include <sstream>
 
 namespace
@@ -406,6 +440,35 @@ std::string formatSummary(const char* label, const TimingSummary& summary)
    out_stream << std::fixed << std::setprecision(2) << label << " min " << summary.minimum_ms << " avg " << summary.average_ms << " max "
               << summary.maximum_ms;
    return out_stream.str();
+}
+
+// the per layer fill breakdown, worst first. one line rather than one per layer: on the console
+// every log line is a write to the sd card. the window is the report interval, so the totals
+// are divided by the frames in it before being held against the view
+void logTileMapLayerFill(int32_t frames, float view_area)
+{
+   if (DrawCallCounter::tilemap_layer_pixels.empty() || frames <= 0 || view_area <= 0.0f)
+   {
+      return;
+   }
+
+   auto layers = DrawCallCounter::tilemap_layer_pixels;
+   std::ranges::sort(layers, [](const auto& lhs, const auto& rhs) { return lhs._pixels_submitted > rhs._pixels_submitted; });
+
+   constexpr auto reported_layer_count = 8u;
+   std::ostringstream layer_line;
+   layer_line << std::fixed << std::setprecision(2) << "profiling: tile fill per layer |";
+   for (auto layer_index = 0u; layer_index < std::min<size_t>(reported_layer_count, layers.size()); layer_index++)
+   {
+      const auto& layer = layers[layer_index];
+      const auto overdraw = static_cast<float>(layer._pixels_submitted) / static_cast<float>(frames) / view_area;
+      const auto draws_per_frame = static_cast<float>(layer._draw_count) / static_cast<float>(frames);
+      layer_line << " " << layer._layer_name << " " << overdraw << "x in " << draws_per_frame << " draws |";
+   }
+   layer_line << " " << layers.size() << " layers total";
+   Log::Info() << layer_line.str();
+
+   DrawCallCounter::tilemap_layer_pixels.clear();
 }
 
 }  // namespace
@@ -510,6 +573,8 @@ void ProfilingUi::draw()
                    << (draw_summary.average_ms - section_total_ms);
       Log::Info() << section_line.str();
    }
+
+   logTileMapLayerFill(std::max(_render_section_frames, 1), static_cast<float>(view_area));
 
    for (const auto& sample : _mechanism_timings)
    {

--- a/src/game/debug/profilingui.cpp
+++ b/src/game/debug/profilingui.cpp
@@ -12,6 +12,7 @@
 #pragma warning(pop)
 
 #include "framework/tools/log.h"
+#include "game/config/gameconfiguration.h"
 
 #include <algorithm>
 #include <iomanip>
@@ -95,6 +96,9 @@ void logDrawCounts(
    const float* ambient_occlusion_draw_calls,
    const float* target_switches,
    const float* scan_steps,
+   const float* tilemap_pixels,
+   const float* ambient_occlusion_pixels,
+   const float* image_layer_pixels,
    int32_t count
 )
 {
@@ -109,6 +113,17 @@ void logDrawCounts(
    counts_line << std::fixed << std::setprecision(1) << "profiling: tilemap draw calls per frame " << average(draw_calls)
                << " | ao draw calls " << average(ambient_occlusion_draw_calls) << " | target switches " << average(target_switches)
                << " | layer scan steps " << average(scan_steps);
+
+   // a pixel count is machine independent, so the overdraw split reads the same here as on the
+   // console. that is what makes a fill cut measurable on a desktop that is not fill bound
+   const auto view_area = static_cast<float>(GameConfiguration::getInstance()._view_width * GameConfiguration::getInstance()._view_height);
+   if (view_area > 0.0f)
+   {
+      counts_line << std::setprecision(2) << " | overdraw tiles " << (average(tilemap_pixels) / view_area) << "x, ao "
+                  << (average(ambient_occlusion_pixels) / view_area) << "x, image layers " << (average(image_layer_pixels) / view_area)
+                  << "x, total "
+                  << ((average(tilemap_pixels) + average(ambient_occlusion_pixels) + average(image_layer_pixels)) / view_area) << "x";
+   }
    Log::Info() << counts_line.str();
 }
 }  // namespace
@@ -193,6 +208,9 @@ void ProfilingUi::draw()
             _ambient_occlusion_draw_calls.data(),
             _tilemap_target_switches.data(),
             _layer_scan_steps.data(),
+            _tilemap_pixels_submitted.data(),
+            _ambient_occlusion_pixels_submitted.data(),
+            _image_layer_pixels_submitted.data(),
             _samples_written
          );
          _render_section_timings.clear();
@@ -289,10 +307,14 @@ void ProfilingUi::recordFrame(sf::Time frame_time, sf::Time update_time, sf::Tim
    DrawCallCounter::tilemap_draw_calls = 0;
    _layer_scan_steps[_write_index] = static_cast<float>(DrawCallCounter::layer_scan_steps);
    _tilemap_pixels_submitted[_write_index] = static_cast<float>(DrawCallCounter::tilemap_pixels_submitted);
+   _ambient_occlusion_pixels_submitted[_write_index] = static_cast<float>(DrawCallCounter::ambient_occlusion_pixels_submitted);
+   _image_layer_pixels_submitted[_write_index] = static_cast<float>(DrawCallCounter::image_layer_pixels_submitted);
    DrawCallCounter::tilemap_target_switches = 0;
    DrawCallCounter::tilemap_last_target = nullptr;
    DrawCallCounter::layer_scan_steps = 0;
    DrawCallCounter::tilemap_pixels_submitted = 0;
+   DrawCallCounter::ambient_occlusion_pixels_submitted = 0;
+   DrawCallCounter::image_layer_pixels_submitted = 0;
    _write_index = (_write_index + 1) % sample_count;
    _samples_written = std::min(_samples_written + 1, sample_count);
 }
@@ -436,9 +458,20 @@ void ProfilingUi::draw()
    // offline from the tilesets
    const auto view_area = GameConfiguration::getInstance()._view_width * GameConfiguration::getInstance()._view_height;
    const auto pixel_summary = summarizeSamples(_tilemap_pixels_submitted.data(), _samples_written);
+   const auto ambient_occlusion_pixel_summary = summarizeSamples(_ambient_occlusion_pixels_submitted.data(), _samples_written);
+   const auto image_layer_pixel_summary = summarizeSamples(_image_layer_pixels_submitted.data(), _samples_written);
    if (view_area > 0)
    {
-      draw_call_line << " | tile overdraw " << std::setprecision(2) << (pixel_summary.average_ms / static_cast<float>(view_area)) << "x";
+      // one screen written once is 1.0x, so these add up to how many times the frame pays for the
+      // average pixel. splitting them by source is what turns "the frame is fill bound" into a
+      // sorted list of what to cut
+      const auto view_area_f = static_cast<float>(view_area);
+      draw_call_line << std::setprecision(2) << " | overdraw tiles " << (pixel_summary.average_ms / view_area_f) << "x, ao "
+                     << (ambient_occlusion_pixel_summary.average_ms / view_area_f) << "x, image layers "
+                     << (image_layer_pixel_summary.average_ms / view_area_f) << "x, total "
+                     << ((pixel_summary.average_ms + ambient_occlusion_pixel_summary.average_ms + image_layer_pixel_summary.average_ms) /
+                         view_area_f)
+                     << "x";
    }
    Log::Info() << draw_call_line.str();
 
@@ -516,10 +549,14 @@ void ProfilingUi::recordFrame(sf::Time frame_time, sf::Time update_time, sf::Tim
    DrawCallCounter::tilemap_draw_calls = 0;
    _layer_scan_steps[_write_index] = static_cast<float>(DrawCallCounter::layer_scan_steps);
    _tilemap_pixels_submitted[_write_index] = static_cast<float>(DrawCallCounter::tilemap_pixels_submitted);
+   _ambient_occlusion_pixels_submitted[_write_index] = static_cast<float>(DrawCallCounter::ambient_occlusion_pixels_submitted);
+   _image_layer_pixels_submitted[_write_index] = static_cast<float>(DrawCallCounter::image_layer_pixels_submitted);
    DrawCallCounter::tilemap_target_switches = 0;
    DrawCallCounter::tilemap_last_target = nullptr;
    DrawCallCounter::layer_scan_steps = 0;
    DrawCallCounter::tilemap_pixels_submitted = 0;
+   DrawCallCounter::ambient_occlusion_pixels_submitted = 0;
+   DrawCallCounter::image_layer_pixels_submitted = 0;
    _write_index = (_write_index + 1) % sample_count;
    _samples_written = std::min(_samples_written + 1, sample_count);
 }

--- a/src/game/debug/profilingui.h
+++ b/src/game/debug/profilingui.h
@@ -47,11 +47,13 @@ private:
    std::array<float, sample_count> _update_times_ms{};
    std::array<float, sample_count> _draw_times_ms{};
    std::array<float, sample_count> _window_display_times_ms{};
-   std::array<float, sample_count> _tilemap_draw_calls{};            //!< tile map draw calls issued in that frame
-   std::array<float, sample_count> _tilemap_target_switches{};       //!< render target changes between those draws
-   std::array<float, sample_count> _ambient_occlusion_draw_calls{};  //!< ao draw calls issued in that frame
-   std::array<float, sample_count> _layer_scan_steps{};              //!< candidates the z loop examined that frame
-   std::array<float, sample_count> _tilemap_pixels_submitted{};      //!< tile pixels submitted that frame, for the overdraw factor
+   std::array<float, sample_count> _tilemap_draw_calls{};                  //!< tile map draw calls issued in that frame
+   std::array<float, sample_count> _tilemap_target_switches{};             //!< render target changes between those draws
+   std::array<float, sample_count> _ambient_occlusion_draw_calls{};        //!< ao draw calls issued in that frame
+   std::array<float, sample_count> _layer_scan_steps{};                    //!< candidates the z loop examined that frame
+   std::array<float, sample_count> _tilemap_pixels_submitted{};            //!< tile pixels submitted that frame, for the overdraw factor
+   std::array<float, sample_count> _ambient_occlusion_pixels_submitted{};  //!< ao pixels submitted that frame
+   std::array<float, sample_count> _image_layer_pixels_submitted{};        //!< image layer pixels submitted that frame
    sf::Clock _wall_clock;
    bool _wall_clock_primed{false};
    int32_t _write_index{0};

--- a/src/game/debug/profilingui.h
+++ b/src/game/debug/profilingui.h
@@ -53,6 +53,7 @@ private:
    std::array<float, sample_count> _layer_scan_steps{};                    //!< candidates the z loop examined that frame
    std::array<float, sample_count> _tilemap_pixels_submitted{};            //!< tile pixels submitted that frame, for the overdraw factor
    std::array<float, sample_count> _ambient_occlusion_pixels_submitted{};  //!< ao pixels submitted that frame
+   std::array<float, sample_count> _tilemap_normal_pixels_submitted{};     //!< the normal pass share of the tile pixels
    std::array<float, sample_count> _image_layer_pixels_submitted{};        //!< image layer pixels submitted that frame
    sf::Clock _wall_clock;
    bool _wall_clock_primed{false};

--- a/src/game/layers/ambientocclusion.cpp
+++ b/src/game/layers/ambientocclusion.cpp
@@ -166,6 +166,7 @@ void AmbientOcclusion::draw(sf::RenderTarget& window, const sf::RenderStates& st
 
 #ifdef DEVELOPMENT_MODE
    DrawCallCounter::ambient_occlusion_draw_calls++;
+   DrawCallCounter::countAmbientOcclusionPixels(window, draw_states, _batched_vertices);
 #endif
 }
 

--- a/src/game/level/tilemap.cpp
+++ b/src/game/level/tilemap.cpp
@@ -554,7 +554,13 @@ void TileMap::draw(sf::RenderTarget& color, sf::RenderTarget& normal, sf::Render
    if (_normal_map)
    {
       states.texture = _normal_map.get();
+#ifdef DEVELOPMENT_MODE
+      DrawCallCounter::beginTileMapNormalPass();
+#endif
       drawVertices(normal, states);
+#ifdef DEVELOPMENT_MODE
+      DrawCallCounter::endTileMapNormalPass();
+#endif
    }
 }
 

--- a/src/game/level/tilemap.cpp
+++ b/src/game/level/tilemap.cpp
@@ -442,7 +442,13 @@ void TileMap::draw(sf::RenderTarget& target, sf::RenderStates states) const
    }
 
    states.texture = _texture_map.get();
+#ifdef DEVELOPMENT_MODE
+   DrawCallCounter::beginTileMapLayer(_layer_name + "/" + _tileset_name);
+#endif
    drawVertices(target, states);
+#ifdef DEVELOPMENT_MODE
+   DrawCallCounter::endTileMapLayer();
+#endif
 }
 
 bool TileMap::dumpToPng(const std::filesystem::path& output_path) const
@@ -549,6 +555,9 @@ void TileMap::draw(sf::RenderTarget& color, sf::RenderTarget& normal, sf::Render
       states.blendMode = _blend_mode.value();
    }
 
+#ifdef DEVELOPMENT_MODE
+   DrawCallCounter::beginTileMapLayer(_layer_name + "/" + _tileset_name);
+#endif
    drawVertices(color, states);
 
    if (_normal_map)
@@ -562,6 +571,10 @@ void TileMap::draw(sf::RenderTarget& color, sf::RenderTarget& normal, sf::Render
       DrawCallCounter::endTileMapNormalPass();
 #endif
    }
+
+#ifdef DEVELOPMENT_MODE
+   DrawCallCounter::endTileMapLayer();
+#endif
 }
 
 bool TileMap::isPostLighting() const

--- a/src/game/mechanisms/imagelayer.cpp
+++ b/src/game/mechanisms/imagelayer.cpp
@@ -7,6 +7,10 @@
 #include "game/io/texturepool.h"
 #include "game/player/playerregistry.h"
 
+#ifdef DEVELOPMENT_MODE
+#include "game/debug/drawcallcounter.h"
+#endif
+
 ImageLayer::ImageLayer(GameNode* parent) : GameNode(parent)
 {
 }
@@ -51,6 +55,10 @@ void ImageLayer::draw(sf::RenderTarget& target, sf::RenderTarget& normal)
 
    target.draw(*_sprite, {_blend_mode});
 
+#ifdef DEVELOPMENT_MODE
+   DrawCallCounter::countImageLayerPixels(target, {_blend_mode}, *_sprite);
+#endif
+
    if (_parallax_settings.has_value())
    {
       target.setView(level_view);
@@ -76,7 +84,11 @@ void ImageLayer::draw(sf::RenderTarget& target, sf::RenderTarget& normal, const 
 
    if (_parallax_settings.has_value())
    {
-      target.draw(*_sprite, sf::RenderStates{.blendMode = _blend_mode, .view = _parallax_view, .texture = texture});
+      const sf::RenderStates parallax_states{.blendMode = _blend_mode, .view = _parallax_view, .texture = texture};
+      target.draw(*_sprite, parallax_states);
+#ifdef DEVELOPMENT_MODE
+      DrawCallCounter::countImageLayerPixels(target, parallax_states, *_sprite);
+#endif
    }
    else
    {
@@ -84,6 +96,9 @@ void ImageLayer::draw(sf::RenderTarget& target, sf::RenderTarget& normal, const 
       draw_states.blendMode = _blend_mode;
       draw_states.texture = texture;
       target.draw(*_sprite, draw_states);
+#ifdef DEVELOPMENT_MODE
+      DrawCallCounter::countImageLayerPixels(target, draw_states, *_sprite);
+#endif
    }
 #else
    (void)states;


### PR DESCRIPTION
The frame is fill bound on hardware, and a pixel count is the only measurement that transfers from
a desktop or an emulator to the console - it is a pure count, not a timing. But the counter only
ever covered tile maps, so the ambient occlusion overlay and the parallax image layers were
invisible in the one unit that matters, and the tile total said nothing about which layer it came
from.

Three splits, each answering the next question:

### 1. By source

| source | overdraw |
|---|---:|
| tiles | 11.57x |
| image layers | 1.83x |
| ao | 0.42x |
| **total** | **13.82x** |

ao is 3% of the budget - it was never the fill problem.

### 2. By pass

The normal pass is 2.94x of the tile 11.57x - a quarter, not the half the draw call count
suggested. So removing it entirely caps out at ~21% of the frame's fill.

### 3. By layer

`level 7.06x in 8.02 draws | bg0 1.85x | vignette 1.01x`, nothing else above 0.3x. One layer is 61%
of the tile fill, and it is drawn eight times a frame rather than being unusually large: six of
those are `LightSystem` re-rasterising it as an occluder, once per light, plus one stencil mask and
one ordinary draw. That is ~38% of the frame's fill spent producing six identical masks.

### Notes

- The counting lives in `drawcallcounter.cpp`, not in the draw paths. `AmbientOcclusion::draw`,
  `ImageLayer::draw` and `TileMap::draw` each gained guarded calls and nothing else.
- Entities, the player and the light sprites are still uncounted, so the total is a floor.
- The first report of a run is inflated: the per layer accumulator starts before the section window
  does. Second and later reports are correct.
- `DEVELOPMENT_MODE` only. Desktop (MSVC/ninja) and switch (devkitA64) both build.