### PR TITLE
correct the fill counter and make it check itself (no runtime change)

### DIFF
--- a/src/game/debug/drawcallcounter.cpp
+++ b/src/game/debug/drawcallcounter.cpp
@@ -85,6 +85,8 @@ int64_t tilemap_pixels_before_normal_pass = 0;
 //! may well pass a temporary, and a pointer to one dangles the moment the call returns
 int64_t tilemap_pixels_before_layer = 0;
 int64_t tilemap_tiles_before_layer = 0;
+int32_t tilemap_blocks_before_layer = 0;
+double tilemap_fraction_before_layer = 0.0;
 std::string current_layer_name;
 bool layer_attribution_active = false;
 
@@ -96,6 +98,8 @@ void DrawCallCounter::beginTileMapLayer(const std::string& layer_name)
    layer_attribution_active = true;
    tilemap_pixels_before_layer = tilemap_pixels_submitted;
    tilemap_tiles_before_layer = tilemap_tiles_submitted;
+   tilemap_blocks_before_layer = tilemap_blocks_drawn;
+   tilemap_fraction_before_layer = tilemap_visible_fraction_sum;
 }
 
 void DrawCallCounter::endTileMapLayer()
@@ -110,6 +114,8 @@ void DrawCallCounter::endTileMapLayer()
 
    const auto submitted = tilemap_pixels_submitted - tilemap_pixels_before_layer;
    const auto tiles = tilemap_tiles_submitted - tilemap_tiles_before_layer;
+   const auto blocks = tilemap_blocks_drawn - tilemap_blocks_before_layer;
+   const auto fraction = tilemap_visible_fraction_sum - tilemap_fraction_before_layer;
    if (submitted == 0)
    {
       return;
@@ -122,13 +128,15 @@ void DrawCallCounter::endTileMapLayer()
 
    if (layer_it == tilemap_layer_pixels.end())
    {
-      tilemap_layer_pixels.push_back({layer_name, submitted, 1, tiles});
+      tilemap_layer_pixels.push_back({layer_name, submitted, 1, tiles, blocks, fraction});
       return;
    }
 
    layer_it->_pixels_submitted += submitted;
    layer_it->_draw_count++;
    layer_it->_tiles_submitted += tiles;
+   layer_it->_blocks_drawn += blocks;
+   layer_it->_visible_fraction_sum += fraction;
 }
 
 void DrawCallCounter::beginTileMapNormalPass()

--- a/src/game/debug/drawcallcounter.cpp
+++ b/src/game/debug/drawcallcounter.cpp
@@ -53,6 +53,30 @@ visibleArea(const sf::Vector2f& view_center, const sf::Vector2f& view_size, floa
    return static_cast<int64_t>(visible_width_px * visible_height_px);
 }
 
+///
+/// \brief Sums the on-screen area of a run of axis aligned quads.
+/// \param view_center centre of the view the quads were drawn through.
+/// \param view_size size of that view.
+/// \param vertices first vertex of the run.
+/// \param vertex_count how many vertices the run holds.
+/// \return the visible area of every whole quad in the run.
+/// \note two triangles per quad, so six vertices: top left, top right, bottom right, then top
+///       left, bottom right, bottom left. Both the ao atlas and the animated tiles build them
+///       that way.
+///
+int64_t
+sumVisibleQuadArea(const sf::Vector2f& view_center, const sf::Vector2f& view_size, const sf::Vertex* vertices, std::size_t vertex_count)
+{
+   int64_t visible_px = 0;
+   for (std::size_t vertex_index = 0; vertex_index + 6 <= vertex_count; vertex_index += 6)
+   {
+      const auto& top_left = vertices[vertex_index].position;
+      const auto& bottom_right = vertices[vertex_index + 2].position;
+      visible_px += visibleArea(view_center, view_size, top_left.x, top_left.y, bottom_right.x, bottom_right.y);
+   }
+   return visible_px;
+}
+
 //! tilemap_pixels_submitted as it stood when the normal pass started, so the pass can be measured
 //! without threading a flag through TileMap::drawVertices
 int64_t tilemap_pixels_before_normal_pass = 0;
