### PR TITLE
skip the atmosphere passes when nothing on screen needs them

### DIFF
--- a/src/framework/tools/sfmlcompat.h
+++ b/src/framework/tools/sfmlcompat.h
@@ -69,6 +69,17 @@ inline void setViewScissor(sf::View& view, const sf::FloatRect& scissor)
 #endif
 }
 
+/// \brief returns a view's scissor rectangle, as a fraction of the target.
+/// \note an unscissored view reports the whole target, i.e. position 0,0 and size 1,1.
+inline sf::FloatRect getViewScissor(const sf::View& view)
+{
+#ifdef DECEPTUS_VRSFML
+   return view.scissor;
+#else
+   return view.getScissor();
+#endif
+}
+
 /// \brief sets the origin of a transformable object.
 template <typename Drawable>
 inline void setOrigin(Drawable& drawable, const sf::Vector2f& origin)

--- a/src/game/config/gameconfiguration.cpp
+++ b/src/game/config/gameconfiguration.cpp
@@ -154,6 +154,10 @@ GameConfiguration& GameConfiguration::getInstance()
       // this session may never run at
       __instance._video_mode_width = 1280;
       __instance._video_mode_height = 720;
+
+      // the console is fragment bound at its scan-out resolution, so the lighting, normal and
+      // atmosphere passes run at half size by default here. the config file still overrides it
+      __instance._render_target_profile = "reduced";
 #elif !defined(__EMSCRIPTEN__)
       const auto desktop = sf::VideoMode::getDesktopMode();
       __instance._video_mode_width = static_cast<int32_t>(desktop.size.x);

--- a/src/game/debug/drawcallcounter.cpp
+++ b/src/game/debug/drawcallcounter.cpp
@@ -30,33 +30,28 @@ const sf::View& resolveView(const sf::RenderTarget& target, const sf::RenderStat
 }
 
 ///
-/// \brief Area of an axis aligned rectangle clipped to the view, in pixels.
-/// \param view_center centre of the view being rendered through.
-/// \param view_size size of the view being rendered through.
+/// \brief Area of an axis aligned rectangle clipped to the rasterised region, in pixels.
+/// \param clip_px region of the view the draw is rasterised into.
 /// \param left_px left edge of the rectangle.
 /// \param top_px top edge of the rectangle.
 /// \param right_px right edge of the rectangle.
 /// \param bottom_px bottom edge of the rectangle.
 /// \return the visible area, or zero when the rectangle is off screen.
 ///
-int64_t
-visibleArea(const sf::Vector2f& view_center, const sf::Vector2f& view_size, float left_px, float top_px, float right_px, float bottom_px)
+int64_t visibleArea(const sf::FloatRect& clip_px, float left_px, float top_px, float right_px, float bottom_px)
 {
-   const auto view_left_px = view_center.x - view_size.x * 0.5f;
-   const auto view_top_px = view_center.y - view_size.y * 0.5f;
-   const auto view_right_px = view_center.x + view_size.x * 0.5f;
-   const auto view_bottom_px = view_center.y + view_size.y * 0.5f;
+   const auto clip_right_px = clip_px.position.x + clip_px.size.x;
+   const auto clip_bottom_px = clip_px.position.y + clip_px.size.y;
 
-   const auto visible_width_px = std::max(0.0f, std::min(right_px, view_right_px) - std::max(left_px, view_left_px));
-   const auto visible_height_px = std::max(0.0f, std::min(bottom_px, view_bottom_px) - std::max(top_px, view_top_px));
+   const auto visible_width_px = std::max(0.0f, std::min(right_px, clip_right_px) - std::max(left_px, clip_px.position.x));
+   const auto visible_height_px = std::max(0.0f, std::min(bottom_px, clip_bottom_px) - std::max(top_px, clip_px.position.y));
 
    return static_cast<int64_t>(visible_width_px * visible_height_px);
 }
 
 ///
 /// \brief Sums the on-screen area of a run of axis aligned quads.
-/// \param view_center centre of the view the quads were drawn through.
-/// \param view_size size of that view.
+/// \param clip_px region of the view the quads are rasterised into.
 /// \param vertices first vertex of the run.
 /// \param vertex_count how many vertices the run holds.
 /// \return the visible area of every whole quad in the run.
@@ -64,15 +59,14 @@ visibleArea(const sf::Vector2f& view_center, const sf::Vector2f& view_size, floa
 ///       left, bottom right, bottom left. Both the ao atlas and the animated tiles build them
 ///       that way.
 ///
-int64_t
-sumVisibleQuadArea(const sf::Vector2f& view_center, const sf::Vector2f& view_size, const sf::Vertex* vertices, std::size_t vertex_count)
+int64_t sumVisibleQuadArea(const sf::FloatRect& clip_px, const sf::Vertex* vertices, std::size_t vertex_count)
 {
    int64_t visible_px = 0;
    for (std::size_t vertex_index = 0; vertex_index + 6 <= vertex_count; vertex_index += 6)
    {
       const auto& top_left = vertices[vertex_index].position;
       const auto& bottom_right = vertices[vertex_index + 2].position;
-      visible_px += visibleArea(view_center, view_size, top_left.x, top_left.y, bottom_right.x, bottom_right.y);
+      visible_px += visibleArea(clip_px, top_left.x, top_left.y, bottom_right.x, bottom_right.y);
    }
    return visible_px;
 }
@@ -149,9 +143,21 @@ void DrawCallCounter::endTileMapNormalPass()
    tilemap_normal_pixels_submitted += tilemap_pixels_submitted - tilemap_pixels_before_normal_pass;
 }
 
