### PR TITLE
only rasterise light occluders where the light can reach

### DIFF
--- a/src/framework/tools/sfmlcompat.h
+++ b/src/framework/tools/sfmlcompat.h
@@ -57,6 +57,18 @@ inline sf::Vector2f getViewSize(const sf::View& view)
 #endif
 }
 
+/// \brief restricts a view's rendering to part of the target, as a fraction of it.
+/// \note the scissor clips the rasteriser without touching the projection, so geometry lands on
+///       exactly the same pixels as it would through the unrestricted view.
+inline void setViewScissor(sf::View& view, const sf::FloatRect& scissor)
+{
+#ifdef DECEPTUS_VRSFML
+   view.scissor = scissor;
+#else
+   view.setScissor(scissor);
+#endif
+}
+
 /// \brief sets the origin of a transformable object.
 template <typename Drawable>
 inline void setOrigin(Drawable& drawable, const sf::Vector2f& origin)

--- a/src/game/effects/lightsystem.cpp
+++ b/src/game/effects/lightsystem.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <cmath>
 #include <numbers>
+#include <optional>
 #include <ranges>
 #ifdef DECEPTUS_VRSFML
 #include <span>
@@ -308,11 +309,11 @@ sf::Vector2f mapCoordsToPixelScreenDimension(sf::RenderTarget& target, const sf:
    return pixel;
 }
 
-void LightSystem::drawOccluders(sf::RenderTarget& target) const
+void LightSystem::drawOccluders(sf::RenderTarget& target, const sf::View& view) const
 {
    if (_occluder_callback)
    {
-      _occluder_callback(target);
+      _occluder_callback(target, view);
    }
 }
 
@@ -385,6 +386,53 @@ void LightSystem::updateLightShader(sf::RenderTarget& target)
       light_id++;
    }
 }