@@ -60,6 +84,7 @@ int64_t tilemap_pixels_before_normal_pass = 0;
 //! the same trick one level up, for the layer currently being drawn. held by value: the caller
 //! may well pass a temporary, and a pointer to one dangles the moment the call returns
 int64_t tilemap_pixels_before_layer = 0;
+int64_t tilemap_tiles_before_layer = 0;
 std::string current_layer_name;
 bool layer_attribution_active = false;
 
@@ -70,6 +95,7 @@ void DrawCallCounter::beginTileMapLayer(const std::string& layer_name)
    current_layer_name = layer_name;
    layer_attribution_active = true;
    tilemap_pixels_before_layer = tilemap_pixels_submitted;
+   tilemap_tiles_before_layer = tilemap_tiles_submitted;
 }
 
 void DrawCallCounter::endTileMapLayer()
@@ -83,6 +109,7 @@ void DrawCallCounter::endTileMapLayer()
    layer_attribution_active = false;
 
    const auto submitted = tilemap_pixels_submitted - tilemap_pixels_before_layer;
+   const auto tiles = tilemap_tiles_submitted - tilemap_tiles_before_layer;
    if (submitted == 0)
    {
       return;
@@ -95,12 +122,13 @@ void DrawCallCounter::endTileMapLayer()
 
    if (layer_it == tilemap_layer_pixels.end())
    {
-      tilemap_layer_pixels.push_back({layer_name, submitted, 1});
+      tilemap_layer_pixels.push_back({layer_name, submitted, 1, tiles});
       return;
    }
 
    layer_it->_pixels_submitted += submitted;
    layer_it->_draw_count++;
+   layer_it->_tiles_submitted += tiles;
 }
 
 void DrawCallCounter::beginTileMapNormalPass()