+sf::FloatRect DrawCallCounter::getClipRectPx(const sf::View& view)
+{
+   const auto view_center = sfcompat::getViewCenter(view);
+   const auto view_size = sfcompat::getViewSize(view);
+   const auto scissor = sfcompat::getViewScissor(view);
+
+   return sf::FloatRect{
+      {view_center.x + (scissor.position.x - 0.5f) * view_size.x, view_center.y + (scissor.position.y - 0.5f) * view_size.y},
+      {scissor.size.x * view_size.x, scissor.size.y * view_size.y}
+   };
+}
+
 void DrawCallCounter::countAnimatedTilePixels(const sf::View& view, const sf::Vertex* vertices, std::size_t vertex_count)
 {
-   tilemap_pixels_submitted += sumVisibleQuadArea(sfcompat::getViewCenter(view), sfcompat::getViewSize(view), vertices, vertex_count);
+   tilemap_pixels_submitted += sumVisibleQuadArea(getClipRectPx(view), vertices, vertex_count);
 }
 
 void DrawCallCounter::countAmbientOcclusionPixels(
@@ -161,25 +167,20 @@ void DrawCallCounter::countAmbientOcclusionPixels(
 )
 {
    const auto& view = resolveView(target, states);
-   const auto view_center = sfcompat::getViewCenter(view);
-   const auto view_size = sfcompat::getViewSize(view);
 
    // the chunks are gathered around the player rather than around the view, so a good part of the
    // batch never reaches the screen. clipping each quad is what keeps this comparable to the tile
    // count, which is measured the same way
-   ambient_occlusion_pixels_submitted += sumVisibleQuadArea(view_center, view_size, batched_vertices.data(), batched_vertices.size());
+   ambient_occlusion_pixels_submitted += sumVisibleQuadArea(getClipRectPx(view), batched_vertices.data(), batched_vertices.size());
 }
 
 void DrawCallCounter::countImageLayerPixels(const sf::RenderTarget& target, const sf::RenderStates& states, const sf::Sprite& sprite)
 {
    const auto& view = resolveView(target, states);
-   const auto view_center = sfcompat::getViewCenter(view);
-   const auto view_size = sfcompat::getViewSize(view);
-
    const auto bounds = sprite.getGlobalBounds();
 
    image_layer_pixels_submitted += visibleArea(
-      view_center, view_size, bounds.position.x, bounds.position.y, bounds.position.x + bounds.size.x, bounds.position.y + bounds.size.y
+      getClipRectPx(view), bounds.position.x, bounds.position.y, bounds.position.x + bounds.size.x, bounds.position.y + bounds.size.y
    );
 }
 

--- a/src/game/debug/drawcallcounter.h
+++ b/src/game/debug/drawcallcounter.h
@@ -106,6 +106,16 @@ void beginTileMapNormalPass();
 void endTileMapNormalPass();
 
 ///
+/// \brief Returns the region of the view a draw through it is actually rasterised into.
+/// \param view the view the draw goes through.
+/// \return the view rectangle narrowed by the view's scissor, in view pixels.
+/// \note the counter works in view space, so a pass clipped to part of the view would otherwise be
+///       priced as the full screen pass it replaced. Folding the scissor in here is what makes the
+///       occluder and normal clipping visible in the numbers.
+///
+sf::FloatRect getClipRectPx(const sf::View& view);
+
+///
 /// \brief Adds the on-screen area of the animated tiles submitted with a tile map batch.
 /// \param view the view the batch was drawn through.
 /// \param vertices first vertex of the animated run, two triangles per tile.

--- a/src/game/effects/lightsystem.cpp
+++ b/src/game/effects/lightsystem.cpp
@@ -434,7 +434,7 @@ std::optional<sf::View> clipViewToLight(const sf::View& full_view, const sf::Flo
 }
 }  // namespace
 
-void LightSystem::draw(sf::RenderTarget& target1, sf::RenderTarget& target2, sf::RenderStates states)
+void LightSystem::updateActiveLights()
 {
    _active_lights.clear();
 
@@ -475,6 +475,52 @@ void LightSystem::draw(sf::RenderTarget& target1, sf::RenderTarget& target2, sf:
       }
       _active_lights.resize(max_lights);
    }