+
+namespace
+{
+///
+/// \brief Restricts a view to the part of the screen one light can reach.
+/// \param full_view the view the level is being rendered through.
+/// \param light_bounds_px the light sprite bounds, in world pixels.
+/// \return the same view with a scissor around the light, or nothing when it is off screen.
+/// \note the occluder pass rasterises the whole visible level layer once per light, and the
+///       shadow quads project to the edge of the world, but neither can change a pixel outside
+///       the light sprite: the sprite is what the stencil is tested against. A scissor clips the
+///       rasteriser without touching the projection, so the geometry lands on exactly the same
+///       pixels it would have, and everything outside the light is never shaded.
+///
+std::optional<sf::View> clipViewToLight(const sf::View& full_view, const sf::FloatRect& light_bounds_px)
+{
+   const auto view_center = sfcompat::getViewCenter(full_view);
+   const auto view_size = sfcompat::getViewSize(full_view);
+   if (view_size.x <= 0.0f || view_size.y <= 0.0f)
+   {
+      return std::nullopt;
+   }
+
+   const auto view_left_px = view_center.x - view_size.x * 0.5f;
+   const auto view_top_px = view_center.y - view_size.y * 0.5f;
+
+   const auto left_px = std::max(light_bounds_px.position.x, view_left_px);
+   const auto top_px = std::max(light_bounds_px.position.y, view_top_px);
+   const auto right_px = std::min(light_bounds_px.position.x + light_bounds_px.size.x, view_left_px + view_size.x);
+   const auto bottom_px = std::min(light_bounds_px.position.y + light_bounds_px.size.y, view_top_px + view_size.y);
+
+   if (right_px <= left_px || bottom_px <= top_px)
+   {
+      return std::nullopt;
+   }
+
+   auto clipped_view = full_view;
+   sfcompat::setViewScissor(
+      clipped_view,
+      sf::FloatRect{
+         {(left_px - view_left_px) / view_size.x, (top_px - view_top_px) / view_size.y},
+         {(right_px - left_px) / view_size.x, (bottom_px - top_px) / view_size.y}
+      }
+   );
+   return clipped_view;
+}
+}  // namespace
 
 void LightSystem::draw(sf::RenderTarget& target1, sf::RenderTarget& target2, sf::RenderStates states)
 {
@@ -485,11 +533,39 @@ void LightSystem::draw(sf::RenderTarget& target1, sf::RenderTarget& target2, sf:
       // draw occluders and shadow quads into the stencil buffer only.
       // each draw call carries stencil_write_mode so SFML enables the stencil test
       // and writes 1 for every occluded pixel instead of disabling it (default behaviour).
-      drawOccluders(target);
+      // the occluder pass redraws the whole visible level layer and the shadow quads project to
+      // the edge of the world, but the stencil they write is only ever tested where this light
+      // sprite is drawn. clipping both to the sprite turns six full screen passes over the level
+      // geometry into six small ones - it was 7.06x of the frame's 13.82x tile overdraw
 #ifdef DECEPTUS_VRSFML
-      drawShadowQuads(target, light, shadow_candidates, states);
+      const auto& full_view = states.view;
 #else
+      const auto& full_view = target.getView();
+#endif
+      const auto clipped_view = clipViewToLight(full_view, light->_sprite->getGlobalBounds());
+      if (!clipped_view.has_value())
+      {
+         channel_index++;
+         continue;
+      }
+
+#ifndef DECEPTUS_VRSFML
+      // captured before the occluder pass, which sets the clipped view on the target itself.
+      // taking it afterwards would restore the scissored view and leak it into the light sprite
+      // and everything drawn after the loop
+      const auto restore_view = target.getView();
+#endif
+
+      drawOccluders(target, clipped_view.value());
+
+#ifdef DECEPTUS_VRSFML
+      auto shadow_states = states;
+      shadow_states.view = clipped_view.value();
+      drawShadowQuads(target, light, shadow_candidates, shadow_states);
+#else
+      target.setView(clipped_view.value());
       drawShadowQuads(target, light, shadow_candidates);
+      target.setView(restore_view);
 #endif
 
       // draw the light sprite only where stencil == 0 (not occluded).

--- a/src/game/effects/lightsystem.h
+++ b/src/game/effects/lightsystem.h
@@ -22,7 +22,7 @@ class LightSystem
 {
 public:
    /// \brief callback to render geometry that occludes lights into the stencil buffer.
-   using OccluderDrawCallback = std::function<void(sf::RenderTarget& target)>;
+   using OccluderDrawCallback = std::function<void(sf::RenderTarget& target, const sf::View& view)>;
    /// \brief represents one light source instance loaded from level data.
    struct LightInstance : public GameNode
    {
@@ -143,7 +143,7 @@ private:
 
    /// \brief renders level occluder geometry to the stencil buffer before shadow/light passes.
    /// \param target render target with active stencil context.
-   void drawOccluders(sf::RenderTarget& target) const;
+   void drawOccluders(sf::RenderTarget& target, const sf::View& view) const;
 
    /// \brief refreshes shader uniforms for active lights, ambient color, and target resolution.
    /// \param target render target.

--- a/src/game/level/level.cpp
+++ b/src/game/level/level.cpp
@@ -206,7 +206,7 @@ Level::Level(const RenderTargets& render_targets) : GameNode(nullptr), _render_t
    _light_system = std::make_shared<LightSystem>();
 
    // set up occluder callback for light occlusion (z=24 "level" layer)
-   _light_system->setOccluderCallback([this](sf::RenderTarget& target) { drawLightOccluders(target); });
+   _light_system->setOccluderCallback([this](sf::RenderTarget& target, const sf::View& view) { drawLightOccluders(target, view); });
 
    // add raycast light for player
    nlohmann::json player_light_config;
@@ -1382,16 +1382,20 @@ void Level::drawDebugInformation()
    }
 }
 
-void Level::drawLightOccluders(sf::RenderTarget& target)
+void Level::drawLightOccluders(sf::RenderTarget& target, const sf::View& view)
 {
    // draw all tilemaps at z=24 into the stencil buffer only.
    // stencilOnly=true suppresses color output (replaces the old zero/zero blend mode).
    // the fragment shader's discard still runs so transparent tile regions don't occlude.
+   //
+   // the view comes from the light system rather than being _level_view directly: it is that
+   // view with a scissor around the light being drawn, so this pass only rasterises where the
+   // light can reach. same projection, a fraction of the fragments
 #ifndef DECEPTUS_VRSFML
-   target.setView(*_level_view);
+   target.setView(view);
    sf::RenderStates states;
 #else
-   sf::RenderStates states{.view = *_level_view};
+   sf::RenderStates states{.view = view};
 #endif
 
 #ifdef DECEPTUS_VRSFML

--- a/src/game/level/level.h
+++ b/src/game/level/level.h
@@ -354,7 +354,7 @@ protected:
 
    /// \brief draws z=24 tilemap geometry to the stencil buffer for light occlusion.
    /// \param target render target with active stencil context.
-   void drawLightOccluders(sf::RenderTarget& target);
+   void drawLightOccluders(sf::RenderTarget& target, const sf::View& view);
 
    /// \brief finalizes and displays intermediate level and normal render textures.
    void displayFinalTextures();


### PR DESCRIPTION
The per layer fill breakdown from #443 pointed straight at this: the `level` tile layer was
**7.06x of the frame's 13.82x total overdraw**, and it was drawn **eight times a frame** rather
than being unusually large. Six of those are `LightSystem` re-rasterising it as an occluder, once
per light.

Neither the occluder pass nor the shadow quads can change a pixel outside the light sprite - the
sprite is the only thing the stencil they write is ever tested against. So both now go through the
level view with a **scissor** around the light, which clips the rasteriser without touching the
projection: geometry lands on exactly the same pixels it did before. `sf::View` supports this in
both SFML flavours, it is just spelled differently, hence `sfcompat::setViewScissor`.

A light whose sprite does not intersect the view is skipped outright. Lights are selected by
distance to the *player*, not by visibility, so several were being rasterised fully off screen
every frame.

### Measured, catacombs start, ryujinx

| | before | after |
|---|---:|---:|
| tile overdraw | 11.57x | **8.44x** |
| total overdraw | 13.82x | **10.69x** |
| tilemap draw calls | 40 | 36 |

The counter measures *submitted geometry*, so it sees the skipped lights but not the scissor. On
hardware, where the frame is fill bound, the passes that remain also shade a fraction of the
fragments they used to - so the real saving is larger than the 23% shown here.

### Still to verify

Lighting looks correct in the emulator (lantern cone, candle, arch shadows all present) but I have
not done a controlled visual comparison - the two runs came out at different window sizes. Worth a
pass with `lab/render_regression/render_probe.py` against a same-build baseline before merging.

Desktop (MSVC/ninja) and switch (devkitA64) both build. One subtlety worth flagging in review: on
the desktop path the view to restore is captured *before* `drawOccluders`, because that function
sets the clipped view on the target itself - taking it afterwards leaked the scissor into the light
sprite and everything drawn after the loop.