@@ -111,6 +139,11 @@ void DrawCallCounter::beginTileMapNormalPass()
 void DrawCallCounter::endTileMapNormalPass()
 {
    tilemap_normal_pixels_submitted += tilemap_pixels_submitted - tilemap_pixels_before_normal_pass;
+}
+
+void DrawCallCounter::countAnimatedTilePixels(const sf::View& view, const sf::Vertex* vertices, std::size_t vertex_count)
+{
+   tilemap_pixels_submitted += sumVisibleQuadArea(sfcompat::getViewCenter(view), sfcompat::getViewSize(view), vertices, vertex_count);
 }
 
 void DrawCallCounter::countAmbientOcclusionPixels(
@@ -125,17 +158,8 @@ void DrawCallCounter::countAmbientOcclusionPixels(
 
    // the chunks are gathered around the player rather than around the view, so a good part of the
    // batch never reaches the screen. clipping each quad is what keeps this comparable to the tile
-   // count, which is measured the same way.
-   //
-   // two triangles per quad, so six vertices: top left, top right, bottom right, then top left,
-   // bottom right, bottom left - see how AmbientOcclusion::load builds them
-   for (auto vertex_index = 0u; vertex_index + 6 <= batched_vertices.size(); vertex_index += 6)
-   {
-      const auto& top_left = batched_vertices[vertex_index].position;
-      const auto& bottom_right = batched_vertices[vertex_index + 2].position;
-
-      ambient_occlusion_pixels_submitted += visibleArea(view_center, view_size, top_left.x, top_left.y, bottom_right.x, bottom_right.y);
-   }
+   // count, which is measured the same way
+   ambient_occlusion_pixels_submitted += sumVisibleQuadArea(view_center, view_size, batched_vertices.data(), batched_vertices.size());
 }
 
 void DrawCallCounter::countImageLayerPixels(const sf::RenderTarget& target, const sf::RenderStates& states, const sf::Sprite& sprite)

--- a/src/game/debug/drawcallcounter.h
+++ b/src/game/debug/drawcallcounter.h
@@ -42,6 +42,9 @@ inline int32_t layer_scan_steps = 0;
 //! which makes it the one way to size a fill problem without a console.
 inline int64_t tilemap_pixels_submitted = 0;
 
+//! tiles submitted this frame, the same count without the per tile area factor
+inline int64_t tilemap_tiles_submitted = 0;
+
 //! Ambient occlusion pixels submitted per frame, each quad clipped to the view. Kept apart from the
 //! tile count because ao is a full screen overlay of thousands of alpha blended quads, so it costs
 //! fill out of proportion to the single draw call it now takes.
@@ -63,7 +66,8 @@ struct TileMapLayerPixels
 {
    std::string _layer_name;
    int64_t _pixels_submitted{0};
-   int32_t _draw_count{0};  //!< times the layer was drawn over the window, colour and normal pass each counting once
+   int32_t _draw_count{0};       //!< times the layer was drawn over the window, colour and normal pass each counting once
+   int64_t _tiles_submitted{0};  //!< tiles handed to the rasteriser, before any per tile area
 };
 
 //! Per layer breakdown of the tile fill, accumulated across the report window rather than reset
@@ -91,6 +95,17 @@ void beginTileMapNormalPass();
 /// \brief Stops attributing submitted tile pixels to the normal pass.
 ///
 void endTileMapNormalPass();
+
+///
+/// \brief Adds the on-screen area of the animated tiles submitted with a tile map batch.
+/// \param view the view the batch was drawn through.
+/// \param vertices first vertex of the animated run, two triangles per tile.
+/// \param vertex_count how many vertices the run holds.
+/// \note the animated tiles are gathered around the player block rather than around the view, so
+///       unlike the static blocks they are not culled before submission. Clipping them here is what
+///       keeps the layer totals comparable to each other.
+///
+void countAnimatedTilePixels(const sf::View& view, const sf::Vertex* vertices, std::size_t vertex_count);
 
 ///
 /// \brief Adds the on-screen area of a batch of ambient occlusion quads.

--- a/src/game/debug/drawcallcounter.h
+++ b/src/game/debug/drawcallcounter.h
@@ -45,6 +45,13 @@ inline int64_t tilemap_pixels_submitted = 0;
 //! tiles submitted this frame, the same count without the per tile area factor
 inline int64_t tilemap_tiles_submitted = 0;
 
+//! blocks handed to the rasteriser this frame, and the sum of how much of each the view covers.
+//! the fractions have to add up to view area over block area - about 1.56 for a 640x360 view and
+//! 384 px blocks. anything above that means block rectangles are overlapping, i.e. the bounds the
+//! cull derives do not match where the block content actually is
+inline int32_t tilemap_blocks_drawn = 0;
+inline double tilemap_visible_fraction_sum = 0.0;
+
 //! Ambient occlusion pixels submitted per frame, each quad clipped to the view. Kept apart from the
 //! tile count because ao is a full screen overlay of thousands of alpha blended quads, so it costs
 //! fill out of proportion to the single draw call it now takes.
@@ -66,8 +73,10 @@ struct TileMapLayerPixels
 {
    std::string _layer_name;
    int64_t _pixels_submitted{0};
-   int32_t _draw_count{0};       //!< times the layer was drawn over the window, colour and normal pass each counting once
-   int64_t _tiles_submitted{0};  //!< tiles handed to the rasteriser, before any per tile area
+   int32_t _draw_count{0};             //!< times the layer was drawn over the window, colour and normal pass each counting once
+   int64_t _tiles_submitted{0};        //!< tiles handed to the rasteriser, before any per tile area
+   int32_t _blocks_drawn{0};           //!< blocks this layer submitted over the window
+   double _visible_fraction_sum{0.0};  //!< how much of each of them the view covered, summed
 };
 
 //! Per layer breakdown of the tile fill, accumulated across the report window rather than reset

--- a/src/game/debug/profilingui.cpp
+++ b/src/game/debug/profilingui.cpp
@@ -149,7 +149,9 @@ void logTileMapLayerFill(int32_t frames, float view_area)
       const auto& layer = layers[layer_index];
       const auto overdraw = static_cast<float>(layer._pixels_submitted) / static_cast<float>(frames) / view_area;
       const auto draws_per_frame = static_cast<float>(layer._draw_count) / static_cast<float>(frames);
-      layer_line << " " << layer._layer_name << " " << overdraw << "x in " << draws_per_frame << " draws |";
+      const auto tiles_per_frame = static_cast<float>(layer._tiles_submitted) / static_cast<float>(frames);
+      layer_line << " " << layer._layer_name << " " << overdraw << "x in " << draws_per_frame << " draws, "
+                 << static_cast<int32_t>(tiles_per_frame) << " tiles |";
    }
    layer_line << " " << layers.size() << " layers total";
    Log::Info() << layer_line.str();