+
+   _active_light_bounds_px.clear();
+   for (const auto& light : _active_lights)
+   {
+      if (light->_sprite)
+      {
+         _active_light_bounds_px.push_back(light->_sprite->getGlobalBounds());
+      }
+   }
+}
+
+const std::vector<sf::FloatRect>& LightSystem::getActiveLightBoundsPx() const
+{
+   return _active_light_bounds_px;
+}
+
+std::optional<sf::View> LightSystem::clipViewToActiveLights(const sf::View& full_view) const
+{
+   std::optional<sf::FloatRect> bounds;
+
+   for (const auto& sprite_bounds : _active_light_bounds_px)
+   {
+      if (!bounds.has_value())
+      {
+         bounds = sprite_bounds;
+         continue;
+      }
+
+      const auto left_px = std::min(bounds->position.x, sprite_bounds.position.x);
+      const auto top_px = std::min(bounds->position.y, sprite_bounds.position.y);
+      const auto right_px = std::max(bounds->position.x + bounds->size.x, sprite_bounds.position.x + sprite_bounds.size.x);
+      const auto bottom_px = std::max(bounds->position.y + bounds->size.y, sprite_bounds.position.y + sprite_bounds.size.y);
+      bounds = sf::FloatRect{{left_px, top_px}, {right_px - left_px, bottom_px - top_px}};
+   }
+
+   if (!bounds.has_value())
+   {
+      return std::nullopt;
+   }
+
+   return clipViewToLight(full_view, bounds.value());
+}
+
+void LightSystem::draw(sf::RenderTarget& target1, sf::RenderTarget& target2, sf::RenderStates states)
+{
+   auto* player_body = PlayerRegistry::getFirst()->getBody();
 
    // pre-build shadow caster candidates once per frame — player, disabled bodies, and
    // enemies are excluded here so drawShadowQuads only needs to check per-light exclusions.

--- a/src/game/effects/lightsystem.h
+++ b/src/game/effects/lightsystem.h
@@ -97,9 +97,36 @@ public:
    /// \return newly created light instance with default smooth texture overridden by json values.
    static std::shared_ptr<LightSystem::LightInstance> createLightInstance(GameNode* parent, const nlohmann::json& node);
 
+   /// \brief picks the lights that will be drawn this frame, closest to the player first.
+   ///
+   /// Split out of draw so the rest of the frame can ask which lights are live before the light map
+   /// is rendered: the light map pass runs after the level layers, but the layers already need to
+   /// know where the lights are to clip the normal pass to them.
+   void updateActiveLights();
+
+   /// \brief narrows a view to the part of the screen the active lights can reach.
+   /// \param full_view the view the level is being rendered through.
+   /// \return the view with a scissor around every active light, or nothing when no light reaches
+   ///         the screen at all.
+   /// \note the deferred shader multiplies the normal map by each light's sprite mask, so a normal
+   ///       outside every light sprite cannot change a single pixel of the frame. That makes this
+   ///       rectangle the only part of the normal target worth rendering, and nothing at all worth
+   ///       rendering when it comes back empty.
+   /// \note one rectangle around six scattered lights is usually the whole view, so this alone
+   ///       saves nothing at a lit spot. getActiveLightBoundsPx is the per-light version, and the
+   ///       one that does the work.
+   std::optional<sf::View> clipViewToActiveLights(const sf::View& full_view) const;
+
+   /// \brief the sprite bounds of each active light, in level pixels.
+   /// \return one rectangle per active light, in the order the light map channels are assigned.
+   /// \note geometry outside every one of these cannot contribute a normal that survives the
+   ///       deferred pass, so a caller drawing into the normal target can drop it.
+   const std::vector<sf::FloatRect>& getActiveLightBoundsPx() const;
+
    /// \brief renders per-light sprites with stencil-clipped shadow volumes into a light map target.
    /// \param target render target.
    /// \param states render states applied to occluder, shadow, and light sprite draws (carries .view for WASM camera transform).
+   /// \note expects updateActiveLights to have run for this frame.
    void draw(sf::RenderTarget& target1, sf::RenderTarget& target2, sf::RenderStates states);
 
    /// \brief renders light sprites to both textures then composites with shader.
@@ -150,6 +177,10 @@ private:
    void updateLightShader(sf::RenderTarget& target);
 
    mutable std::vector<std::shared_ptr<LightInstance>> _active_lights;
+
+   //!< the sprite bounds of the active lights, rebuilt with them once per frame. kept as a member
+   //!< so the layer passes can read it without walking the light list again for every tile map
+   std::vector<sf::FloatRect> _active_light_bounds_px;
 
    // cached texture pointers to avoid redundant setUniform calls each frame
    const sf::Texture* _last_color_map{nullptr};

--- a/src/game/level/atmosphere.cpp
+++ b/src/game/level/atmosphere.cpp
@@ -1,5 +1,7 @@
 #include "atmosphere.h"
 
+#include <algorithm>
+#include <cmath>
 #include <iostream>
 
 #include "framework/tmxparser/tmxlayer.h"
@@ -48,6 +50,34 @@ void Atmosphere::parse(const std::shared_ptr<TmxLayer>& layer, const std::shared
          _map[y_tl * width_tl + x_tl] = tile_relative;
       }
    }
+}
+
+bool Atmosphere::hasTileInRect(const sf::FloatRect& rect_px) const
+{
+   if (_map.empty())
+   {
+      return false;
+   }
+
+   const auto first_x_tl = std::max(0, static_cast<int32_t>(std::floor(rect_px.position.x / PIXELS_PER_TILE)));
+   const auto first_y_tl = std::max(0, static_cast<int32_t>(std::floor(rect_px.position.y / PIXELS_PER_TILE)));
+   const auto last_x_tl =
+      std::min(_map_width_tl - 1, static_cast<int32_t>(std::floor((rect_px.position.x + rect_px.size.x) / PIXELS_PER_TILE)));
+   const auto last_y_tl =
+      std::min(_map_height_tl - 1, static_cast<int32_t>(std::floor((rect_px.position.y + rect_px.size.y) / PIXELS_PER_TILE)));
+
+   for (auto y_tl = first_y_tl; y_tl <= last_y_tl; y_tl++)
+   {
+      for (auto x_tl = first_x_tl; x_tl <= last_x_tl; x_tl++)
+      {
+         if (_map[y_tl * _map_width_tl + x_tl] != static_cast<int32_t>(AtmosphereTileInvalid))
+         {
+            return true;
+         }
+      }
+   }
+
+   return false;
 }
 
 AtmosphereTile Atmosphere::getTileForPosition(const b2Vec2& pos_m) const

--- a/src/game/level/atmosphere.h
+++ b/src/game/level/atmosphere.h
@@ -3,8 +3,8 @@
 #include "game/constants.h"
 #include "level/tilemap.h"
 
-#include "box2d/box2d.h"
 #include <SFML/Graphics.hpp>
+#include "box2d/box2d.h"
 
 #include <cstdint>
 #include <vector>
@@ -35,6 +35,15 @@ struct Atmosphere
    /// \param pos_px world position in pixels.
    /// \return atmosphere tile at the queried location, or AtmosphereTileInvalid when out of bounds.
    AtmosphereTile getTileForPosition(const sf::Vector2f& pos_px) const;
+
+   /// \brief whether any atmosphere tile falls inside a rectangle given in pixels.
+   /// \param rect_px region to test, in world pixels.
+   /// \return true as soon as one atmosphere tile is found inside it.
+   /// \note the distortion shader decides per fragment, from the atmosphere map at that fragment's
+   ///       own position, so an atmosphere tile off screen cannot distort anything on it. With none
+   ///       on screen the shader is an exact copy of what it samples, which is what lets the whole
+   ///       atmosphere pass be skipped rather than run to no effect.
+   bool hasTileInRect(const sf::FloatRect& rect_px) const;
 
    std::vector<int32_t> _map;
 

--- a/src/game/level/level.cpp
+++ b/src/game/level/level.cpp
@@ -1083,7 +1083,7 @@ void Level::drawPostLightingLayers(sf::RenderTarget& target)
       {
          if (tile_map->getZ() == z_index && tile_map->isPostLighting())
          {
-            tile_map->draw(target, target, level_view_states);
+            tile_map->draw(target, target, level_view_states, std::nullopt, {});
          }
       }
 