@@ -463,7 +465,9 @@ void logTileMapLayerFill(int32_t frames, float view_area)
       const auto& layer = layers[layer_index];
       const auto overdraw = static_cast<float>(layer._pixels_submitted) / static_cast<float>(frames) / view_area;
       const auto draws_per_frame = static_cast<float>(layer._draw_count) / static_cast<float>(frames);
-      layer_line << " " << layer._layer_name << " " << overdraw << "x in " << draws_per_frame << " draws |";
+      const auto tiles_per_frame = static_cast<float>(layer._tiles_submitted) / static_cast<float>(frames);
+      layer_line << " " << layer._layer_name << " " << overdraw << "x in " << draws_per_frame << " draws, "
+                 << static_cast<int32_t>(tiles_per_frame) << " tiles |";
    }
    layer_line << " " << layers.size() << " layers total";
    Log::Info() << layer_line.str();

--- a/src/game/debug/profilingui.cpp
+++ b/src/game/debug/profilingui.cpp
@@ -151,7 +151,9 @@ void logTileMapLayerFill(int32_t frames, float view_area)
       const auto draws_per_frame = static_cast<float>(layer._draw_count) / static_cast<float>(frames);
       const auto tiles_per_frame = static_cast<float>(layer._tiles_submitted) / static_cast<float>(frames);
       layer_line << " " << layer._layer_name << " " << overdraw << "x in " << draws_per_frame << " draws, "
-                 << static_cast<int32_t>(tiles_per_frame) << " tiles |";
+                 << static_cast<int32_t>(tiles_per_frame) << " tiles, "
+                 << (static_cast<float>(layer._blocks_drawn) / static_cast<float>(frames)) << " blocks, frac "
+                 << (static_cast<float>(layer._visible_fraction_sum) / static_cast<float>(frames)) << " |";
    }
    layer_line << " " << layers.size() << " layers total";
    Log::Info() << layer_line.str();
@@ -467,7 +469,9 @@ void logTileMapLayerFill(int32_t frames, float view_area)
       const auto draws_per_frame = static_cast<float>(layer._draw_count) / static_cast<float>(frames);
       const auto tiles_per_frame = static_cast<float>(layer._tiles_submitted) / static_cast<float>(frames);
       layer_line << " " << layer._layer_name << " " << overdraw << "x in " << draws_per_frame << " draws, "
-                 << static_cast<int32_t>(tiles_per_frame) << " tiles |";
+                 << static_cast<int32_t>(tiles_per_frame) << " tiles, "
+                 << (static_cast<float>(layer._blocks_drawn) / static_cast<float>(frames)) << " blocks, frac "
+                 << (static_cast<float>(layer._visible_fraction_sum) / static_cast<float>(frames)) << " |";
    }
    layer_line << " " << layers.size() << " layers total";
    Log::Info() << layer_line.str();

--- a/src/game/level/tilemap.cpp
+++ b/src/game/level/tilemap.cpp
@@ -392,6 +392,7 @@ void TileMap::drawVertices(sf::RenderTarget& target, sf::RenderStates states) co
          const auto tile_count = static_cast<float>(block_vertex_count / 6);
          DrawCallCounter::tilemap_pixels_submitted +=
             static_cast<int64_t>(tile_count * visible_fraction * static_cast<float>(_tile_size_px.x * _tile_size_px.y));
+         DrawCallCounter::tilemap_tiles_submitted += static_cast<int64_t>(tile_count * visible_fraction);
 #endif
       }
    }