@@ -1194,6 +1194,17 @@ void Level::drawLayers(sf::RenderTarget& target, sf::RenderTarget& normal, int32
    const auto stencil_start_layer = PlayerStencil::getStartLayer();
    const auto stencil_stop_layer = PlayerStencil::getStopLayer();
 
+   // the normal pass only feeds the deferred lighting shader, which multiplies every normal by a
+   // light's sprite mask before it can contribute anything. so the pass is worth exactly the region
+   // the active lights reach: a scissor around that leaves the frame identical and takes the second
+   // tile pass off the rest of the screen, and no light on screen takes it off the frame entirely
+   const auto normal_view = _light_system->clipViewToActiveLights(*_level_view);
+
+   // one rectangle around six scattered lights is the whole view, so the scissor above rarely
+   // narrows anything on its own. the per light rectangles do: a tile block none of them touches is
+   // dropped from the normal batch entirely
+   const auto& normal_clip_rects_px = _light_system->getActiveLightBoundsPx();
+
    for (auto z_index = from; z_index <= to; z_index++)
    {
       // reset the stencil mask before the foreground layers start writing into it
@@ -1231,7 +1242,7 @@ void Level::drawLayers(sf::RenderTarget& target, sf::RenderTarget& normal, int32
 #endif
          if (tile_map->getZ() == z_index && !tile_map->isPostLighting())
          {
-            tile_map->draw(target, normal, layer_states);
+            tile_map->draw(target, normal, layer_states, normal_view, normal_clip_rects_px);
          }
       }
 
@@ -1292,7 +1303,7 @@ void Level::drawLayers(sf::RenderTarget& target, sf::RenderTarget& normal, int32
 
 void Level::drawAtmosphereLayer()
 {
-   if (!_atmosphere._tile_map)
+   if (!_atmosphere._tile_map || !_atmosphere_visible)
    {
       return;
    }
@@ -1622,6 +1633,19 @@ void Level::draw(const std::shared_ptr<sf::RenderTexture>& window, bool screensh
 
    rebuildMechanismDrawIndex();
 
+   // the distortion shader reads the atmosphere map at each fragment's own position, so atmosphere
+   // tiles that are off screen cannot bend a pixel on it. With none on screen the shader reduces to
+   // a plain copy of what it samples, and rendering the atmosphere map plus running the shader over
+   // two full screen resolves is work with no result at all
+   const auto view_center = sfcompat::getViewCenter(*_level_view);
+   const auto view_size = sfcompat::getViewSize(*_level_view);
+   const auto view_rect_px = sf::FloatRect{{view_center.x - view_size.x * 0.5f, view_center.y - view_size.y * 0.5f}, view_size};
+   _atmosphere_visible = _atmosphere._tile_map && _atmosphere.hasTileInRect(view_rect_px);
+
+   // the light map is rendered after the level layers, but the layers already need to know which
+   // lights are live: the normal pass is clipped to the region they reach
+   _light_system->updateActiveLights();
+
    beginRenderSectionTiming();
 
    // render atmosphere to atmosphere texture, that texture is used in the shader only
@@ -1636,44 +1660,62 @@ void Level::draw(const std::shared_ptr<sf::RenderTexture>& window, bool screensh
    drawGlowLayer();
 #endif
 
+   // the background layers only need a detour through level_background and normal_tmp so the
+   // distortion shader has something to read that is not the target it writes. with no atmosphere on
+   // screen there is no distortion, so they can go straight into the final targets - which drops two
+   // clears and two full screen blits from the frame
+   auto& background_color_target = _atmosphere_visible ? *_render_targets.level_background.get() : *_render_targets.level.get();
+   auto& background_normal_target = _atmosphere_visible ? *_render_targets.normal_tmp.get() : *_render_targets.normal.get();
+
    // render layers affected by the atmosphere
    _render_targets.level->clear();
-   _render_targets.level_background->clear();
-   _render_targets.normal_tmp->clear();
    _render_targets.normal->clear();
+   if (_atmosphere_visible)
+   {
+      _render_targets.level_background->clear();
+      _render_targets.normal_tmp->clear();
+   }
    markRenderSection("clear level targets");
 
    drawLayers(
-      *_render_targets.level_background.get(),
-      *_render_targets.normal_tmp.get(),
+      background_color_target,
+      background_normal_target,
       static_cast<int32_t>(ZDepth::BackgroundMin),
       static_cast<int32_t>(ZDepth::BackgroundMax)
    );
 
-   _render_targets.level_background->display();
-   takeScreenshot("texture_level_background", *_render_targets.level_background.get());
+   if (_atmosphere_visible)
+   {
+      _render_targets.level_background->display();
+      takeScreenshot("texture_level_background", *_render_targets.level_background.get());
 
-   _render_targets.normal_tmp->display();
-   takeScreenshot("texture_level_background_normal", *_render_targets.normal_tmp.get());
+      _render_targets.normal_tmp->display();
+      takeScreenshot("texture_level_background_normal", *_render_targets.normal_tmp.get());
+   }
    markRenderSection("background layers");
 
    // draw the atmospheric parts into the level texture using the atmosphere shader
 #ifndef DECEPTUS_VRSFML
-   sf::Sprite tmp_sprite(_render_targets.level_background->getTexture());
-   _atmosphere_shader->update();
-   _render_targets.level->draw(tmp_sprite, &_atmosphere_shader->getShader());
-   takeScreenshot("texture_level_level_dist", *_render_targets.level.get());
+   if (_atmosphere_visible)
+   {
+      sf::Sprite tmp_sprite(_render_targets.level_background->getTexture());
+      _atmosphere_shader->update();
+      const auto* atmosphere_shader = &_atmosphere_shader->getShader();
 
-   // draw the normal parts into the final normal texture using the atmosphere shader
-   tmp_sprite.setTexture(_render_targets.normal_tmp->getTexture());
-   _atmosphere_shader->update();
-   _render_targets.normal->draw(tmp_sprite, &_atmosphere_shader->getShader());
-   takeScreenshot("texture_level_background_normal_dist", *_render_targets.normal.get());
+      _render_targets.level->draw(tmp_sprite, atmosphere_shader);
+      takeScreenshot("texture_level_level_dist", *_render_targets.level.get());
+
+      // draw the normal parts into the final normal texture using the atmosphere shader
+      tmp_sprite.setTexture(_render_targets.normal_tmp->getTexture());
+      _render_targets.normal->draw(tmp_sprite, atmosphere_shader);
+      takeScreenshot("texture_level_background_normal_dist", *_render_targets.normal.get());
+   }
 
 #ifdef GLOW_ENABLED
    drawGlowSprite();
 #endif
 #else
+   if (_atmosphere_visible)
    {
       sf::Sprite atmosphere_sprite;
       const sf::Vector2u atmosphere_sprite_size = _render_targets.level_background->getSize();
@@ -1681,13 +1723,13 @@ void Level::draw(const std::shared_ptr<sf::RenderTexture>& window, bool screensh
          sf::FloatRect{{0.f, 0.f}, {static_cast<float>(atmosphere_sprite_size.x), static_cast<float>(atmosphere_sprite_size.y)}};
 
       _atmosphere_shader->update();
-      const sf::Shader& atmosphere_shader = _atmosphere_shader->getShader();
+      const auto* atmosphere_shader = &_atmosphere_shader->getShader();
 
       const sf::Texture& level_background_texture = _render_targets.level_background->getTexture();
-      _render_targets.level->draw(atmosphere_sprite, sf::RenderStates{.texture = &level_background_texture, .shader = &atmosphere_shader});
+      _render_targets.level->draw(atmosphere_sprite, sf::RenderStates{.texture = &level_background_texture, .shader = atmosphere_shader});
 
       const sf::Texture& normal_tmp_texture = _render_targets.normal_tmp->getTexture();
-      _render_targets.normal->draw(atmosphere_sprite, sf::RenderStates{.texture = &normal_tmp_texture, .shader = &atmosphere_shader});
+      _render_targets.normal->draw(atmosphere_sprite, sf::RenderStates{.texture = &normal_tmp_texture, .shader = atmosphere_shader});
    }
 #endif
    markRenderSection("atmosphere resolve");

--- a/src/game/level/level.h
+++ b/src/game/level/level.h
@@ -392,6 +392,10 @@ protected:
    std::unordered_map<std::string, TmxEnemy> _enemy_data_from_tmx_layer;
 
    Atmosphere _atmosphere;
+
+   //!< whether any atmosphere tile is on screen this frame. false makes the distortion shader an
+   //!< exact copy of what it samples, so the atmosphere map and both resolves can be skipped
+   bool _atmosphere_visible{false};
    Physics _physics;
    sf::Vector2f _start_position_px;
 

--- a/src/game/level/stenciltilemap.cpp
+++ b/src/game/level/stenciltilemap.cpp
@@ -46,7 +46,13 @@ bool StencilTileMap::load(
    return true;
 }
 
-void StencilTileMap::draw(sf::RenderTarget& color, sf::RenderTarget& normal, sf::RenderStates states) const
+void StencilTileMap::draw(
+   sf::RenderTarget& color,
+   sf::RenderTarget& normal,
+   sf::RenderStates states,
+   const std::optional<sf::View>& normal_view,
+   const std::vector<sf::FloatRect>& normal_clip_rects_px
+) const
 {
    if (!_stencil_tilemap)
    {
@@ -114,7 +120,7 @@ void StencilTileMap::draw(sf::RenderTarget& color, sf::RenderTarget& normal, sf:
    );
 #endif
 
-   TileMap::draw(color, normal, color_render_state);
+   TileMap::draw(color, normal, color_render_state, normal_view, normal_clip_rects_px);
 
    // dumpStencilAndColorToPng(color, states);
 }

--- a/src/game/level/stenciltilemap.h
+++ b/src/game/level/stenciltilemap.h
@@ -37,7 +37,13 @@ public:
    /// \param color color render target.
    /// \param normal normal render target.
    /// \param states render states forwarded to draw calls.
-   void draw(sf::RenderTarget& color, sf::RenderTarget& normal, sf::RenderStates states) const override;
+   void draw(
+      sf::RenderTarget& color,
+      sf::RenderTarget& normal,
+      sf::RenderStates states,
+      const std::optional<sf::View>& normal_view,
+      const std::vector<sf::FloatRect>& normal_clip_rects_px
+   ) const override;
 
    /// \brief returns TMX layer name of the mask tilemap.
    /// \return stencil reference string.

--- a/src/game/level/tilemap.cpp
+++ b/src/game/level/tilemap.cpp
@@ -1,5 +1,7 @@
 #include "tilemap.h"
 
+#include <ranges>
+
 #include <math.h>
 #include <algorithm>
 #include <iostream>
@@ -302,7 +304,7 @@ void TileMap::update(const sf::Time& dt)
    }
 }
 
-void TileMap::drawVertices(sf::RenderTarget& target, sf::RenderStates states) const
+void TileMap::drawVertices(sf::RenderTarget& target, sf::RenderStates states, const std::vector<sf::FloatRect>& clip_rects_px) const
 {
    states.transform *= getTransform();
 
@@ -326,6 +328,18 @@ void TileMap::drawVertices(sf::RenderTarget& target, sf::RenderStates states) co
 #endif
    const auto view_center = sfcompat::getViewCenter(view);
    const auto view_size = sfcompat::getViewSize(view);
+
+#ifdef DEVELOPMENT_MODE
+   // the scissor is what a clipped pass actually pays for. the fill counter works in view space, so
+   // without folding it in here a pass clipped to a light sprite reports the same overdraw as the
+   // full screen pass it replaced - which is exactly what made the occluder clipping saving
+   // invisible on the desktop instrument
+   const auto clip_rect_px = DrawCallCounter::getClipRectPx(view);
+   const auto clip_left_px = clip_rect_px.position.x;
+   const auto clip_top_px = clip_rect_px.position.y;
+   const auto clip_right_px = clip_left_px + clip_rect_px.size.x;
+   const auto clip_bottom_px = clip_top_px + clip_rect_px.size.y;
+#endif
 
    // blocks are binned by the tileset's own tile size at load time, so the window has to be measured
    // in those units too - PIXELS_PER_TILE only happens to match for tilesets that use 24 px tiles
@@ -365,6 +379,34 @@ void TileMap::drawVertices(sf::RenderTarget& target, sf::RenderStates states) co
       {
          const auto& block_vertices = column_it->second;
          const auto block_vertex_count = block_vertices.getVertexCount();
+
+         // a block the caller cannot use is dropped before it is copied into the batch, so it costs
+         // neither the copy nor the fill. the normal pass uses this: a block no light reaches
+         // produces normals the deferred shader multiplies by a zero mask
+         if (!clip_rects_px.empty())
+         {
+            const auto block_rect_px = sf::FloatRect{
+               {static_cast<float>(column_it->first) * block_width_px, static_cast<float>(row_it->first) * block_height_px},
+               {block_width_px, block_height_px}
+            };
+
+            const auto touches_clip_rect = std::ranges::any_of(
+               clip_rects_px,
+               [&block_rect_px](const auto& clip_rect_px)
+               {
+                  return block_rect_px.position.x < clip_rect_px.position.x + clip_rect_px.size.x &&
+                         clip_rect_px.position.x < block_rect_px.position.x + block_rect_px.size.x &&
+                         block_rect_px.position.y < clip_rect_px.position.y + clip_rect_px.size.y &&
+                         clip_rect_px.position.y < block_rect_px.position.y + block_rect_px.size.y;
+               }
+            );
+
+            if (!touches_clip_rect)
+            {
+               continue;
+            }
+         }
+
          if (block_vertex_count > 0)
          {
             _batched_vertices.insert(_batched_vertices.end(), &block_vertices[0], &block_vertices[0] + block_vertex_count);
@@ -387,12 +429,22 @@ void TileMap::drawVertices(sf::RenderTarget& target, sf::RenderStates states) co
          );
          const auto visible_fraction = (visible_width_px * visible_height_px) / (block_width_px * block_height_px);
 
+         // the fraction the rasteriser is charged for, i.e. the block clipped to the scissor rather
+         // than to the whole view. it stays separate from visible_fraction on purpose: that one is
+         // the self check on the cull bounds and has to keep summing to view area over block area,
+         // whatever a pass happens to be clipped to
+         const auto rasterised_width_px =
+            std::max(0.0f, std::min(block_left_px + block_width_px, clip_right_px) - std::max(block_left_px, clip_left_px));
+         const auto rasterised_height_px =
+            std::max(0.0f, std::min(block_top_px + block_height_px, clip_bottom_px) - std::max(block_top_px, clip_top_px));
+         const auto rasterised_fraction = (rasterised_width_px * rasterised_height_px) / (block_width_px * block_height_px);
+
          // tiles are stored as two triangles, so six vertices make one tile - not four. dividing by
          // four overstated every count by 1.5x
          const auto tile_count = static_cast<float>(block_vertex_count / 6);
          DrawCallCounter::tilemap_pixels_submitted +=
-            static_cast<int64_t>(tile_count * visible_fraction * static_cast<float>(_tile_size_px.x * _tile_size_px.y));
-         DrawCallCounter::tilemap_tiles_submitted += static_cast<int64_t>(tile_count * visible_fraction);
+            static_cast<int64_t>(tile_count * rasterised_fraction * static_cast<float>(_tile_size_px.x * _tile_size_px.y));
+         DrawCallCounter::tilemap_tiles_submitted += static_cast<int64_t>(tile_count * rasterised_fraction);
          DrawCallCounter::tilemap_blocks_drawn++;
          DrawCallCounter::tilemap_visible_fraction_sum += visible_fraction;
 #endif
@@ -544,7 +596,13 @@ bool TileMap::dumpToPng(const std::filesystem::path& output_path) const
 #endif
 }
 
-void TileMap::draw(sf::RenderTarget& color, sf::RenderTarget& normal, sf::RenderStates states) const
+void TileMap::draw(
+   sf::RenderTarget& color,
+   sf::RenderTarget& normal,
+   sf::RenderStates states,
+   const std::optional<sf::View>& normal_view,
+   const std::vector<sf::FloatRect>& normal_clip_rects_px
+) const
 {
    if (!_visible)
    {
@@ -563,15 +621,35 @@ void TileMap::draw(sf::RenderTarget& color, sf::RenderTarget& normal, sf::Render
 #endif
    drawVertices(color, states);
 
-   if (_normal_map)
+   // the normal pass writes the same geometry a second time, and the deferred shader only ever
+   // multiplies a normal by a light's sprite mask - so a normal the lights cannot reach is shaded
+   // for nothing. an empty normal_view means no light reaches the screen at all, which makes the
+   // whole second pass dead rather than merely oversized
+   if (_normal_map && normal_view.has_value())
    {
       states.texture = _normal_map.get();
+
+      auto normal_states = states;
+#ifdef DECEPTUS_VRSFML
+      normal_states.view = normal_view.value();
+#else
+      // the view lives on the target rather than in the states here, so it has to be put back:
+      // the normal target is also blitted into outside this pass, and a leftover scissor would
+      // clip that too
+      const auto restore_view = normal.getView();
+      normal.setView(normal_view.value());
+#endif
+
 #ifdef DEVELOPMENT_MODE
       DrawCallCounter::beginTileMapNormalPass();
 #endif
-      drawVertices(normal, states);
+      drawVertices(normal, normal_states, normal_clip_rects_px);
 #ifdef DEVELOPMENT_MODE
       DrawCallCounter::endTileMapNormalPass();
+#endif
+
+#ifndef DECEPTUS_VRSFML
+      normal.setView(restore_view);
 #endif
    }
 

--- a/src/game/level/tilemap.h
+++ b/src/game/level/tilemap.h
@@ -43,7 +43,13 @@ public:
    /// \param color color render target.
    /// \param normal normal render target.
    /// \param states render states forwarded to draw calls.
-   virtual void draw(sf::RenderTarget& color, sf::RenderTarget& normal, sf::RenderStates states) const;
+   virtual void draw(
+      sf::RenderTarget& color,
+      sf::RenderTarget& normal,
+      sf::RenderStates states,
+      const std::optional<sf::View>& normal_view,
+      const std::vector<sf::FloatRect>& normal_clip_rects_px
+   ) const;
 
    /// \brief draws this layer to a single render target.
    /// \param target render target.
@@ -88,7 +94,13 @@ protected:
    /// \brief draws static and animated vertex buffers near the player.
    /// \param target render target.
    /// \param states render states forwarded to draw calls.
-   void drawVertices(sf::RenderTarget& target, sf::RenderStates states) const;
+   ///
+   /// \brief submits the visible blocks of this layer as one batch.
+   /// \param target render target.
+   /// \param states render states for the batch.
+   /// \param clip_rects_px blocks touching none of these are dropped; empty means keep everything.
+   ///
+   void drawVertices(sf::RenderTarget& target, sf::RenderStates states, const std::vector<sf::FloatRect>& clip_rects_px = {}) const;
 
 private:
    /// \brief stores one tile quad as an animated tile entry.


### PR DESCRIPTION
Four changes, three measured wins and one honest zero.

### The fill counter now sees scissors

`DrawCallCounter` worked in view space pixels and ignored the view's scissor, so a pass clipped to a
small rectangle was priced as the full screen pass it replaced. That is why #444's occluder clipping
read as if it had done nothing.

| same build, catacombs start | tiles | total |
|---|---:|---:|
| as #445 reported it | 7.91x | 10.16x |
| scissor aware | **6.77x** | **9.02x** |

Not a new saving - #444 was worth **1.14x of tile fill** all along. Any future clipping change can
now be priced on the desktop instead of needing hardware.

`visible_fraction` still measures against the whole view, so the `frac` self check on the cull bounds
stays valid; the new `rasterised_fraction` measures against the scissor and feeds the pixel counts.
The two diverging is the signal that clipping is doing work.

### Skip the atmosphere passes when no atmosphere tile is on screen

`water.frag` decides per fragment from the atmosphere map at that fragment's own position, so
atmosphere tiles off screen cannot bend a pixel on it - and its non-water branch is
`sf_v_color * texel`, an exact copy. So with no water visible the frame rendered the atmosphere map
and then ran the shader over two full screen resolves to copy two images.

The detour through `level_background` / `normal_tmp` only exists so the shader has something to read
that is not the target it writes, so with no distortion the background layers go straight into
`level` / `normal` - dropping two clears and two full screen blits as well.

| section, catacombs start | before | after |
|---|---:|---:|
| atmosphere | 0.007 ms | **0.000** |
| atmosphere resolve | 0.036 ms | **0.000** |
| clear level targets | 0.013 ms | 0.004 |

**It fires almost everywhere:** the catacombs atmosphere layer covers 0.60% of the level and only
3.2% of screen sized regions contain any of it.

Desktop is not fill bound, so ~4% of the frame here. On the console these are two 1280x720 textured
blits per frame.

### Clip the tile normal pass to light reach - exact, and worth nothing here

Included because the reasoning is sound and it costs nothing, but do not expect a number from it.

The deferred shader multiplies every normal by a light's sprite mask, so a normal outside every
active light sprite provably cannot change a pixel - clipping is exact, not a quality trade. Measured
two ways at the catacombs start:

- union scissor around the active lights: comes out as `0,0 1x1`, the whole view. **0.00x**
- per block rejection: one empty block of twelve dropped. **0.00x**

Six lights with 256 px sprites blanket a 640x360 view. It pays where the screen is dark and costs
nothing where it is not. Easy to drop as a single commit if you would rather not carry the extra
parameter.

### Switch defaults to the reduced render target profile

`RenderTargetProfile::reduced()` already existed; reaching it meant hand editing `game.json` on the
sd card. Seeded in the existing `#if defined(__SWITCH__)` block, before `deserializeFromFile`, so a
config file still overrides it.

---

### Verification

Screenshots at the six catacombs checkpoints against a same-build noise floor (water, fireflies,
candles and the idle animation all move, so two runs of the same build never match):

| | worst frame | worst 64px cell |
|---|---:|---:|
| noise floor | 2.40% | 100% |
| this branch | 1.45% | 58% |

The faint rings visible in an amplified diff appear identically when diffing the same build twice -
light gradient dithering, not this change.

**Not covered:** none of the six checkpoints obviously had water on screen, so the
`_atmosphere_visible == true` path is not exercised by these captures. It is unchanged code wrapped
in an `if`, but it is untested. Desktop only - the VRSFML branch of the resolve is changed the same
way but has not been compiled.

**Still open:** `catacombs-background-diffuse_normals` is 69% exactly flat (mean deviation 12, max
68) against the level tileset's mean 51 / max 255. `bg0` + `bg2` + `bg4` spend ~1.08x of fill, 12% of
the frame, rasterising it. Dropping the normal pass for that one tileset is the largest cut found so
far, but it is a visual change.