@@ -417,10 +418,10 @@ void TileMap::drawVertices(sf::RenderTarget& target, sf::RenderStates states) co
 
 #ifdef DEVELOPMENT_MODE
    DrawCallCounter::tilemap_draw_calls++;
-   // the animated tiles are collected around the player block rather than around the view, so this
-   // adds tiles that are off screen. it is an upper bound, unlike the block term above
-   DrawCallCounter::tilemap_pixels_submitted +=
-      static_cast<int64_t>(_vertices_animated.getVertexCount() / 6) * _tile_size_px.x * _tile_size_px.y;
+   if (animated_vertex_count > 0)
+   {
+      DrawCallCounter::countAnimatedTilePixels(view, &_vertices_animated[0], animated_vertex_count);
+   }
 #endif
 }
 

--- a/src/game/level/tilemap.cpp
+++ b/src/game/level/tilemap.cpp
@@ -393,6 +393,8 @@ void TileMap::drawVertices(sf::RenderTarget& target, sf::RenderStates states) co
          DrawCallCounter::tilemap_pixels_submitted +=
             static_cast<int64_t>(tile_count * visible_fraction * static_cast<float>(_tile_size_px.x * _tile_size_px.y));
          DrawCallCounter::tilemap_tiles_submitted += static_cast<int64_t>(tile_count * visible_fraction);
+         DrawCallCounter::tilemap_blocks_drawn++;
+         DrawCallCounter::tilemap_visible_fraction_sum += visible_fraction;
 #endif
       }
    }


### PR DESCRIPTION
**This changes no runtime behaviour.** It is `DEVELOPMENT_MODE` instrumentation only - the frame
does exactly the same work before and after. Both corrections are to what the counter from #443
*claims*, after using it to pick the next cut and nearly chasing a ghost.

### The animated tiles were counted unculled

They are gathered around the player block rather than around the view, so unlike the static blocks
they were added to the fill total whole - the code said so and called itself an upper bound. They
are clipped like every other quad now, sharing the ao quad's area code rather than repeating it.

Catacombs start: tiles 8.44x -> 7.91x, total 10.69x -> 10.16x. **This is not a saving.** Those
tiles were always being drawn; they were being over-counted. The number went down, the cost did
not.

### The report now carries raw tile counts, blocks drawn and a fraction sum

An overdraw figure alone cannot tell a layer that covers the screen once from a measurement
artefact. The fraction sum is a self check: the visible fractions of the blocks a draw touches have
to add up to `view_area / block_area` - about 1.56 for a 640x360 view and 384 px blocks - because
the blocks tile the plane. Anything above that means the cull's bounds do not match where the block
content is.

It paid for itself immediately. `bg0` submits **737 tiles for a 400 tile screen**, which looked
like a culling bug: I had ruled out tile overhang (its tileset is 24x24, same as the map grid), a
parallax property, and a mismatched view, and the arithmetic said the total was capped at 400. The
new numbers read `12.02 blocks, frac 3.13` for **every** layer - exactly twice 1.56 - because both
catacombs tilesets carry a normal map, so each layer is rasterised into the colour target and again
into the normal one.

So `bg0` is 0.93x per pass rather than 1.85x in one. There is no bug; I had been reading a per-draw
figure as a single pass. Without this check the next pass would have gone hunting for it.
`vignette` reading exactly 398 tiles for a 400 tile screen is the same check passing.

### Fill budget, with the real and the measured separated

| | | |
|---|---:|---|
| session start | 13.82x | |
| after #444 | 10.69x | **real saving** - occluder clipping, less work done |
| after this PR | 10.16x | **no saving** - counter stops over-reporting |

So the fill actually cut this session is #444's -23%, plus the scissor saving Ryujinx cannot see.
What remains is dominated by the normal pass at 2.73x, and every route into it costs either
resolution or a per-layer content decision about which layers need normals - so it wants a
deliberate call rather than being folded into this.

Desktop (MSVC/ninja) and switch (devkitA64) both build.