### PR TITLE
step the simulation at a fixed rate instead of once per frame

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,6 +480,8 @@ set(GAME_FILES
     src/game/physics/onewaywall.h
     src/game/physics/physics.cpp
     src/game/physics/physics.h
+    src/game/physics/fixedtimestep.cpp
+    src/game/physics/fixedtimestep.h
     src/game/physics/physicsconfiguration.cpp
     src/game/physics/physicsconfiguration.h
     src/game/physics/physicsconfigurationui.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -482,6 +482,8 @@ set(GAME_FILES
     src/game/physics/physics.h
     src/game/physics/fixedtimestep.cpp
     src/game/physics/fixedtimestep.h
+    src/game/physics/renderinterpolation.cpp
+    src/game/physics/renderinterpolation.h
     src/game/physics/physicsconfiguration.cpp
     src/game/physics/physicsconfiguration.h
     src/game/physics/physicsconfigurationui.cpp

--- a/src/game/camera/camerasystem.cpp
+++ b/src/game/camera/camerasystem.cpp
@@ -46,6 +46,11 @@
 
 void CameraSystem::update(const sf::Time& dt, float view_width_px, float view_height_px)
 {
+   // where the camera stood going into this step, so the frames drawn before the next one can be
+   // placed between the two
+   _previous_x_px = getX();
+   _previous_y_px = getY();
+
    _view_width_px = view_width_px;
    _view_height_px = view_height_px;
 
@@ -243,6 +248,16 @@ float CameraSystem::getX() const
 float CameraSystem::getY() const
 {
    return _y_px - (_view_height_px / CameraSystemConfiguration::getInstance().getViewRatioY());
+}
+
+float CameraSystem::getPreviousX() const
+{
+   return _previous_x_px;
+}
+
+float CameraSystem::getPreviousY() const
+{
+   return _previous_y_px;
 }
 
 float CameraSystem::getFocusZoneX0() const

--- a/src/game/camera/camerasystem.h
+++ b/src/game/camera/camerasystem.h
@@ -25,6 +25,16 @@ public:
    /// \return world y coordinate in pixels adjusted by the configured vertical view ratio.
    float getY() const;
 
+   /// \brief the x position the camera had before the last simulation step.
+   /// \return what getX returned then.
+   /// \note the camera has to be interpolated by exactly the same amount as the things it follows,
+   ///       or they slide against the scenery instead of moving with it - see RenderInterpolation.
+   float getPreviousX() const;
+
+   /// \brief the y position the camera had before the last simulation step.
+   /// \return what getY returned then.
+   float getPreviousY() const;
+
    /// \brief returns the left edge of the horizontal focus zone in view space.
    /// \return focus-zone left boundary in pixels.
    float getFocusZoneX0() const;
@@ -90,6 +100,12 @@ private:
 
    float _x_px = 0.0f;
    float _y_px = 0.0f;
+
+   //!< what getX and getY returned before the last simulation step. Held as the finished result
+   //!< rather than as the raw position, so the focus zone and view ratio corrections do not have to
+   //!< be reproduced for the previous state
+   float _previous_x_px = 0.0f;
+   float _previous_y_px = 0.0f;
 
    float _dx_px = 0.0f;
    float _dy_px = 0.0f;

--- a/src/game/debug/console.cpp
+++ b/src/game/debug/console.cpp
@@ -291,6 +291,24 @@ Console::Console()
    registerCallback("tps", [this](const auto&) { teleportToStartPosition(); }, "teleportation", "tps: teleport to start position");
 
    registerCallback(
+      "interpolate",
+      [this](const auto& args)
+      {
+         if (args.size() == 2)
+         {
+            RenderInterpolation::setEnabled(std::atoi(args.at(1).c_str()) != 0);
+         }
+
+         std::ostringstream os;
+         os << "interpolation: " << (RenderInterpolation::isEnabled() ? "on" : "off");
+         _log.push_back(os.str());
+      },
+      "rendering",
+      "interpolate <0|1>: draw between simulation steps, or snap to the newest one",
+      {"interpolate 0"}
+   );
+
+   registerCallback(
       "lead",
       [this](const auto& args)
       {

--- a/src/game/debug/console.cpp
+++ b/src/game/debug/console.cpp
@@ -1,5 +1,7 @@
 #include "console.h"
 
+#include "game/physics/renderinterpolation.h"
+
 #include "framework/tools/callbackmap.h"
 #include "framework/tools/log.h"
 #include "game/config/tweaks.h"
@@ -287,6 +289,24 @@ Console::Console()
 
    // teleportation
    registerCallback("tps", [this](const auto&) { teleportToStartPosition(); }, "teleportation", "tps: teleport to start position");
+
+   registerCallback(
+      "lead",
+      [this](const auto& args)
+      {
+         if (args.size() == 2)
+         {
+            RenderInterpolation::setLead(static_cast<float>(std::atof(args.at(1).c_str())));
+         }
+
+         std::ostringstream os;
+         os << "interpolation lead: " << RenderInterpolation::getLead();
+         _log.push_back(os.str());
+      },
+      "rendering",
+      "lead <0..1>: how far ahead of the simulation the picture is aimed. 0 lags by up to a step, 1 overshoots by one",
+      {"lead 0.5"}
+   );
 
    registerCallback(
       "tpp",

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -517,6 +517,10 @@ void Game::processPendingLevelLoad()
 
       _level_loading_finished = true;
 
+      // loading took seconds of real time that the simulation must not make up for, or the first
+      // frame back would run its whole catch-up allowance at once
+      _fixed_time_step.reset();
+
       playLevelMusic();
 
       // before synchronizing the camera with the player position, the camera needs to know its room limitations
@@ -1126,10 +1130,32 @@ void Game::update()
          updateGameController();
          updateGameControllerForGame();
 
-         EventSerializer::updateAll(dt);
+         // the simulation is stepped at a fixed rate rather than once per frame. everything below
+         // this line was written expecting to run exactly once per physics step, with a delta of
+         // PhysicsConfiguration::_time_step - the player's jump and dash forces, the conveyor belt
+         // state, the contact events. Feeding it the frame time instead made the world run at double
+         // speed at 120 fps and in slow motion below 60, so the fix is to restore that expectation
+         // in this one place rather than to teach every one of those about the frame rate.
+         //
+         // A frame faster than one step runs the loop zero times and draws the same state again.
+         const auto simulation_step_count = _fixed_time_step.consumeSteps(dt);
+         const auto simulation_dt = _fixed_time_step.getStepDuration();
 
-         _level->update(dt);
-         _player->update(dt);
+         for (auto simulation_step = 0; simulation_step < simulation_step_count; simulation_step++)
+         {
+            EventSerializer::updateAll(simulation_dt);
+
+            _level->update(simulation_dt);
+            _player->update(simulation_dt);
+
+            // a lua script can request a level change from inside the update above, which hands
+            // _level over for teardown. Stepping it again would run a level that is already gone or
+            // already asking to be replaced
+            if (!_level || _level->isDirty())
+            {
+               break;
+            }
+         }
 
 #ifndef DECEPTUS_VRSFML
          if (DebugDrawStates::_draw_test_scene)

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1157,6 +1157,14 @@ void Game::update()
             }
          }
 
+         // once per frame, after the steps: the simulation has moved, so the sprites are placed
+         // where they sit between the last two steps. Positions belong in update, draw draws
+         if (_level)
+         {
+            _level->updateSpritePositions();
+            _player->updateSpritePositions();
+         }
+
 #ifndef DECEPTUS_VRSFML
          if (DebugDrawStates::_draw_test_scene)
          {

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -19,6 +19,7 @@
 #include "game/io/eventserializer.h"
 #include "game/layers/controlleroverlay.h"
 #include "game/layers/infolayer.h"
+#include "game/physics/fixedtimestep.h"
 #include "game/physics/physicsconfigurationui.h"
 #include "game/rendering/postprocessingpass.h"
 #include "game/rendering/rendertargets.h"
@@ -182,6 +183,9 @@ private:
    RenderTargets _render_targets;
    std::shared_ptr<Player> _player;
    std::shared_ptr<Level> _level;
+
+   //! \brief banks frame time so the simulation is stepped at a fixed rate whatever the frame rate
+   FixedTimeStep _fixed_time_step;
 
    //! \brief load requested by loadLevel(), carried out by processPendingLevelLoad() next frame
    std::optional<LoadingMode> _pending_level_load;

--- a/src/game/items/item.cpp
+++ b/src/game/items/item.cpp
@@ -4,6 +4,10 @@ void Item::draw(sf::RenderTarget& /*target*/, const sf::RenderStates& /*states*/
 {
 }
 
+void Item::updateSpritePositions()
+{
+}
+
 void Item::update(const sf::Time& /*dt*/)
 {
 }
@@ -15,4 +19,3 @@ void Item::onEquipped()
 void Item::onUnequipped()
 {
 }
-

--- a/src/game/items/item.h
+++ b/src/game/items/item.h
@@ -22,6 +22,11 @@ public:
    /// \param dt elapsed frame time since the previous update.
    virtual void update(const sf::Time& dt);
 
+   /// \brief places this item's sprites for the frame about to be drawn.
+   /// \note items ride on the player, which is placed once per frame from an interpolated position,
+   ///       so an item placed once per simulation step would sit a step away from it.
+   virtual void updateSpritePositions();
+
    /// \brief handles the item being equipped by the player.
    virtual void onEquipped();
 

--- a/src/game/items/itemheadtorch.cpp
+++ b/src/game/items/itemheadtorch.cpp
@@ -74,18 +74,15 @@ void ItemHeadTorch::updateSpritePositions()
    // the beam comes out of the lamp on that helmet, so it is placed from the same position. Its
    // shadow origin is left alone: that decides which polygons the beam extrudes shadows from, and
    // that belongs to the simulation rather than to where the frame happens to draw things
-   if (!_light_offset_m.has_value())
+   if (!_light_sprite_offset_px.has_value())
    {
       return;
    }
 
    auto& active_light = _light_points_right ? _player_light_right : _player_light_left;
-   if (active_light)
+   if (active_light && active_light->_sprite)
    {
-      const auto player_position_m = b2Vec2{player_position_px.x * MPP, player_position_px.y * MPP};
-      sfcompat::setOrigin(*active_light->_sprite, {0.0f, 0.0f});
-      active_light->_pos_m = player_position_m + _light_offset_m.value();
-      active_light->updateSpritePosition();
+      sfcompat::setPosition(*active_light->_sprite, player_position_px + _light_sprite_offset_px.value());
    }
 }
 
@@ -202,8 +199,6 @@ void ItemHeadTorch::update(const sf::Time& delta_time)
    active_light->_pos_m = light_pos_m;
    active_light->updateSpritePosition();
 
-   // kept as an offset from the player so the per frame pass can put the beam where the helmet is
-   _light_offset_m = light_pos_m - player->getBody()->GetPosition();
    _light_points_right = pointing_right;
 
    // the beam casts its shadows from the lamp end, which sits right about on the player's own
@@ -232,6 +227,10 @@ void ItemHeadTorch::update(const sf::Time& delta_time)
    sfcompat::setPosition(
       *active_light->_sprite, {top_left_pos.x + lamp_origin_x_local * sprite_scale.x, top_left_pos.y + lamp_origin_y_local * sprite_scale.y}
    );
+
+   // recorded after the origin shift, so the per frame pass can move the sprite without having to
+   // redo - or undo - any of it
+   _light_sprite_offset_px = sfcompat::getPosition(*active_light->_sprite) - player->getPixelPositionFloat();
 
    // easeOutSine brings the beam smoothly back to neutral after a landing tilt
    sf::Angle tilt_angle = sf::degrees(0.0f);

--- a/src/game/items/itemheadtorch.cpp
+++ b/src/game/items/itemheadtorch.cpp
@@ -65,9 +65,28 @@ void ItemHeadTorch::updateSpritePositions()
       return;
    }
 
-   const auto helmet_position_px = PlayerRegistry::getFirst()->getSpritePositionPx() + _helmet_offset_px.value();
+   const auto& player_position_px = PlayerRegistry::getFirst()->getSpritePositionPx();
+
+   const auto helmet_position_px = player_position_px + _helmet_offset_px.value();
    sfcompat::setPosition(*_helmet_sprite_r, helmet_position_px);
    sfcompat::setPosition(*_helmet_sprite_l, helmet_position_px);
+
+   // the beam comes out of the lamp on that helmet, so it is placed from the same position. Its
+   // shadow origin is left alone: that decides which polygons the beam extrudes shadows from, and
+   // that belongs to the simulation rather than to where the frame happens to draw things
+   if (!_light_offset_m.has_value())
+   {
+      return;
+   }
+
+   auto& active_light = _light_points_right ? _player_light_right : _player_light_left;
+   if (active_light)
+   {
+      const auto player_position_m = b2Vec2{player_position_px.x * MPP, player_position_px.y * MPP};
+      sfcompat::setOrigin(*active_light->_sprite, {0.0f, 0.0f});
+      active_light->_pos_m = player_position_m + _light_offset_m.value();
+      active_light->updateSpritePosition();
+   }
 }
 
 void ItemHeadTorch::update(const sf::Time& delta_time)
@@ -182,6 +201,10 @@ void ItemHeadTorch::update(const sf::Time& delta_time)
    sfcompat::setOrigin(*active_light->_sprite, {0.0f, 0.0f});
    active_light->_pos_m = light_pos_m;
    active_light->updateSpritePosition();
+
+   // kept as an offset from the player so the per frame pass can put the beam where the helmet is
+   _light_offset_m = light_pos_m - player->getBody()->GetPosition();
+   _light_points_right = pointing_right;
 
    // the beam casts its shadows from the lamp end, which sits right about on the player's own
    // collision edge. anything adam presses against - a moveable box he is pushing, or a wall he is

--- a/src/game/items/itemheadtorch.cpp
+++ b/src/game/items/itemheadtorch.cpp
@@ -58,6 +58,18 @@ void ItemHeadTorch::draw(sf::RenderTarget& target, const sf::RenderStates& state
 #endif
 }
 
+void ItemHeadTorch::updateSpritePositions()
+{
+   if (!_enabled || !_helmet_offset_px.has_value())
+   {
+      return;
+   }
+
+   const auto helmet_position_px = PlayerRegistry::getFirst()->getSpritePositionPx() + _helmet_offset_px.value();
+   sfcompat::setPosition(*_helmet_sprite_r, helmet_position_px);
+   sfcompat::setPosition(*_helmet_sprite_l, helmet_position_px);
+}
+
 void ItemHeadTorch::update(const sf::Time& delta_time)
 {
    if (!_enabled)
@@ -214,9 +226,7 @@ void ItemHeadTorch::update(const sf::Time& delta_time)
    sfcompat::setRotation(*inactive_light->_sprite, sf::degrees(0.0f));
 
    sf::Vector2f helmet_offset_px{pointing_right ? -50.0f : -45.0f, -54.0f};
-   const auto helmet_position_px = player->getPixelPositionFloat() + _last_valid_eye_position.value() + helmet_offset_px;
-   sfcompat::setPosition(*_helmet_sprite_r, helmet_position_px);
-   sfcompat::setPosition(*_helmet_sprite_l, helmet_position_px);
+   _helmet_offset_px = _last_valid_eye_position.value() + helmet_offset_px;
    const uint8_t helmet_alpha = static_cast<uint8_t>(255.0f * fade_alpha_factor);
    sfcompat::setColor(*_helmet_sprite_r, sf::Color(255, 255, 255, helmet_alpha));
    sfcompat::setColor(*_helmet_sprite_l, sf::Color(255, 255, 255, helmet_alpha));

--- a/src/game/items/itemheadtorch.h
+++ b/src/game/items/itemheadtorch.h
@@ -54,6 +54,11 @@ private:
    //!< where the helmet sits relative to the player. Worked out per simulation step and applied to
    //!< the player's drawn position per frame
    std::optional<sf::Vector2f> _helmet_offset_px;
+
+   //!< where the light sits relative to the player, in box2d meters, and which of the two lights is
+   //!< the live one. Applied per frame for the same reason the helmet offset is
+   std::optional<b2Vec2> _light_offset_m;
+   bool _light_points_right{false};
    std::shared_ptr<sf::Texture> _player_texture;
    std::unique_ptr<sf::Sprite> _helmet_sprite_r;
    std::unique_ptr<sf::Sprite> _helmet_sprite_l;

--- a/src/game/items/itemheadtorch.h
+++ b/src/game/items/itemheadtorch.h
@@ -57,7 +57,9 @@ private:
 
    //!< where the light sits relative to the player, in box2d meters, and which of the two lights is
    //!< the live one. Applied per frame for the same reason the helmet offset is
-   std::optional<b2Vec2> _light_offset_m;
+   //!< where the light sprite ended up relative to the player, after update has shifted it to put
+   //!< its origin on the lamp. Applied per frame, without touching that origin again
+   std::optional<sf::Vector2f> _light_sprite_offset_px;
    bool _light_points_right{false};
    std::shared_ptr<sf::Texture> _player_texture;
    std::unique_ptr<sf::Sprite> _helmet_sprite_r;

--- a/src/game/items/itemheadtorch.h
+++ b/src/game/items/itemheadtorch.h
@@ -22,6 +22,11 @@ public:
    /// \param dt elapsed frame time since the previous update.
    void update(const sf::Time& dt) override;
 
+   /// \brief places the helmet for the frame about to be drawn.
+   /// \note the body is placed once per frame from an interpolated position, so a helmet placed once
+   ///       per simulation step sat a step behind the head it belongs to.
+   void updateSpritePositions() override;
+
    /// \brief enables head torch rendering and updates while equipped.
    void onEquipped() override;
 
@@ -45,6 +50,10 @@ private:
    std::shared_ptr<LightSystem::LightInstance> _player_light_right;
    std::optional<sf::Vector2f>
       _last_valid_eye_position;  //!< set once a valid eye position is received since the last onEquipped; empty until then
+
+   //!< where the helmet sits relative to the player. Worked out per simulation step and applied to
+   //!< the player's drawn position per frame
+   std::optional<sf::Vector2f> _helmet_offset_px;
    std::shared_ptr<sf::Texture> _player_texture;
    std::unique_ptr<sf::Sprite> _helmet_sprite_r;
    std::unique_ptr<sf::Sprite> _helmet_sprite_l;

--- a/src/game/level/level.cpp
+++ b/src/game/level/level.cpp
@@ -832,6 +832,26 @@ void Level::updateViews()
    updateViewsForDraw();
 }
 
+void Level::updateSpritePositions()
+{
+   // the views first: everything below is placed in world space, and the view is what decides where
+   // that lands on screen, so the two have to be derived from the same interpolated camera
+   updateViewsForDraw();
+
+   for (auto& mechanism_vector : _mechanism_registry.getList())
+   {
+      for (auto& mechanism : *mechanism_vector)
+      {
+         mechanism->updateSpritePositions();
+      }
+   }
+
+   for (const auto& enemy : LuaInterface::instance().getObjectList())
+   {
+      enemy->updateSpritePositions();
+   }
+}
+
 void Level::updateViewsForDraw()
 {
    // the view is built from where the camera sits between the last two simulation steps, matching
@@ -1653,10 +1673,6 @@ void Level::draw(const std::shared_ptr<sf::RenderTexture>& window, bool screensh
    _screenshot = screenshot;
 
    rebuildMechanismDrawIndex();
-
-   // a frame drawn between two simulation steps needs its own view, or the whole scene would only
-   // move once per step while everything drawn in it interpolates
-   updateViewsForDraw();
 
    // the distortion shader reads the atmosphere map at each fragment's own position, so atmosphere
    // tiles that are off screen cannot bend a pixel on it. With none on screen the shader reduces to

--- a/src/game/level/level.cpp
+++ b/src/game/level/level.cpp
@@ -838,17 +838,28 @@ void Level::updateSpritePositions()
    // that lands on screen, so the two have to be derived from the same interpolated camera
    updateViewsForDraw();
 
+   // filtered the same way update is: placing a sprite that is nowhere near the player is work with
+   // no result, and some of these rebuild real geometry - the rope its strip, the spike ball its
+   // spline. Unfiltered, an uncapped frame rate would rebuild all of them several times per step
+   const auto& player_chunk = PlayerRegistry::getFirst()->getChunk();
+
    for (auto& mechanism_vector : _mechanism_registry.getList())
    {
       for (auto& mechanism : *mechanism_vector)
       {
-         mechanism->updateSpritePositions();
+         if (checkUpdateMechanism(player_chunk, mechanism))
+         {
+            mechanism->updateSpritePositions();
+         }
       }
    }
 
    for (const auto& enemy : LuaInterface::instance().getObjectList())
    {
-      enemy->updateSpritePositions();
+      if (checkUpdateMechanism(player_chunk, enemy))
+      {
+         enemy->updateSpritePositions();
+      }
    }
 }
 

--- a/src/game/level/level.cpp
+++ b/src/game/level/level.cpp
@@ -46,6 +46,7 @@
 #include "game/physics/chainshapeanalyzer.h"
 #include "game/physics/gamecontactlistener.h"
 #include "game/physics/physicsconfiguration.h"
+#include "game/physics/renderinterpolation.h"
 #include "game/physics/squaremarcher.h"
 #include "game/player/player.h"
 #include "game/player/playerfirefly.h"
@@ -807,20 +808,40 @@ void Level::createViews()
 #endif  // !DECEPTUS_VRSFML
 }
 
+sf::FloatRect Level::computeViewRect(float camera_x_px, float camera_y_px) const
+{
+   const auto& look_vector = CameraPanorama::getInstance().getLookVector();
+
+   auto view_rect = sf::FloatRect{{camera_x_px + look_vector.x, camera_y_px + look_vector.y}, {_view_width, _view_height}};
+   CameraZoom::getInstance().adjust(view_rect);
+   return view_rect;
+}
+
 void Level::updateViews()
 {
    // this should really just fetch the camera position and the camera panorama vectors and
    // update the views with them; no camera or camera panorama correction must be done here
-   const auto& look_vector = CameraPanorama::getInstance().getLookVector();
    const auto& camera_system = CameraSystem::getInstance();
-   const auto level_view_x = camera_system.getX() + look_vector.x;
-   const auto level_view_y = camera_system.getY() + look_vector.y;
+   const auto view_rect = computeViewRect(camera_system.getX(), camera_system.getY());
 
-   auto& zoom = CameraZoom::getInstance();
-   auto view_rect = sf::FloatRect{{level_view_x, level_view_y}, {_view_width, _view_height}};
-   zoom.adjust(view_rect);
-
+   // the room lock reads this back on the next step, so it has to see where the simulation actually
+   // put the camera. Feeding it the interpolated rect instead would make room locking depend on the
+   // frame rate, which is the very thing the fixed step exists to prevent
    CameraRoomLock::setViewRect(view_rect);
+
+   updateViewsForDraw();
+}
+
+void Level::updateViewsForDraw()
+{
+   // the view is built from where the camera sits between the last two simulation steps, matching
+   // what the player and the mechanisms are drawn at. Rounding to whole pixels keeps the tile art on
+   // the pixel grid, which is the other half of what makes an uncapped frame rate look right
+   const auto& camera_system = CameraSystem::getInstance();
+   const auto view_rect = computeViewRect(
+      RenderInterpolation::valuePx(camera_system.getPreviousX(), camera_system.getX()),
+      RenderInterpolation::valuePx(camera_system.getPreviousY(), camera_system.getY())
+   );
 
 #ifdef DECEPTUS_VRSFML
    _level_view = std::make_shared<sf::View>(sf::View::fromRect(view_rect));
@@ -1632,6 +1653,10 @@ void Level::draw(const std::shared_ptr<sf::RenderTexture>& window, bool screensh
    _screenshot = screenshot;
 
    rebuildMechanismDrawIndex();
+
+   // a frame drawn between two simulation steps needs its own view, or the whole scene would only
+   // move once per step while everything drawn in it interpolates
+   updateViewsForDraw();
 
    // the distortion shader reads the atmosphere map at each fragment's own position, so atmosphere
    // tiles that are off screen cannot bend a pixel on it. With none on screen the shader reduces to

--- a/src/game/level/level.h
+++ b/src/game/level/level.h
@@ -96,6 +96,17 @@ public:
    /// \brief recalculates level, parallax, and image-layer views from camera position, panorama, and zoom.
    void updateViews();
 
+   /// \brief rebuilds the views the frame is drawn through, from the interpolated camera position.
+   /// \note separate from updateViews because that one also feeds the room lock, which must see the
+   ///       simulation's camera rather than an interpolated one.
+   void updateViewsForDraw();
+
+   /// \brief builds the view rectangle for a camera position, applying panorama and zoom.
+   /// \param camera_x_px camera x position in pixels.
+   /// \param camera_y_px camera y position in pixels.
+   /// \return the view rectangle to render through.
+   sf::FloatRect computeViewRect(float camera_x_px, float camera_y_px) const;
+
    /// \brief refreshes mechanism audio volume inputs with the current player position.
    void updateMechanismVolumes();
 

--- a/src/game/level/level.h
+++ b/src/game/level/level.h
@@ -96,6 +96,13 @@ public:
    /// \brief recalculates level, parallax, and image-layer views from camera position, panorama, and zoom.
    void updateViews();
 
+   /// \brief places every sprite in the level for the frame about to be drawn.
+   /// \note called once per frame after that frame's simulation steps, unlike update which runs once
+   ///       per step. The simulation advances at a fixed rate, so this is where the interpolation
+   ///       between the last two steps happens - and it is where sprite positions belong, because
+   ///       draw draws.
+   void updateSpritePositions();
+
    /// \brief rebuilds the views the frame is drawn through, from the interpolated camera position.
    /// \note separate from updateViews because that one also feeds the room lock, which must see the
    ///       simulation's camera rather than an interpolated one.

--- a/src/game/level/luanode.cpp
+++ b/src/game/level/luanode.cpp
@@ -28,6 +28,7 @@
 #include "game/level/luainterface.h"
 #include "game/level/luanodecallbacks.h"
 #include "game/physics/physicsconfiguration.h"
+#include "game/physics/renderinterpolation.h"
 #include "game/player/player.h"
 #include "game/player/playerregistry.h"
 #include "game/state/savestate.h"
@@ -1082,6 +1083,7 @@ void LuaNode::updatePosition()
    auto x_px = _body->GetPosition().x * PPM;
    auto y_px = _body->GetPosition().y * PPM;
 
+   _position_px_previous = _position_px;
    _position_px.x = x_px;
    _position_px.y = y_px;
 
@@ -1494,7 +1496,7 @@ void LuaNode::drawParts(
 
       const auto& offset = _sprite_offsets_px[i];
       const auto center = sf::Vector2f(sprite->textureRect.size.x / 2.0f, sprite->textureRect.size.y / 2.0f);
-      sprite->position = _position_px - center + offset;
+      sprite->position = RenderInterpolation::positionPx(_position_px_previous, _position_px) - center + offset;
       sf::RenderStates sprite_states = states;
       sprite_states.texture = _texture.get();
       if (_flash_shader.isLoaded())
@@ -1510,7 +1512,7 @@ void LuaNode::drawParts(
 
       const auto& offset = _sprite_offsets_px[i];
       const auto center = sf::Vector2f(sprite->getTextureRect().size.x / 2.0f, sprite->getTextureRect().size.y / 2.0f);
-      sprite->setPosition(_position_px - center + offset);
+      sprite->setPosition(RenderInterpolation::positionPx(_position_px_previous, _position_px) - center + offset);
       auto sprite_states = states;
       sprite_states.shader = &_flash_shader.native();
       target.draw(*sprite, sprite_states);

--- a/src/game/level/luanode.cpp
+++ b/src/game/level/luanode.cpp
@@ -1090,6 +1090,27 @@ void LuaNode::updatePosition()
    updateHitboxOffsets();
 }
 
+void LuaNode::updateSpritePositions()
+{
+   // between the position this node had before the last simulation step and the one it has now, so a
+   // frame drawn in between does not repeat a position it has already shown
+   const auto interpolated_position_px = RenderInterpolation::positionPx(_position_px_previous, _position_px);
+
+   for (auto i = 0u; i < _sprites.size(); i++)
+   {
+      auto& sprite = _sprites[i];
+      const auto& offset = _sprite_offsets_px[i];
+
+#ifdef DECEPTUS_VRSFML
+      const auto center = sf::Vector2f(sprite->textureRect.size.x / 2.0f, sprite->textureRect.size.y / 2.0f);
+      sprite->position = interpolated_position_px - center + offset;
+#else
+      const auto center = sf::Vector2f(sprite->getTextureRect().size.x / 2.0f, sprite->getTextureRect().size.y / 2.0f);
+      sprite->setPosition(interpolated_position_px - center + offset);
+#endif
+   }
+}
+
 void LuaNode::updateSpriteRect(int32_t id, int32_t x_px, int32_t y_px, int32_t w_px, int32_t h_px)
 {
    sfcompat::setTextureRect(*_sprites[id], sf::IntRect({x_px, y_px}, {w_px, h_px}));
@@ -1494,9 +1515,6 @@ void LuaNode::drawParts(
          continue;
       }
 
-      const auto& offset = _sprite_offsets_px[i];
-      const auto center = sf::Vector2f(sprite->textureRect.size.x / 2.0f, sprite->textureRect.size.y / 2.0f);
-      sprite->position = RenderInterpolation::positionPx(_position_px_previous, _position_px) - center + offset;
       sf::RenderStates sprite_states = states;
       sprite_states.texture = _texture.get();
       if (_flash_shader.isLoaded())
@@ -1510,9 +1528,6 @@ void LuaNode::drawParts(
          continue;
       }
 
-      const auto& offset = _sprite_offsets_px[i];
-      const auto center = sf::Vector2f(sprite->getTextureRect().size.x / 2.0f, sprite->getTextureRect().size.y / 2.0f);
-      sprite->setPosition(RenderInterpolation::positionPx(_position_px_previous, _position_px) - center + offset);
       auto sprite_states = states;
       sprite_states.shader = &_flash_shader.native();
       target.draw(*sprite, sprite_states);

--- a/src/game/level/luanode.h
+++ b/src/game/level/luanode.h
@@ -542,6 +542,11 @@ struct LuaNode : public GameMechanism, public GameNode
    //!< per-z-index draw loop does not have to scan all sprite layers and weapons of every enemy
    std::vector<int32_t> _part_z_indices;
    sf::Vector2f _position_px;
+
+   //!< where this node was before the last simulation step, so a frame drawn between two steps can
+   //!< be placed between the two positions rather than on the newest one - see RenderInterpolation.
+   //!< without it an enemy steps at the simulation rate while the scenery around it moves smoothly
+   sf::Vector2f _position_px_previous;
    std::vector<sf::Vector2f> _movement_path_px;
    sfcompat::Shader _flash_shader;
    float _hit_flash{0.0f};

--- a/src/game/level/luanode.h
+++ b/src/game/level/luanode.h
@@ -97,6 +97,11 @@ struct LuaNode : public GameMechanism, public GameNode
    /// \brief syncs rendered position from box2d body coordinates.
    void updatePosition();
 
+   /// \brief places this node's sprites for the frame about to be drawn.
+   /// \note called once per frame after that frame's simulation steps, so it can place them between
+   ///       the last two. Sprite positions belong in update; draw draws.
+   void updateSpritePositions() override;
+
    /// \brief applies script-facing velocity constraints and friction behavior.
    void updateVelocity();
 

--- a/src/game/mechanisms/bubblecube.cpp
+++ b/src/game/mechanisms/bubblecube.cpp
@@ -304,10 +304,16 @@ void BubbleCube::updateSpriteIndex()
 void BubbleCube::updatePosition()
 {
    const auto pos_px = PPM * _body->GetPosition();
-   sfcompat::setPosition(*_sprite, {pos_px.x + sprite_offset_x_px, pos_px.y + sprite_offset_y_px});
+   _interpolated_position.step(pos_px.x, pos_px.y);
 
    // move translated rect along body position
    _translated_rect_px.position.y = _body->GetPosition().y * PPM;
+}
+
+void BubbleCube::updateSpritePositions()
+{
+   const auto position_px = _interpolated_position.getPositionPx();
+   sfcompat::setPosition(*_sprite, {position_px.x + sprite_offset_x_px, position_px.y + sprite_offset_y_px});
 }
 
 void BubbleCube::updateRespawnCondition()

--- a/src/game/mechanisms/bubblecube.h
+++ b/src/game/mechanisms/bubblecube.h
@@ -13,6 +13,7 @@ struct TmxObject;
 #include "game/io/gamedeserializedata.h"
 #include "game/level/fixturenode.h"
 #include "game/mechanisms/gamemechanism.h"
+#include "game/physics/renderinterpolation.h"
 
 #include "box2d/box2d.h"
 
@@ -46,6 +47,7 @@ public:
    /// \brief updates motion, contact logic, popping conditions, and respawn state.
    /// \param dt elapsed frame time.
    void update(const sf::Time& dt) override;
+   void updateSpritePositions() override;
 
    /// \brief returns the original platform bounds in pixel coordinates.
    /// \return rectangle for culling and gameplay checks.
@@ -124,6 +126,10 @@ private:
    // sf
    std::shared_ptr<sf::Texture> _texture;
    std::unique_ptr<sf::Sprite> _sprite;
+
+   //!< where this was before the last simulation step, so a frame drawn between two steps is
+   //!< placed between the two rather than on the newest one
+   InterpolatedPosition _interpolated_position;
 
    // b2d
    b2Body* _body = nullptr;

--- a/src/game/mechanisms/collapsingplatform.cpp
+++ b/src/game/mechanisms/collapsingplatform.cpp
@@ -406,11 +406,19 @@ void CollapsingPlatform::endContact(FixtureNode* other)
    _foot_sensor_contact = false;
 }
 
+void CollapsingPlatform::updateSpritePositions()
+{
+   for (auto& block : _blocks)
+   {
+      sfcompat::setPosition(*block._sprite, block._interpolated_position.getPositionPx());
+   }
+}
+
 void CollapsingPlatform::updateBlockSprites()
 {
    for (auto& block : _blocks)
    {
-      sfcompat::setPosition(*block._sprite, {block._x_px + block._shake_x_px, block._y_px + block._shake_y_px + block._fall_offset_y_px});
+      block._interpolated_position.step(block._x_px + block._shake_x_px, block._y_px + block._shake_y_px + block._fall_offset_y_px);
       sfcompat::setTextureRect(
          *block._sprite,
          sf::IntRect(

--- a/src/game/mechanisms/collapsingplatform.h
+++ b/src/game/mechanisms/collapsingplatform.h
@@ -6,6 +6,7 @@ struct TmxObject;
 #include "game/io/gamedeserializedata.h"
 #include "game/level/fixturenode.h"
 #include "game/mechanisms/gamemechanism.h"
+#include "game/physics/renderinterpolation.h"
 
 #include "box2d/box2d.h"
 
@@ -34,6 +35,9 @@ public:
       float _shake_x_px = 0.0f;
       float _shake_y_px = 0.0f;
       float _fall_offset_y_px = 0.0f;
+
+      //!< where this block sat before the last simulation step
+      InterpolatedPosition _interpolated_position;
       float _elapsed_s = 0.0f;
       float _fall_speed = 0.0f;
       float _destruction_speed = 0.0f;
@@ -80,6 +84,7 @@ public:
    /// \brief updates collapse timing, block animation, and respawn behavior.
    /// \param dt elapsed frame time.
    void update(const sf::Time& dt) override;
+   void updateSpritePositions() override;
 
    /// \brief returns the platform bounds in pixel coordinates.
    /// \return rectangle used for culling and respawn overlap checks.

--- a/src/game/mechanisms/crusher.cpp
+++ b/src/game/mechanisms/crusher.cpp
@@ -13,6 +13,7 @@
 #include "game/level/levelregistry.h"
 #include "game/level/roomupdater.h"
 #include "game/mechanisms/gamemechanismdeserializerregistry.h"
+#include "game/physics/renderinterpolation.h"
 
 int32_t Crusher::__instance_counter = 0;
 
@@ -169,8 +170,8 @@ void Crusher::step(const sf::Time& dt)
 void Crusher::update(const sf::Time& dt)
 {
    updateState();
+   _blade_offset_previous = _blade_offset;
    step(dt);
-   updateSpritePositions();
    updateTransform();
 }
 
@@ -567,41 +568,43 @@ void Crusher::setupBody(const std::shared_ptr<b2World>& world)
 
 void Crusher::updateSpritePositions()
 {
+   const auto blade_offset = RenderInterpolation::positionPx(_blade_offset_previous, _blade_offset);
+
    switch (_alignment)
    {
       case Alignment::PointsDown:
       {
 #ifdef DECEPTUS_VRSFML
-         _sprite_pusher->scale = {1.0f, _blade_offset.y};
+         _sprite_pusher->scale = {1.0f, blade_offset.y};
 #else
-         _sprite_pusher->setScale({1.0f, _blade_offset.y});
+         _sprite_pusher->setScale({1.0f, blade_offset.y});
 #endif
          break;
       }
       case Alignment::PointsUp:
       {
 #ifdef DECEPTUS_VRSFML
-         _sprite_pusher->scale = {1.0f, _blade_offset.y};
+         _sprite_pusher->scale = {1.0f, blade_offset.y};
 #else
-         _sprite_pusher->setScale({1.0f, _blade_offset.y});
+         _sprite_pusher->setScale({1.0f, blade_offset.y});
 #endif
          break;
       }
       case Alignment::PointsLeft:
       {
 #ifdef DECEPTUS_VRSFML
-         _sprite_pusher->scale = {_blade_offset.x, 1.0f};
+         _sprite_pusher->scale = {blade_offset.x, 1.0f};
 #else
-         _sprite_pusher->setScale({_blade_offset.x, 1.0f});
+         _sprite_pusher->setScale({blade_offset.x, 1.0f});
 #endif
          break;
       }
       case Alignment::PointsRight:
       {
 #ifdef DECEPTUS_VRSFML
-         _sprite_pusher->scale = {_blade_offset.x, 1.0f};
+         _sprite_pusher->scale = {blade_offset.x, 1.0f};
 #else
-         _sprite_pusher->setScale({_blade_offset.x, 1.0f});
+         _sprite_pusher->setScale({blade_offset.x, 1.0f});
 #endif
          break;
       }
@@ -614,10 +617,10 @@ void Crusher::updateSpritePositions()
 #ifdef DECEPTUS_VRSFML
    _sprite_mount->position = _position_px + _offset_mount_px;
    _sprite_pusher->position = _position_px + _offset_pusher_px;
-   _sprite_spike->position = _position_px + _offset_spike_px + _blade_offset;
+   _sprite_spike->position = _position_px + _offset_spike_px + blade_offset;
 #else
    _sprite_mount->setPosition(_position_px + _offset_mount_px);
    _sprite_pusher->setPosition(_position_px + _offset_pusher_px);
-   _sprite_spike->setPosition(_position_px + _offset_spike_px + _blade_offset);
+   _sprite_spike->setPosition(_position_px + _offset_spike_px + blade_offset);
 #endif
 }

--- a/src/game/mechanisms/crusher.h
+++ b/src/game/mechanisms/crusher.h
@@ -74,7 +74,7 @@ private:
    void updateState();
 
    /// \brief updates sprite scaling and positions to match current blade offset.
-   void updateSpritePositions();
+   void updateSpritePositions() override;
 
    /// \brief triggers a camera shake boom once during extraction when allowed.
    void startBoomEffect();
@@ -90,6 +90,11 @@ private:
    b2Body* _body{nullptr};
    sf::Vector2f _position_px;
    sf::Vector2f _blade_offset;
+
+   //!< how far the blade had travelled before the last simulation step. The blade is driven by an
+   //!< easing over simulated time rather than by a body, but it still only advances once per step,
+   //!< so a frame drawn in between is placed between the two - see RenderInterpolation
+   sf::Vector2f _blade_offset_previous;
    sf::FloatRect _rect;
 
    sf::Time _idle_time;

--- a/src/game/mechanisms/deathblock.cpp
+++ b/src/game/mechanisms/deathblock.cpp
@@ -422,8 +422,8 @@ void DeathBlock::updateBoundingBox()
 
 void DeathBlock::updateSprites()
 {
-   const auto x = _body->GetPosition().x * PPM - PIXELS_PER_TILE;
-   const auto y = _body->GetPosition().y * PPM - PIXELS_PER_TILE;
+   _interpolated_position.step(_body->GetPosition().x * PPM - PIXELS_PER_TILE, _body->GetPosition().y * PPM - PIXELS_PER_TILE);
+
    const auto tl_px = PIXELS_PER_TILE * 3;
 
    int32_t row = 1;  // first row is reserved for center
@@ -434,12 +434,22 @@ void DeathBlock::updateSprites()
          sfcompat::setTextureRect(*spike._sprite, sf::IntRect({spike._sprite_index * tl_px, tl_px * row}, {tl_px, tl_px}));
       }
 
-      sfcompat::setPosition(*spike._sprite, {x, y});
       row++;
    }
 
    sfcompat::setTextureRect(*_center_sprite, sf::IntRect({_center_sprite_index * tl_px, 0}, {tl_px, tl_px}));
-   sfcompat::setPosition(*_center_sprite, {x, y});
+}
+
+void DeathBlock::updateSpritePositions()
+{
+   const auto position_px = _interpolated_position.getPositionPx();
+
+   for (auto& spike : _spikes)
+   {
+      sfcompat::setPosition(*spike._sprite, position_px);
+   }
+
+   sfcompat::setPosition(*_center_sprite, position_px);
 }
 
 void DeathBlock::updatePosition(const sf::Time& dt)

--- a/src/game/mechanisms/deathblock.h
+++ b/src/game/mechanisms/deathblock.h
@@ -5,6 +5,7 @@
 #include "game/io/gamedeserializedata.h"
 #include "game/level/gamenode.h"
 #include "game/mechanisms/gamemechanism.h"
+#include "game/physics/renderinterpolation.h"
 
 #include "box2d/box2d.h"
 
@@ -45,6 +46,7 @@ public:
    /// \brief updates lever lag, spike animation states, movement, and player damage checks.
    /// \param dt elapsed frame time.
    void update(const sf::Time& dt) override;
+   void updateSpritePositions() override;
 
    /// \brief returns current block bounds in pixel coordinates.
    /// \return bounding rectangle around the 3x3 tile trap.
@@ -178,6 +180,10 @@ private:
    sf::Time _time_off;
    sf::Time _time_offset;
    std::array<Spike, 4> _spikes;
+
+   //!< where this was before the last simulation step, so a frame drawn between two steps is
+   //!< placed between the two rather than on the newest one
+   InterpolatedPosition _interpolated_position;
    std::unique_ptr<sf::Sprite> _center_sprite;
    float _center_sprite_time_s{0.0f};
    int32_t _center_sprite_index{0};

--- a/src/game/mechanisms/fireflies.cpp
+++ b/src/game/mechanisms/fireflies.cpp
@@ -3,6 +3,7 @@
 #include "framework/tmxparser/tmxobject.h"
 #include "framework/tmxparser/tmxproperties.h"
 #include "framework/tmxparser/tmxproperty.h"
+#include "framework/tools/sfmlcompat.h"
 #include "game/debug/debugdraw.h"
 #include "game/io/texturepool.h"
 #include "game/mechanisms/gamemechanismdeserializerregistry.h"
@@ -83,6 +84,14 @@ void Fireflies::draw(sf::RenderTarget& target, sf::RenderTarget& /*normal*/, con
    for (const auto& firefly : _fireflies)
    {
       target.draw(*firefly._sprite, draw_states);
+   }
+}
+
+void Fireflies::updateSpritePositions()
+{
+   for (auto& firefly : _fireflies)
+   {
+      firefly.updateSpritePosition();
    }
 }
 
@@ -249,15 +258,20 @@ void Fireflies::Firefly::update(const sf::Time& dt)
    _position.x = _rect_px.position.x + (_rect_px.size.x * 0.5f) + x_scaled_px;
    _position.y = _rect_px.position.y + (_rect_px.size.y * 0.5f) + y_scaled_px;
 
+   _interpolated_position.step(_position.x, _position.y);
+
 #ifdef DECEPTUS_VRSFML
-   _sprite->position = _position;
    _sprite->origin = {PIXELS_PER_TILE / 2, PIXELS_PER_TILE / 2};
 #else
-   _sprite->setPosition(_position);
    _sprite->setOrigin({PIXELS_PER_TILE / 2, PIXELS_PER_TILE / 2});
 #endif
 
    updateTextureRect();
+}
+
+void Fireflies::Firefly::updateSpritePosition()
+{
+   sfcompat::setPosition(*_sprite, _interpolated_position.getPositionPx());
 }
 
 void Fireflies::Firefly::updateTextureRect()

--- a/src/game/mechanisms/fireflies.h
+++ b/src/game/mechanisms/fireflies.h
@@ -5,6 +5,7 @@
 #include "game/io/gamedeserializedata.h"
 #include "game/level/gamenode.h"
 #include "game/mechanisms/gamemechanism.h"
+#include "game/physics/renderinterpolation.h"
 
 /// \brief spawns animated fireflies that orbit inside a configured rectangle.
 class Fireflies : public GameMechanism, public GameNode
@@ -24,8 +25,15 @@ public:
       /// \brief updates the sprite texture rectangle for the current animation frame.
       void updateTextureRect();
 
+      /// \brief places this firefly's sprite for the frame about to be drawn.
+      void updateSpritePosition();
+
       sf::Vector3f _position_3d;
       sf::Vector2f _position;
+
+      //!< where this firefly was before the last simulation step. It flies a path driven by
+      //!< simulated time rather than by a body, but it still only advances once per step
+      InterpolatedPosition _interpolated_position;
       std::unique_ptr<sf::Sprite> _sprite;
       sf::Time _elapsed;
       sf::FloatRect _rect_px;
@@ -63,6 +71,7 @@ public:
    /// \brief updates all firefly instances.
    /// \param dt elapsed frame time.
    void update(const sf::Time& dt) override;
+   void updateSpritePositions() override;
 
    /// \brief returns bounds for mechanism queries.
    /// \return `std::nullopt` because this mechanism does not expose collision bounds.

--- a/src/game/mechanisms/gamemechanism.cpp
+++ b/src/game/mechanisms/gamemechanism.cpp
@@ -132,6 +132,10 @@ void GameMechanism::draw(sf::RenderTarget& target, sf::RenderTarget& normal, con
    draw(target, normal);
 }
 
+void GameMechanism::updateSpritePositions()
+{
+}
+
 void GameMechanism::update(const sf::Time& /*dt*/)
 {
 }

--- a/src/game/mechanisms/gamemechanism.h
+++ b/src/game/mechanisms/gamemechanism.h
@@ -54,6 +54,16 @@ public:
    /// \param states render states to apply (carries .view for WASM camera transform).
    virtual void draw(sf::RenderTarget& target, sf::RenderTarget& normal, const sf::RenderStates& states);
 
+   /// \brief places this mechanism's sprites for the frame about to be drawn.
+   ///
+   /// Called once per frame, after the simulation steps for that frame have run. Mechanisms that move
+   /// override it and position their sprites between the state they had before the last step and the
+   /// state they have now, via RenderInterpolation - the simulation advances at a fixed rate, so a
+   /// frame drawn between two steps would otherwise repeat a position it has already shown.
+   ///
+   /// Sprite positions belong here rather than in draw: draw draws.
+   virtual void updateSpritePositions();
+
    /// \brief updates mechanism logic for one frame.
    /// \param dt elapsed frame time.
    virtual void update(const sf::Time& dt);

--- a/src/game/mechanisms/laser.cpp
+++ b/src/game/mechanisms/laser.cpp
@@ -85,6 +85,16 @@ const sf::FloatRect& Laser::getPixelRect() const
    return _rect_px;
 }
 
+void Laser::updateSpritePositions()
+{
+   if (!_path.has_value())
+   {
+      return;
+   }
+
+   sfcompat::setPosition(*_sprite, _interpolated_position.getPositionPx());
+}
+
 void Laser::update(const sf::Time& dt)
 {
    _time += dt.asMilliseconds();
@@ -213,7 +223,7 @@ void Laser::update(const sf::Time& dt)
       {
          _path_interpolation.updateTime(_settings._movement_speed * dt.asSeconds());
          _move_offset_px = _path_interpolation.computePosition(_path_interpolation.getTime());
-         sfcompat::setPosition(*_sprite, _position_px + _move_offset_px);
+         _interpolated_position.step(_position_px.x + _move_offset_px.x, _position_px.y + _move_offset_px.y);
       }
    }
 

--- a/src/game/mechanisms/laser.h
+++ b/src/game/mechanisms/laser.h
@@ -4,6 +4,7 @@
 #include "game/io/gamedeserializedata.h"
 #include "game/level/gamenode.h"
 #include "game/mechanisms/gamemechanism.h"
+#include "game/physics/renderinterpolation.h"
 
 // sfml
 #include "SFML/Graphics.hpp"
@@ -64,6 +65,7 @@ public:
    /// \brief updates signal timing, frame animation, optional movement, and player collision checks.
    /// \param dt elapsed frame time.
    void update(const sf::Time& dt) override;
+   void updateSpritePositions() override;
 
    /// \brief returns the base laser tile rectangle.
    /// \return laser rectangle in pixels.
@@ -128,6 +130,10 @@ protected:
 
    std::optional<std::vector<sf::Vector2f>> _path;
    sf::Vector2f _move_offset_px;
+
+   //!< where the laser sat before the last simulation step. It travels along a path over simulated
+   //!< time rather than from a body, but it still only advances once per step
+   InterpolatedPosition _interpolated_position;
    PathInterpolation<sf::Vector2f> _path_interpolation;
 
    bool _on = true;

--- a/src/game/mechanisms/moveablebox.cpp
+++ b/src/game/mechanisms/moveablebox.cpp
@@ -84,15 +84,19 @@ void MoveableBox::draw(sf::RenderTarget& color, sf::RenderTarget& /*normal*/, co
    color.draw(*_sprite, draw_states);
 }
 
+void MoveableBox::updateSpritePositions()
+{
+   const auto position_px = _interpolated_position.getPositionPx();
+#ifdef DECEPTUS_VRSFML
+   _sprite->position = {position_px.x, position_px.y - 24};
+#else
+   _sprite->setPosition({position_px.x, position_px.y - 24});
+#endif
+}
+
 void MoveableBox::update(const sf::Time& /*dt*/)
 {
-   const auto x = _body->GetPosition().x * PPM;
-   const auto y = _body->GetPosition().y * PPM;
-#ifdef DECEPTUS_VRSFML
-   _sprite->position = {x, y - 24};
-#else
-   _sprite->setPosition({x, y - 24});
-#endif
+   _interpolated_position.step(_body->GetPosition().x * PPM, _body->GetPosition().y * PPM);
 
    // if the thing is moving, start playing a scratching sound
    if (fabs(_body->GetLinearVelocity().x) > 0.01)

--- a/src/game/mechanisms/moveablebox.h
+++ b/src/game/mechanisms/moveablebox.h
@@ -7,6 +7,7 @@
 #include "game/io/gamedeserializedata.h"
 #include "game/level/gamenode.h"
 #include "game/mechanisms/gamemechanism.h"
+#include "game/physics/renderinterpolation.h"
 
 struct TmxObject;
 
@@ -40,6 +41,7 @@ public:
    /// \brief syncs sprite position from box2d and starts or stops pushing audio by velocity.
    /// \param dt elapsed frame time.
    void update(const sf::Time& dt) override;
+   void updateSpritePositions() override;
 
    /// \brief returns the current sprite bounds.
    /// \return box bounds in pixels.
@@ -75,6 +77,10 @@ private:
 
    std::shared_ptr<sf::Texture> _texture;
    std::unique_ptr<sf::Sprite> _sprite;
+
+   //!< where this was before the last simulation step, so a frame drawn between two steps is
+   //!< placed between the two rather than on the newest one
+   InterpolatedPosition _interpolated_position;
    sf::Vector2f _size;
    b2Body* _body = nullptr;
    std::optional<int32_t> _pushing_sample;

--- a/src/game/mechanisms/movingplatform.cpp
+++ b/src/game/mechanisms/movingplatform.cpp
@@ -16,6 +16,7 @@
 #include "game/io/valuereader.h"
 #include "game/level/fixturenode.h"
 #include "game/mechanisms/gamemechanismdeserializerregistry.h" 0
+#include "game/physics/renderinterpolation.h"
 #include "game/player/playerregistry.h"
 
 #include <array>
@@ -384,6 +385,23 @@ void MovingPlatform::updateLeverLag(const sf::Time& delta_time)
    }
 }
 
+void MovingPlatform::updateSpritePositions()
+{
+   // the platform carries the player, so it has to be placed between the same two simulation steps
+   // the player is - otherwise the player appears to slide along it
+   const auto horizontal = (_platform_width_tl > 1) ? 1 : 0;
+   const auto position_px =
+      RenderInterpolation::positionPx(sf::Vector2f{_pos_prev_m.x * PPM, _pos_prev_m.y * PPM}, sf::Vector2f{_pos_m.x * PPM, _pos_m.y * PPM});
+
+   auto sprite_index = 0;
+   for (auto& sprite : _sprites)
+   {
+      // there is one tile offset for the perspective tile
+      sfcompat::setPosition(sprite, {position_px.x + (horizontal * sprite_index * PIXELS_PER_TILE), position_px.y - PIXELS_PER_TILE});
+      sprite_index++;
+   }
+}
+
 void MovingPlatform::update(const sf::Time& delta_time)
 {
    updateLeverLag(delta_time);
@@ -432,10 +450,6 @@ void MovingPlatform::update(const sf::Time& delta_time)
 
    for (auto& sprite : _sprites)
    {
-      const auto pos_body_x_px = (_body->GetPosition().x * PPM) + (horizontal * sprite_index * PIXELS_PER_TILE);
-      const auto pos_body_y_px = (_body->GetPosition().y * PPM) - PIXELS_PER_TILE;  // there's one tile offset for the perspective tile
-
-      sfcompat::setPosition(sprite, {pos_body_x_px, pos_body_y_px});
       auto update_sprite_rect = false;
       auto texture_u = 0;
       auto texture_v = 0;

--- a/src/game/mechanisms/movingplatform.h
+++ b/src/game/mechanisms/movingplatform.h
@@ -50,6 +50,7 @@ public:
    /// \brief updates path movement, enable-ramp lag, player coupling, and wheel animations.
    /// \param dt elapsed frame time.
    void update(const sf::Time& dt) override;
+   void updateSpritePositions() override;
 
    /// \brief returns the precomputed area covered by this platform path.
    /// \return platform bounds in pixels.

--- a/src/game/mechanisms/rope.cpp
+++ b/src/game/mechanisms/rope.cpp
@@ -82,20 +82,43 @@ void Rope::draw(sf::RenderTarget& color, sf::RenderTarget& normal)
    draw(color, normal, {});
 }
 
-void Rope::draw(sf::RenderTarget& color, sf::RenderTarget& normal, const sf::RenderStates& incoming_states)
+void Rope::updateSpritePositions()
 {
+   if (_chain_elements.size() < 2)
+   {
+      return;
+   }
+
+   // the chain positions this frame is drawn at, between the last two simulation steps. They are
+   // interpolated in meters and converted to pixels when the vertex is built, so the rounding to
+   // whole pixels happens once, on the vertex itself
+   const auto alpha = RenderInterpolation::getAlpha();
+   const auto interpolated = [this, alpha](std::size_t index)
+   {
+      if (index >= _chain_positions_current_m.size())
+      {
+         return _chain_elements[index]->GetPosition();
+      }
+
+      const auto& current_m = _chain_positions_current_m[index];
+      if (index >= _chain_positions_previous_m.size())
+      {
+         return current_m;
+      }
+
+      const auto& previous_m = _chain_positions_previous_m[index];
+      return b2Vec2{previous_m.x + (current_m.x - previous_m.x) * alpha, previous_m.y + (current_m.y - previous_m.y) * alpha};
+   };
+
    std::optional<b2Vec2> q1_prev;
    std::optional<b2Vec2> q4_prev;
 
-   std::vector<sf::Vertex> strip;
+   _strip.clear();
 
    for (auto i = 0u; i < _chain_elements.size() - 1; i++)
    {
-      auto* c1 = _chain_elements[i];
-      auto* c2 = _chain_elements[i + 1];
-
-      const auto c1_pos_m = c1->GetPosition();
-      const auto c2_pos_m = c2->GetPosition();
+      const auto c1_pos_m = interpolated(i);
+      const auto c2_pos_m = interpolated(i + 1);
 
       constexpr auto thickness_m = 0.025f;
 
@@ -145,27 +168,35 @@ void Rope::draw(sf::RenderTarget& color, sf::RenderTarget& normal, const sf::Ren
          )
       );
 
-      strip.push_back(v1);
-      strip.push_back(v2);
-      strip.push_back(v4);
-      strip.push_back(v3);
+      _strip.push_back(v1);
+      _strip.push_back(v2);
+      _strip.push_back(v4);
+      _strip.push_back(v3);
+   }
+}
+
+void Rope::draw(sf::RenderTarget& color, sf::RenderTarget& normal, const sf::RenderStates& incoming_states)
+{
+   if (_strip.empty())
+   {
+      return;
    }
 
    // render color texture
    sf::RenderStates states = incoming_states;
    states.texture = _texture.get();
 #ifdef DECEPTUS_VRSFML
-   color.draw(std::span<const sf::Vertex>{strip.data(), strip.size()}, sf::PrimitiveType::TriangleStrip, states);
+   color.draw(std::span<const sf::Vertex>{_strip.data(), _strip.size()}, sf::PrimitiveType::TriangleStrip, states);
 #else
-   color.draw(strip.data(), strip.size(), sf::PrimitiveType::TriangleStrip, states);
+   color.draw(_strip.data(), _strip.size(), sf::PrimitiveType::TriangleStrip, states);
 #endif
 
    // render normal map (same geometry, different texture)
    states.texture = _normal_map.get();
 #ifdef DECEPTUS_VRSFML
-   normal.draw(std::span<const sf::Vertex>{strip.data(), strip.size()}, sf::PrimitiveType::TriangleStrip, states);
+   normal.draw(std::span<const sf::Vertex>{_strip.data(), _strip.size()}, sf::PrimitiveType::TriangleStrip, states);
 #else
-   normal.draw(strip.data(), strip.size(), sf::PrimitiveType::TriangleStrip, states);
+   normal.draw(_strip.data(), _strip.size(), sf::PrimitiveType::TriangleStrip, states);
 #endif
 }
 
@@ -180,6 +211,15 @@ void Rope::pushChain(float impulse)
 
 void Rope::update(const sf::Time& dt)
 {
+   // mechanisms update after the world has stepped, so the pair is kept by shifting rather than by
+   // reading the bodies at two different times
+   _chain_positions_previous_m = _chain_positions_current_m;
+   _chain_positions_current_m.clear();
+   for (auto* element : _chain_elements)
+   {
+      _chain_positions_current_m.push_back(element->GetPosition());
+   }
+
    // prevent glitches
    // it might make sense to come up with a more high level concept for this
    if (dt.asMilliseconds() > 500)

--- a/src/game/mechanisms/rope.h
+++ b/src/game/mechanisms/rope.h
@@ -3,6 +3,7 @@
 #include "game/io/gamedeserializedata.h"
 #include "game/level/gamenode.h"
 #include "game/mechanisms/gamemechanism.h"
+#include "game/physics/renderinterpolation.h"
 
 #include "box2d/box2d.h"
 
@@ -38,6 +39,7 @@ public:
    /// \brief updates wind impulses, player influence, and rope motion.
    /// \param dt elapsed frame time.
    void update(const sf::Time& dt) override;
+   void updateSpritePositions() override;
 
    /// \brief returns the interaction area used for player impulse transfer.
    /// \return rope bounding rectangle in pixel space.
@@ -64,6 +66,15 @@ protected:
    float _segment_length_m = 0.01f;
 
    std::vector<b2Body*> _chain_elements;
+
+   //!< where each chain element sat before the last simulation step, and where it sits now, so the
+   //!< strip can be built between the two rather than jumping once per step. Mechanisms update after
+   //!< the world has stepped, so the pair is kept by shifting rather than by reading the bodies twice
+   std::vector<b2Vec2> _chain_positions_previous_m;
+   std::vector<b2Vec2> _chain_positions_current_m;
+
+   //!< the strip the rope is drawn as, rebuilt once per frame by updateSpritePositions
+   std::vector<sf::Vertex> _strip;
    std::shared_ptr<sf::Texture> _texture;
    std::shared_ptr<sf::Texture> _normal_map;
 

--- a/src/game/mechanisms/ropewithlight.cpp
+++ b/src/game/mechanisms/ropewithlight.cpp
@@ -86,12 +86,30 @@ void RopeWithLight::update(const sf::Time& dt)
 
    const auto angle_rad = static_cast<float>(atan2(c_m.y, c_m.x));
 
+   _lamp_position_px_previous = _lamp_position_px_current;
+   _lamp_position_px_current = sf::Vector2f{_light->_pos_m.x * PPM, _light->_pos_m.y * PPM};
+
+   _lamp_rotation_deg_previous = _lamp_rotation_deg_current;
+   _lamp_rotation_deg_current = 90.0f + FACTOR_RAD_TO_DEG * angle_rad;
+}
+
+void RopeWithLight::updateSpritePositions()
+{
+   Rope::updateSpritePositions();
+
+   const auto position_px = RenderInterpolation::positionPx(_lamp_position_px_previous, _lamp_position_px_current);
+
+   // the rotation is interpolated too, otherwise the lamp swings in steps while it travels smoothly.
+   // it is not rounded: an angle has no pixel grid to sit on
+   const auto alpha = RenderInterpolation::getAlpha();
+   const auto rotation_deg = _lamp_rotation_deg_previous + (_lamp_rotation_deg_current - _lamp_rotation_deg_previous) * alpha;
+
 #ifdef DECEPTUS_VRSFML
-   _lamp_sprite->rotation = sf::degrees(90.0f + FACTOR_RAD_TO_DEG * angle_rad);
-   _lamp_sprite->position = {_light->_pos_m.x * PPM, _light->_pos_m.y * PPM};
+   _lamp_sprite->rotation = sf::degrees(rotation_deg);
+   _lamp_sprite->position = position_px;
 #else
-   _lamp_sprite->setRotation(sf::degrees(90.0f + FACTOR_RAD_TO_DEG * angle_rad));
-   _lamp_sprite->setPosition({_light->_pos_m.x * PPM, _light->_pos_m.y * PPM});
+   _lamp_sprite->setRotation(sf::degrees(rotation_deg));
+   _lamp_sprite->setPosition(position_px);
 #endif
 }
 

--- a/src/game/mechanisms/ropewithlight.h
+++ b/src/game/mechanisms/ropewithlight.h
@@ -34,12 +34,22 @@ public:
    /// \param dt elapsed frame time.
    void update(const sf::Time& dt) override;
 
+   /// \brief places the lamp for the frame about to be drawn.
+   void updateSpritePositions() override;
+
    /// \brief initializes rope physics, lamp visuals, and light properties from tmx data.
    /// \param data deserialization data with rope and lamp configuration.
    void setup(const GameDeserializeData& data) override;
 
 private:
    std::unique_ptr<sf::Sprite> _lamp_sprite;
+
+   //!< where the lamp hung before the last simulation step, and where it hangs now, so the frames in
+   //!< between can be placed between the two
+   sf::Vector2f _lamp_position_px_previous;
+   sf::Vector2f _lamp_position_px_current;
+   float _lamp_rotation_deg_previous{0.0f};
+   float _lamp_rotation_deg_current{0.0f};
    std::array<sf::IntRect, 3> _lamp_sprite_rects;
    std::shared_ptr<LightSystem::LightInstance> _light;
 };

--- a/src/game/mechanisms/rotatingblade.cpp
+++ b/src/game/mechanisms/rotatingblade.cpp
@@ -274,6 +274,14 @@ void RotatingBlade::updateAudio()
    }
 }
 
+void RotatingBlade::updateSpritePositions()
+{
+   // the rotation is interpolated too, otherwise the blade turns in steps while it travels smoothly
+   const auto alpha = RenderInterpolation::getAlpha();
+   sfcompat::setRotation(*_sprite, sf::degrees(_angle_previous + (_angle - _angle_previous) * alpha));
+   sfcompat::setPosition(*_sprite, _interpolated_position.getPositionPx());
+}
+
 void RotatingBlade::update(const sf::Time& dt)
 {
    if (_enabled)
@@ -288,10 +296,10 @@ void RotatingBlade::update(const sf::Time& dt)
    // update position and rotation along path
    const auto movement_delta = dt.asSeconds() * _velocity * _settings._movement_speed;
    _path_interpolation.updateTime(movement_delta);
+   _angle_previous = _angle;
    _angle += dt.asSeconds() * _velocity * _direction * _settings._blade_rotation_speed;
    _pos = _path_interpolation.computePosition(_path_interpolation.getTime());
-   sfcompat::setRotation(*_sprite, sf::degrees(_angle));
-   sfcompat::setPosition(*_sprite, _pos);
+   _interpolated_position.step(_pos.x, _pos.y);
 
    updateAudio();
 

--- a/src/game/mechanisms/rotatingblade.h
+++ b/src/game/mechanisms/rotatingblade.h
@@ -4,6 +4,7 @@
 #include "game/io/gamedeserializedata.h"
 #include "game/level/gamenode.h"
 #include "game/mechanisms/gamemechanism.h"
+#include "game/physics/renderinterpolation.h"
 
 #include <vector>
 #include "SFML/Graphics.hpp"
@@ -52,6 +53,7 @@ public:
    /// \brief advances blade speed, movement, rotation, audio state, and hit detection.
    /// \param dt elapsed frame time.
    void update(const sf::Time& dt) override;
+   void updateSpritePositions() override;
 
    /// \brief draws the rotating blade sprite.
    /// \param target render target.
@@ -97,6 +99,10 @@ private:
    sf::FloatRect _rectangle;
    std::vector<sf::Vector2f> _path;
    sf::Vector2f _pos;
+
+   //!< where the blade sat and how far it had turned before the last simulation step
+   InterpolatedPosition _interpolated_position;
+   float _angle_previous = 0.0f;
    PathInterpolation<sf::Vector2f> _path_interpolation;
    PathType _path_type = PathType::Polygon;
    Settings _settings;

--- a/src/game/mechanisms/spikeball.cpp
+++ b/src/game/mechanisms/spikeball.cpp
@@ -1,5 +1,7 @@
 #include "spikeball.h"
 
+#include <cmath>
+
 #include <array>
 #include <iostream>
 

--- a/src/game/mechanisms/spikeball.cpp
+++ b/src/game/mechanisms/spikeball.cpp
@@ -152,30 +152,12 @@ void SpikeBall::preload()
 #ifdef DECEPTUS_VRSFML
 void SpikeBall::drawChain(sf::RenderTarget& window, const sf::RenderStates& states)
 {
-   std::vector<HermiteCurveKey> keys;
-
-   auto t = 0.0f;
-   auto ti = 1.0f / _chain_elements.size();
-   for (auto* c : _chain_elements)
+   for (auto i = 0u; i < _chain_spline_points_px.size(); i++)
    {
-      HermiteCurveKey k;
-      k._position = sf::Vector2f{c->GetPosition().x * PPM, c->GetPosition().y * PPM};
-      k._time = (t += ti);
-      keys.push_back(k);
-   }
-
-   HermiteCurve curve;
-   curve.setPositionKeys(keys);
-   curve.compute();
-
-   auto val = 0.0f;
-   auto increment = 1.0f / _config._spline_point_count;
-   for (auto i = 0; i < _config._spline_point_count; i++)
-   {
-      auto point = curve.computePoint(val += increment);
-
+      // one sprite is reused for every point along the chain, so it is moved as it is submitted -
+      // the positions themselves come from updateSpritePositions
       auto& element = (i % 2 == 0) ? _chain_element_a : _chain_element_b;
-      element->position = point;
+      element->position = _chain_spline_points_px[i];
 
       sf::RenderStates draw_states = states;
       draw_states.texture = _texture.get();
@@ -185,30 +167,12 @@ void SpikeBall::drawChain(sf::RenderTarget& window, const sf::RenderStates& stat
 #else
 void SpikeBall::drawChain(sf::RenderTarget& window)
 {
-   std::vector<HermiteCurveKey> keys;
-
-   auto t = 0.0f;
-   auto ti = 1.0f / _chain_elements.size();
-   for (auto* c : _chain_elements)
+   for (auto i = 0u; i < _chain_spline_points_px.size(); i++)
    {
-      HermiteCurveKey k;
-      k._position = sf::Vector2f{c->GetPosition().x * PPM, c->GetPosition().y * PPM};
-      k._time = (t += ti);
-      keys.push_back(k);
-   }
-
-   HermiteCurve curve;
-   curve.setPositionKeys(keys);
-   curve.compute();
-
-   auto val = 0.0f;
-   auto increment = 1.0f / _config._spline_point_count;
-   for (auto i = 0; i < _config._spline_point_count; i++)
-   {
-      auto point = curve.computePoint(val += increment);
-
+      // one sprite is reused for every point along the chain, so it is moved as it is submitted -
+      // the positions themselves come from updateSpritePositions
       auto& element = (i % 2 == 0) ? _chain_element_a : _chain_element_b;
-      element->setPosition(point);
+      element->setPosition(_chain_spline_points_px[i]);
 
       window.draw(*element);
    }
@@ -289,6 +253,56 @@ void SpikeBall::draw(sf::RenderTarget& color, sf::RenderTarget& /*normal*/)
 }
 #endif
 
+void SpikeBall::updateSpritePositions()
+{
+   const auto ball_position_px = _interpolated_ball_position.getPositionPx();
+#ifdef DECEPTUS_VRSFML
+   _spike_sprite->position = ball_position_px;
+#else
+   _spike_sprite->setPosition(ball_position_px);
+#endif
+
+   if (_chain_positions_current_m.empty())
+   {
+      return;
+   }
+
+   // the chain runs along a spline through the elements, so the elements are interpolated first and
+   // the spline is computed from the result
+   const auto alpha = RenderInterpolation::getAlpha();
+
+   std::vector<HermiteCurveKey> keys;
+   auto time = 0.0f;
+   const auto time_increment = 1.0f / static_cast<float>(_chain_positions_current_m.size());
+   for (auto i = 0u; i < _chain_positions_current_m.size(); i++)
+   {
+      const auto& current_m = _chain_positions_current_m[i];
+      const auto position_m = (i < _chain_positions_previous_m.size())
+                                 ? b2Vec2{
+                                      _chain_positions_previous_m[i].x + (current_m.x - _chain_positions_previous_m[i].x) * alpha,
+                                      _chain_positions_previous_m[i].y + (current_m.y - _chain_positions_previous_m[i].y) * alpha
+                                   }
+                                 : current_m;
+
+      HermiteCurveKey key;
+      key._position = sf::Vector2f{position_m.x * PPM, position_m.y * PPM};
+      key._time = (time += time_increment);
+      keys.push_back(key);
+   }
+
+   HermiteCurve curve;
+   curve.setPositionKeys(keys);
+   curve.compute();
+
+   _chain_spline_points_px.clear();
+   auto value = 0.0f;
+   const auto increment = 1.0f / _config._spline_point_count;
+   for (auto i = 0; i < _config._spline_point_count; i++)
+   {
+      _chain_spline_points_px.push_back(curve.computePoint(value += increment));
+   }
+}
+
 void SpikeBall::update(const sf::Time& dt)
 {
    if (dt.asMilliseconds() > 16 * 2)
@@ -296,11 +310,16 @@ void SpikeBall::update(const sf::Time& dt)
       return;
    }
 
-#ifdef DECEPTUS_VRSFML
-   _spike_sprite->position = {_ball_body->GetPosition().x * PPM, _ball_body->GetPosition().y * PPM};
-#else
-   _spike_sprite->setPosition({_ball_body->GetPosition().x * PPM, _ball_body->GetPosition().y * PPM});
-#endif
+   _interpolated_ball_position.step(_ball_body->GetPosition().x * PPM, _ball_body->GetPosition().y * PPM);
+
+   // mechanisms update after the world has stepped, so the chain pair is kept by shifting rather than
+   // by reading the bodies at two different times
+   _chain_positions_previous_m = _chain_positions_current_m;
+   _chain_positions_current_m.clear();
+   for (auto* element : _chain_elements)
+   {
+      _chain_positions_current_m.push_back(element->GetPosition());
+   }
 
    static const b2Vec2 up{0.0, 1.0};
 

--- a/src/game/mechanisms/spikeball.h
+++ b/src/game/mechanisms/spikeball.h
@@ -7,6 +7,7 @@
 #include "game/io/gamedeserializedata.h"
 #include "game/level/gamenode.h"
 #include "game/mechanisms/gamemechanism.h"
+#include "game/physics/renderinterpolation.h"
 
 struct TmxObject;
 
@@ -60,6 +61,9 @@ public:
    /// \param dt elapsed frame time.
    void update(const sf::Time& dt) override;
 
+   /// \brief places the ball and computes the chain spline for the frame about to be drawn.
+   void updateSpritePositions() override;
+
    /// \brief returns the map-defined mechanism bounds in pixel space.
    /// \return rectangle used for chunk activation.
    std::optional<sf::FloatRect> getBoundingBoxPx() override;
@@ -91,6 +95,15 @@ private:
    std::shared_ptr<sf::Texture> _texture;
    std::unique_ptr<sf::Sprite> _spike_sprite;
    std::unique_ptr<sf::Sprite> _box_sprite;
+   //!< where the ball and each chain element sat before the last simulation step, and where they
+   //!< sit now. Mechanisms update after the world has stepped, so the pairs are kept by shifting
+   InterpolatedPosition _interpolated_ball_position;
+   std::vector<b2Vec2> _chain_positions_previous_m;
+   std::vector<b2Vec2> _chain_positions_current_m;
+
+   //!< the spline the chain is drawn along, computed once per frame by updateSpritePositions
+   std::vector<sf::Vector2f> _chain_spline_points_px;
+
    std::unique_ptr<sf::Sprite> _chain_element_a;
    std::unique_ptr<sf::Sprite> _chain_element_b;
 

--- a/src/game/physics/fixedtimestep.cpp
+++ b/src/game/physics/fixedtimestep.cpp
@@ -1,6 +1,7 @@
 #include "fixedtimestep.h"
 
 #include "game/physics/physicsconfiguration.h"
+#include "game/physics/renderinterpolation.h"
 
 int32_t FixedTimeStep::consumeSteps(const sf::Time& dt)
 {
@@ -13,19 +14,23 @@ int32_t FixedTimeStep::consumeSteps(const sf::Time& dt)
    _accumulated_s += dt.asSeconds();
 
    auto step_count = static_cast<int32_t>(_accumulated_s / step_duration_s);
-   if (step_count <= 0)
-   {
-      return 0;
-   }
 
    if (step_count > max_steps_per_frame)
    {
       step_count = max_steps_per_frame;
       _accumulated_s = 0.0f;
-      return step_count;
+   }
+   else if (step_count > 0)
+   {
+      _accumulated_s -= static_cast<float>(step_count) * step_duration_s;
    }
 
-   _accumulated_s -= static_cast<float>(step_count) * step_duration_s;
+   // what is left over is how far the frame about to be drawn sits past the step just taken, which
+   // is what the draw path interpolates by. Without it a frame faster than the step rate would draw
+   // a state it has already drawn, and the step would land on a frame boundary rather than on an
+   // even interval - which is what makes an uncapped run stutter
+   RenderInterpolation::setAlpha(_accumulated_s / step_duration_s);
+
    return step_count;
 }
 

--- a/src/game/physics/fixedtimestep.cpp
+++ b/src/game/physics/fixedtimestep.cpp
@@ -1,0 +1,45 @@
+#include "fixedtimestep.h"
+
+#include "game/physics/physicsconfiguration.h"
+
+int32_t FixedTimeStep::consumeSteps(const sf::Time& dt)
+{
+   const auto step_duration_s = getStepDurationInS();
+   if (step_duration_s <= 0.0f)
+   {
+      return 1;
+   }
+
+   _accumulated_s += dt.asSeconds();
+
+   auto step_count = static_cast<int32_t>(_accumulated_s / step_duration_s);
+   if (step_count <= 0)
+   {
+      return 0;
+   }
+
+   if (step_count > max_steps_per_frame)
+   {
+      step_count = max_steps_per_frame;
+      _accumulated_s = 0.0f;
+      return step_count;
+   }
+
+   _accumulated_s -= static_cast<float>(step_count) * step_duration_s;
+   return step_count;
+}
+
+float FixedTimeStep::getStepDurationInS() const
+{
+   return PhysicsConfiguration::getInstance()._time_step;
+}
+
+sf::Time FixedTimeStep::getStepDuration() const
+{
+   return sf::seconds(getStepDurationInS());
+}
+
+void FixedTimeStep::reset()
+{
+   _accumulated_s = 0.0f;
+}

--- a/src/game/physics/fixedtimestep.cpp
+++ b/src/game/physics/fixedtimestep.cpp
@@ -1,6 +1,5 @@
 #include "fixedtimestep.h"
 
-#include "game/physics/physicsconfiguration.h"
 #include "game/physics/renderinterpolation.h"
 
 int32_t FixedTimeStep::consumeSteps(const sf::Time& dt)
@@ -36,7 +35,7 @@ int32_t FixedTimeStep::consumeSteps(const sf::Time& dt)
 
 float FixedTimeStep::getStepDurationInS() const
 {
-   return PhysicsConfiguration::getInstance()._time_step;
+   return 1.0f / steps_per_second;
 }
 
 sf::Time FixedTimeStep::getStepDuration() const

--- a/src/game/physics/fixedtimestep.h
+++ b/src/game/physics/fixedtimestep.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <cstdint>
+
+#include <SFML/System/Time.hpp>
+
+/// \brief turns a variable frame time into a whole number of fixed simulation steps.
+///
+/// The simulation is written against one assumption: it is updated exactly once per physics step,
+/// with a delta of PhysicsConfiguration::_time_step. Driving it straight from the frame time breaks
+/// that - the world advanced one step per frame whatever the frame rate, so it ran at double speed
+/// at 120 fps and in slow motion whenever the frame rate dropped below 60.
+///
+/// This restores the assumption instead of spreading frame rate compensation across the code that
+/// relies on it: leftover frame time is banked here, and the caller runs the whole simulation update
+/// as many whole steps as the bank affords. A frame that is faster than the step runs none of them
+/// and simply draws the same state again.
+class FixedTimeStep
+{
+public:
+   /// \brief adds a frame's worth of time and reports how many steps it pays for.
+   /// \param dt time elapsed since the previous frame.
+   /// \return number of simulation steps to run this frame, never more than the catch-up limit.
+   /// \note the time behind the limit is discarded rather than banked. Keeping it would leave the
+   ///       simulation permanently in catch-up after a single long frame - a level load, a breakpoint
+   ///       - and each frame of catch-up costs more time, so it never gets out.
+   int32_t consumeSteps(const sf::Time& dt);
+
+   /// \brief duration of one simulation step, in seconds.
+   /// \return the step the physics world is advanced by, from PhysicsConfiguration.
+   float getStepDurationInS() const;
+
+   /// \brief duration of one simulation step, as the delta handed to the simulation update.
+   sf::Time getStepDuration() const;
+
+   /// \brief drops the banked time.
+   /// \note call this whenever real time has passed that the simulation must not make up for, i.e.
+   ///       after loading a level.
+   void reset();
+
+private:
+   //!< frame time banked but not yet spent on a step
+   float _accumulated_s{0.0f};
+
+   //!< most steps one frame may run. below the resulting frame rate the game slows down rather than
+   //!< spending ever more of each frame catching up
+   static constexpr int32_t max_steps_per_frame = 5;
+};

--- a/src/game/physics/fixedtimestep.h
+++ b/src/game/physics/fixedtimestep.h
@@ -6,15 +6,22 @@
 
 /// \brief turns a variable frame time into a whole number of fixed simulation steps.
 ///
-/// The simulation is written against one assumption: it is updated exactly once per physics step,
-/// with a delta of PhysicsConfiguration::_time_step. Driving it straight from the frame time breaks
-/// that - the world advanced one step per frame whatever the frame rate, so it ran at double speed
-/// at 120 fps and in slow motion whenever the frame rate dropped below 60.
+/// The simulation is written against one assumption: it is updated exactly once per frame, at the
+/// frame rate the game was tuned at. Driving it straight from the frame time breaks that - the world
+/// advanced one step per frame whatever the frame rate, so it ran at double speed at 120 fps and in
+/// slow motion whenever the frame rate dropped below 60.
 ///
 /// This restores the assumption instead of spreading frame rate compensation across the code that
 /// relies on it: leftover frame time is banked here, and the caller runs the whole simulation update
-/// as many whole steps as the bank affords. A frame that is faster than the step runs none of them
-/// and simply draws the same state again.
+/// as many whole steps as the bank affords. A frame that is faster than the step rate runs none of
+/// them and simply draws the same state again.
+///
+/// \note the step rate is deliberately NOT derived from PhysicsConfiguration::_time_step. That value
+///       is the delta handed to b2World::Step, and Level::update passes it there regardless of how
+///       much time has really passed - it currently reads 1/35 s while the game is tuned to step
+///       once per 1/60 s frame, so the world deliberately advances faster than real time. Deriving
+///       the rate from it would make the simulation take 35 steps a second, and the whole game would
+///       run at 58% of the speed it is tuned for.
 class FixedTimeStep
 {
 public:
@@ -26,11 +33,10 @@ public:
    ///       - and each frame of catch-up costs more time, so it never gets out.
    int32_t consumeSteps(const sf::Time& dt);
 
-   /// \brief duration of one simulation step, in seconds.
-   /// \return the step the physics world is advanced by, from PhysicsConfiguration.
+   /// \brief how much time one simulation step stands for, in seconds.
    float getStepDurationInS() const;
 
-   /// \brief duration of one simulation step, as the delta handed to the simulation update.
+   /// \brief how much time one simulation step stands for, as the delta handed to the simulation.
    sf::Time getStepDuration() const;
 
    /// \brief drops the banked time.
@@ -41,6 +47,10 @@ public:
 private:
    //!< frame time banked but not yet spent on a step
    float _accumulated_s{0.0f};
+
+   //!< the rate the simulation is stepped at: the frame rate the game is tuned at, so that one step
+   //!< per 1/60 s reproduces exactly what stepping once per frame did at 60 fps
+   static constexpr float steps_per_second = 60.0f;
 
    //!< most steps one frame may run. below the resulting frame rate the game slows down rather than
    //!< spending ever more of each frame catching up

--- a/src/game/physics/renderinterpolation.cpp
+++ b/src/game/physics/renderinterpolation.cpp
@@ -9,6 +9,9 @@ float __alpha = 0.0f;
 
 //!< how far past that the picture is aimed, in steps. see setLead
 float __lead = 0.0f;
+
+//!< whether the frame is drawn between two simulation states at all. see setEnabled
+bool __enabled = true;
 }  // namespace
 
 namespace RenderInterpolation
@@ -34,6 +37,16 @@ float getLead()
    return __lead;
 }
 
+void setEnabled(bool enabled)
+{
+   __enabled = enabled;
+}
+
+bool isEnabled()
+{
+   return __enabled;
+}
+
 sf::Vector2f positionPx(const sf::Vector2f& previous_px, const sf::Vector2f& current_px)
 {
    return sf::Vector2f{valuePx(previous_px.x, current_px.x), valuePx(previous_px.y, current_px.y)};
@@ -41,6 +54,11 @@ sf::Vector2f positionPx(const sf::Vector2f& previous_px, const sf::Vector2f& cur
 
 float valuePx(float previous_px, float current_px)
 {
+   if (!__enabled)
+   {
+      return current_px;
+   }
+
    return previous_px + (current_px - previous_px) * (__alpha + __lead);
 }
 

--- a/src/game/physics/renderinterpolation.cpp
+++ b/src/game/physics/renderinterpolation.cpp
@@ -10,8 +10,10 @@ float __alpha = 0.0f;
 //!< how far past that the picture is aimed, in steps. see setLead
 float __lead = 0.0f;
 
-//!< whether the frame is drawn between two simulation states at all. see setEnabled
-bool __enabled = true;
+//!< whether the frame is drawn between two simulation states at all. see setEnabled.
+//!< off by default: 60 steps a second reads as smooth on its own, and this way the frame is never
+//!< behind the simulation
+bool __enabled = false;
 }  // namespace
 
 namespace RenderInterpolation

--- a/src/game/physics/renderinterpolation.cpp
+++ b/src/game/physics/renderinterpolation.cpp
@@ -6,6 +6,9 @@ namespace
 {
 //!< how far the frame being drawn sits past the last simulation step
 float __alpha = 0.0f;
+
+//!< how far past that the picture is aimed, in steps. see setLead
+float __lead = 0.0f;
 }  // namespace
 
 namespace RenderInterpolation
@@ -21,6 +24,16 @@ float getAlpha()
    return __alpha;
 }
 
+void setLead(float lead)
+{
+   __lead = std::clamp(lead, 0.0f, 1.0f);
+}
+
+float getLead()
+{
+   return __lead;
+}
+
 sf::Vector2f positionPx(const sf::Vector2f& previous_px, const sf::Vector2f& current_px)
 {
    return sf::Vector2f{valuePx(previous_px.x, current_px.x), valuePx(previous_px.y, current_px.y)};
@@ -28,7 +41,7 @@ sf::Vector2f positionPx(const sf::Vector2f& previous_px, const sf::Vector2f& cur
 
 float valuePx(float previous_px, float current_px)
 {
-   return previous_px + (current_px - previous_px) * __alpha;
+   return previous_px + (current_px - previous_px) * (__alpha + __lead);
 }
 
 }  // namespace RenderInterpolation

--- a/src/game/physics/renderinterpolation.cpp
+++ b/src/game/physics/renderinterpolation.cpp
@@ -33,3 +33,14 @@ float valuePx(float previous_px, float current_px)
 }
 
 }  // namespace RenderInterpolation
+
+void InterpolatedPosition::step(float x_px, float y_px)
+{
+   _previous_px = _current_px;
+   _current_px = sf::Vector2f{x_px, y_px};
+}
+
+sf::Vector2f InterpolatedPosition::getPositionPx() const
+{
+   return RenderInterpolation::positionPx(_previous_px, _current_px);
+}

--- a/src/game/physics/renderinterpolation.cpp
+++ b/src/game/physics/renderinterpolation.cpp
@@ -1,0 +1,35 @@
+#include "renderinterpolation.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace
+{
+//!< how far the frame being drawn sits past the last simulation step
+float __alpha = 0.0f;
+}  // namespace
+
+namespace RenderInterpolation
+{
+
+void setAlpha(float alpha)
+{
+   __alpha = std::clamp(alpha, 0.0f, 1.0f);
+}
+
+float getAlpha()
+{
+   return __alpha;
+}
+
+sf::Vector2f positionPx(const sf::Vector2f& previous_px, const sf::Vector2f& current_px)
+{
+   return sf::Vector2f{valuePx(previous_px.x, current_px.x), valuePx(previous_px.y, current_px.y)};
+}
+
+float valuePx(float previous_px, float current_px)
+{
+   return std::round(previous_px + (current_px - previous_px) * __alpha);
+}
+
+}  // namespace RenderInterpolation

--- a/src/game/physics/renderinterpolation.cpp
+++ b/src/game/physics/renderinterpolation.cpp
@@ -1,7 +1,6 @@
 #include "renderinterpolation.h"
 
 #include <algorithm>
-#include <cmath>
 
 namespace
 {
@@ -29,7 +28,7 @@ sf::Vector2f positionPx(const sf::Vector2f& previous_px, const sf::Vector2f& cur
 
 float valuePx(float previous_px, float current_px)
 {
-   return std::round(previous_px + (current_px - previous_px) * __alpha);
+   return previous_px + (current_px - previous_px) * __alpha;
 }
 
 }  // namespace RenderInterpolation

--- a/src/game/physics/renderinterpolation.h
+++ b/src/game/physics/renderinterpolation.h
@@ -43,7 +43,7 @@ void setLead(float lead);
 
 /// \brief turns the interpolation off, so every frame draws the newest simulation state.
 /// \param enabled false snaps to the last step instead of drawing between the last two.
-/// \note off is what the game did before any of this: correct speed, but a frame rate above
+/// \note off is the default, and is what the game did before any of this: correct speed, but a frame rate above
 ///       the step rate repeats a position it has already shown. Here to be able to feel the
 ///       difference rather than argue about it.
 void setEnabled(bool enabled);

--- a/src/game/physics/renderinterpolation.h
+++ b/src/game/physics/renderinterpolation.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <SFML/System/Vector2.hpp>
+
+/// \brief positions the frame being drawn between the last two simulation states.
+///
+/// The simulation advances in whole steps of PhysicsConfiguration::_time_step, see FixedTimeStep.
+/// That fixes the speed of the world but it also means a frame drawn faster than the step rate shows
+/// a state it has already shown, and the step lands on a frame boundary rather than on an even
+/// interval - so a run at 200 fps stutters even though the motion underneath is uniform.
+///
+/// The frame therefore draws where things are *between* two steps: the caller keeps the position a
+/// body had before the last step alongside its current one, and asks for the point in between.
+///
+/// The interpolated position is rounded to whole pixels. The game is pixel art rendered at an
+/// integer scale (see GameConfiguration::computeViewScale), and a sprite at a fractional position
+/// samples its texels across a screen pixel boundary - the same smearing an unfloored view scale
+/// produced. Rounding keeps every sprite exact and still yields one distinct position per pixel of
+/// travel, which is what makes the motion read as smooth.
+namespace RenderInterpolation
+{
+
+/// \brief publishes how far the frame about to be drawn sits past the last simulation step.
+/// \param alpha 0 at the step just taken, approaching 1 at the next one.
+/// \note there is one simulation clock in the process, so this is held centrally rather than
+///       threaded through every draw signature.
+void setAlpha(float alpha);
+
+/// \brief how far the frame being drawn sits past the last simulation step, 0..1.
+float getAlpha();
+
+/// \brief the position to draw at, between two simulation states.
+/// \param previous_px where it was before the last step.
+/// \param current_px where it is after the last step.
+/// \return the point in between, rounded to whole pixels.
+sf::Vector2f positionPx(const sf::Vector2f& previous_px, const sf::Vector2f& current_px);
+
+/// \brief the value to draw at, between two simulation states, for a single axis.
+/// \param previous_px where it was before the last step.
+/// \param current_px where it is after the last step.
+/// \return the value in between, rounded to a whole pixel.
+float valuePx(float previous_px, float current_px);
+
+}  // namespace RenderInterpolation

--- a/src/game/physics/renderinterpolation.h
+++ b/src/game/physics/renderinterpolation.h
@@ -12,11 +12,13 @@
 /// The frame therefore draws where things are *between* two steps: the caller keeps the position a
 /// body had before the last step alongside its current one, and asks for the point in between.
 ///
-/// The interpolated position is rounded to whole pixels. The game is pixel art rendered at an
-/// integer scale (see GameConfiguration::computeViewScale), and a sprite at a fractional position
-/// samples its texels across a screen pixel boundary - the same smearing an unfloored view scale
-/// produced. Rounding keeps every sprite exact and still yields one distinct position per pixel of
-/// travel, which is what makes the motion read as smooth.
+/// The interpolated position is deliberately NOT rounded to whole pixels. Rounding it looks like the
+/// right thing for pixel art, and it is not: the camera and the things it follows would each be
+/// rounded on their own, so a sprite's screen position - the difference between the two - flips by a
+/// pixel whenever one rounds up and the other does not. That happens once per distinct interpolation
+/// fraction, so the higher the frame rate the more often the whole scene shivers. Sprites sat on
+/// fractional positions before any of this existed; what needed to be exact was the view scale, see
+/// GameConfiguration::computeViewScale.
 namespace RenderInterpolation
 {
 

--- a/src/game/physics/renderinterpolation.h
+++ b/src/game/physics/renderinterpolation.h
@@ -42,3 +42,26 @@ sf::Vector2f positionPx(const sf::Vector2f& previous_px, const sf::Vector2f& cur
 float valuePx(float previous_px, float current_px);
 
 }  // namespace RenderInterpolation
+
+/// \brief remembers where something was across simulation steps, so it can be drawn in between.
+///
+/// Every mechanism that moves shares the same shape: a physics body advances once per simulation
+/// step, and a sprite is placed at its position plus an offset. Rather than each of them keeping its
+/// own pair of positions, they hold one of these: step() during update, getPositionPx() where the
+/// sprite is placed.
+class InterpolatedPosition
+{
+public:
+   /// \brief records the position this simulation step moved to.
+   /// \param x_px position along x, in pixels.
+   /// \param y_px position along y, in pixels.
+   void step(float x_px, float y_px);
+
+   /// \brief where to place the sprite for the frame about to be drawn.
+   /// \return the position between the last two steps, rounded to whole pixels.
+   sf::Vector2f getPositionPx() const;
+
+private:
+   sf::Vector2f _previous_px;
+   sf::Vector2f _current_px;
+};

--- a/src/game/physics/renderinterpolation.h
+++ b/src/game/physics/renderinterpolation.h
@@ -41,6 +41,16 @@ float getAlpha();
 ///       because the camera follows the player and the scenery does not.
 void setLead(float lead);
 
+/// \brief turns the interpolation off, so every frame draws the newest simulation state.
+/// \param enabled false snaps to the last step instead of drawing between the last two.
+/// \note off is what the game did before any of this: correct speed, but a frame rate above
+///       the step rate repeats a position it has already shown. Here to be able to feel the
+///       difference rather than argue about it.
+void setEnabled(bool enabled);
+
+/// \brief whether the frame is drawn between two simulation states.
+bool isEnabled();
+
 /// \brief how far past the frame's own point in time the picture is aimed, in steps.
 float getLead();
 

--- a/src/game/physics/renderinterpolation.h
+++ b/src/game/physics/renderinterpolation.h
@@ -2,22 +2,22 @@
 
 #include <SFML/System/Vector2.hpp>
 
-/// \brief positions the frame being drawn between the last two simulation states.
+/// \brief positions the frame being drawn relative to the last two simulation states.
 ///
-/// The simulation advances in whole steps of PhysicsConfiguration::_time_step, see FixedTimeStep.
-/// That fixes the speed of the world but it also means a frame drawn faster than the step rate shows
-/// a state it has already shown, and the step lands on a frame boundary rather than on an even
-/// interval - so a run at 200 fps stutters even though the motion underneath is uniform.
+/// The simulation advances in whole steps, see FixedTimeStep. That fixes the speed of the world but
+/// it also means a frame drawn faster than the step rate shows a state it has already shown, and the
+/// step lands on a frame boundary rather than on an even interval - so a run at 200 fps stutters even
+/// though the motion underneath is uniform.
 ///
-/// The frame therefore draws where things are *between* two steps: the caller keeps the position a
-/// body had before the last step alongside its current one, and asks for the point in between.
+/// The frame therefore draws where things are between two steps: the caller keeps the position a body
+/// had before the last step alongside its current one, and asks for the point in between.
 ///
-/// The interpolated position is deliberately NOT rounded to whole pixels. Rounding it looks like the
-/// right thing for pixel art, and it is not: the camera and the things it follows would each be
-/// rounded on their own, so a sprite's screen position - the difference between the two - flips by a
-/// pixel whenever one rounds up and the other does not. That happens once per distinct interpolation
-/// fraction, so the higher the frame rate the more often the whole scene shivers. Sprites sat on
-/// fractional positions before any of this existed; what needed to be exact was the view scale, see
+/// Positions are deliberately NOT rounded to whole pixels. Rounding them looks like the right thing
+/// for pixel art, and it is not: the camera and the things it follows would each be rounded on their
+/// own, so a sprite's screen position - the difference between the two - flips by a pixel whenever
+/// one rounds up and the other does not. That happens once per distinct interpolation fraction, so
+/// the higher the frame rate the more often the whole scene shivers. Sprites sat on fractional
+/// positions before any of this existed; what needed to be exact was the view scale, see
 /// GameConfiguration::computeViewScale.
 namespace RenderInterpolation
 {
@@ -31,16 +31,29 @@ void setAlpha(float alpha);
 /// \brief how far the frame being drawn sits past the last simulation step, 0..1.
 float getAlpha();
 
-/// \brief the position to draw at, between two simulation states.
+/// \brief how far past the frame's own point in time to aim, in steps.
+/// \param lead 0 draws between the last two steps, so the picture sits up to a step behind the
+///        simulation - which shows up as the player answering the controls a few milliseconds late.
+///        1 draws a whole step ahead, removing that lag and overshooting instead: something that
+///        stops hard pokes past where it stopped and comes back. Half a step is the middle - no
+///        average lag, against half a step of overshoot.
+/// \note one value for everything. Giving the player its own would make it slide against the world,
+///       because the camera follows the player and the scenery does not.
+void setLead(float lead);
+
+/// \brief how far past the frame's own point in time the picture is aimed, in steps.
+float getLead();
+
+/// \brief the position to draw at, relative to two simulation states.
 /// \param previous_px where it was before the last step.
 /// \param current_px where it is after the last step.
-/// \return the point in between, rounded to whole pixels.
+/// \return the point between them, carried past current_px by the lead.
 sf::Vector2f positionPx(const sf::Vector2f& previous_px, const sf::Vector2f& current_px);
 
-/// \brief the value to draw at, between two simulation states, for a single axis.
+/// \brief the value to draw at, relative to two simulation states, for a single axis.
 /// \param previous_px where it was before the last step.
 /// \param current_px where it is after the last step.
-/// \return the value in between, rounded to a whole pixel.
+/// \return the value between them, carried past current_px by the lead.
 float valuePx(float previous_px, float current_px);
 
 }  // namespace RenderInterpolation
@@ -60,7 +73,7 @@ public:
    void step(float x_px, float y_px);
 
    /// \brief where to place the sprite for the frame about to be drawn.
-   /// \return the position between the last two steps, rounded to whole pixels.
+   /// \return the position derived from the last two steps.
    sf::Vector2f getPositionPx() const;
 
 private:

--- a/src/game/player/itemsystem.cpp
+++ b/src/game/player/itemsystem.cpp
@@ -9,6 +9,17 @@
 // Items have their own update and draw functions, so they can have their own behavior and
 // visuals while being equipped.
 
+void ItemSystem::updateSpritePositions()
+{
+   for (auto& item : _slots)
+   {
+      if (item)
+      {
+         item->updateSpritePositions();
+      }
+   }
+}
+
 void ItemSystem::update(const sf::Time& dt)
 {
    for (auto& item : _slots)

--- a/src/game/player/itemsystem.h
+++ b/src/game/player/itemsystem.h
@@ -18,6 +18,9 @@ public:
    /// \param dt elapsed frame time forwarded to each equipped item.
    void update(const sf::Time& dt);
 
+   /// \brief places every equipped item's sprites for the frame about to be drawn.
+   void updateSpritePositions();
+
    /// \brief draws all currently equipped item instances.
    /// \param target render target passed to each equipped item.
    /// \param states render states passed to each equipped item (carries .view for WASM camera transform).

--- a/src/game/player/player.cpp
+++ b/src/game/player/player.cpp
@@ -19,6 +19,7 @@
 #include "game/physics/gamecontactlistener.h"
 #include "game/physics/onewaywall.h"
 #include "game/physics/physicsconfiguration.h"
+#include "game/physics/renderinterpolation.h"
 #include "game/player/inventorybasedcontrols.h"
 #include "game/player/itemsystem.h"
 #include "game/player/playeraudio.h"
@@ -332,7 +333,7 @@ void Player::draw(sf::RenderTarget& color, sf::RenderTarget& normal, const sf::R
    }
 
    // that y offset is to compensate the wonky box2d origin
-   const auto draw_position_px = _position_px_f + sf::Vector2f(0, 8);
+   const auto draw_position_px = RenderInterpolation::positionPx(_position_px_f_previous, _position_px_f) + sf::Vector2f(0, 8);
 
    const auto& current_cycle = _player_animation->getCurrentCycle();
    if (current_cycle)
@@ -374,7 +375,7 @@ void Player::draw(sf::RenderTarget& color, sf::RenderTarget& normal, const sf::R
 void Player::drawStencil(sf::RenderTarget& color, const sf::RenderStates& states)
 {
    const auto stencil_color = sf::Color{255, 255, 255, 25};
-   const auto draw_position_px = _position_px_f + sf::Vector2f(0, 8);
+   const auto draw_position_px = RenderInterpolation::positionPx(_position_px_f_previous, _position_px_f) + sf::Vector2f(0, 8);
 
    // the silhouette shader forces the occluded player to transparent white (its rgb comes from the
    // shader, its alpha from the sprite shape scaled by u_alpha) instead of the dimmed sprite colors
@@ -1641,6 +1642,10 @@ void Player::updateHealth(const sf::Time& dt)
 void Player::update(const sf::Time& dt)
 {
    _time += dt;
+
+   // the position this step starts from, kept so the frames drawn before the next step can be placed
+   // between the two rather than all on the newest one
+   _position_px_f_previous = _position_px_f;
 
    // a lot depends on an up-to-date pixel position and the hitbox that's generated out of it
    updatePixelPosition();

--- a/src/game/player/player.cpp
+++ b/src/game/player/player.cpp
@@ -336,7 +336,7 @@ void Player::draw(sf::RenderTarget& color, sf::RenderTarget& normal, const sf::R
    if (current_cycle)
    {
       current_cycle->setColor(sf::Color(255, 255, 255, static_cast<uint8_t>(_fade_out_alpha * 255)));
-      drawDash(color, current_cycle, _sprite_position_px);
+      drawDash(color, current_cycle, _sprite_position_px + sf::Vector2f(0, 8));
       updateHurtColor(current_cycle);
       current_cycle->draw(color, normal, states);
    }
@@ -414,16 +414,20 @@ const sf::FloatRect& Player::getPixelRectFloat() const
 
 void Player::updateSpritePositions()
 {
-   // the y offset compensates the wonky box2d origin
-   _sprite_position_px = RenderInterpolation::positionPx(_position_px_f_previous, _position_px_f) + sf::Vector2f(0, 8);
+   _sprite_position_px = RenderInterpolation::positionPx(_position_px_f_previous, _position_px_f);
+
+   // that y offset compensates the wonky box2d origin. It belongs to these sprites rather than to
+   // the position: anything else riding on the player, the head torch helmet for one, has its own
+   // offset from the player and would be pushed down by this one
+   const auto body_position_px = _sprite_position_px + sf::Vector2f(0, 8);
 
    const auto& current_cycle = _player_animation->getCurrentCycle();
    if (current_cycle)
    {
 #ifdef DECEPTUS_VRSFML
-      current_cycle->position = _sprite_position_px;
+      current_cycle->position = body_position_px;
 #else
-      current_cycle->setPosition(_sprite_position_px);
+      current_cycle->setPosition(body_position_px);
 #endif
    }
 
@@ -431,9 +435,9 @@ void Player::updateSpritePositions()
    if (auxiliary_cycle)
    {
 #ifdef DECEPTUS_VRSFML
-      auxiliary_cycle->position = _sprite_position_px;
+      auxiliary_cycle->position = body_position_px;
 #else
-      auxiliary_cycle->setPosition(_sprite_position_px);
+      auxiliary_cycle->setPosition(body_position_px);
 #endif
    }
 

--- a/src/game/player/player.cpp
+++ b/src/game/player/player.cpp
@@ -332,19 +332,11 @@ void Player::draw(sf::RenderTarget& color, sf::RenderTarget& normal, const sf::R
       weapon_system._selected->draw(color, states);
    }
 
-   // that y offset is to compensate the wonky box2d origin
-   const auto draw_position_px = RenderInterpolation::positionPx(_position_px_f_previous, _position_px_f) + sf::Vector2f(0, 8);
-
    const auto& current_cycle = _player_animation->getCurrentCycle();
    if (current_cycle)
    {
       current_cycle->setColor(sf::Color(255, 255, 255, static_cast<uint8_t>(_fade_out_alpha * 255)));
-#ifdef DECEPTUS_VRSFML
-      current_cycle->position = draw_position_px;
-#else
-      current_cycle->setPosition(draw_position_px);
-#endif
-      drawDash(color, current_cycle, draw_position_px);
+      drawDash(color, current_cycle, _sprite_position_px);
       updateHurtColor(current_cycle);
       current_cycle->draw(color, normal, states);
    }
@@ -353,11 +345,6 @@ void Player::draw(sf::RenderTarget& color, sf::RenderTarget& normal, const sf::R
    if (auxiliary_cycle)
    {
       auxiliary_cycle->setColor(sf::Color(255, 255, 255, static_cast<uint8_t>(_fade_out_alpha * 255)));
-#ifdef DECEPTUS_VRSFML
-      auxiliary_cycle->position = draw_position_px;
-#else
-      auxiliary_cycle->setPosition(draw_position_px);
-#endif
       auxiliary_cycle->draw(color, normal, states);
    }
 
@@ -375,7 +362,6 @@ void Player::draw(sf::RenderTarget& color, sf::RenderTarget& normal, const sf::R
 void Player::drawStencil(sf::RenderTarget& color, const sf::RenderStates& states)
 {
    const auto stencil_color = sf::Color{255, 255, 255, 25};
-   const auto draw_position_px = RenderInterpolation::positionPx(_position_px_f_previous, _position_px_f) + sf::Vector2f(0, 8);
 
    // the silhouette shader forces the occluded player to transparent white (its rgb comes from the
    // shader, its alpha from the sprite shape scaled by u_alpha) instead of the dimmed sprite colors
@@ -391,11 +377,6 @@ void Player::drawStencil(sf::RenderTarget& color, const sf::RenderStates& states
    if (current_cycle)
    {
       current_cycle->setColor(stencil_color);
-#ifdef DECEPTUS_VRSFML
-      current_cycle->position = draw_position_px;
-#else
-      current_cycle->setPosition(draw_position_px);
-#endif
       current_cycle->draw(color, stencil_states);
    }
 
@@ -403,11 +384,6 @@ void Player::drawStencil(sf::RenderTarget& color, const sf::RenderStates& states
    if (auxiliary_cycle)
    {
       auxiliary_cycle->setColor(stencil_color);
-#ifdef DECEPTUS_VRSFML
-      auxiliary_cycle->position = draw_position_px;
-#else
-      auxiliary_cycle->setPosition(draw_position_px);
-#endif
       auxiliary_cycle->draw(color, stencil_states);
    }
 }
@@ -434,6 +410,32 @@ void Player::setPixelPosition(float x, float y)
 const sf::FloatRect& Player::getPixelRectFloat() const
 {
    return _rect_px_f;
+}
+
+void Player::updateSpritePositions()
+{
+   // the y offset compensates the wonky box2d origin
+   _sprite_position_px = RenderInterpolation::positionPx(_position_px_f_previous, _position_px_f) + sf::Vector2f(0, 8);
+
+   const auto& current_cycle = _player_animation->getCurrentCycle();
+   if (current_cycle)
+   {
+#ifdef DECEPTUS_VRSFML
+      current_cycle->position = _sprite_position_px;
+#else
+      current_cycle->setPosition(_sprite_position_px);
+#endif
+   }
+
+   const auto& auxiliary_cycle = _player_animation->getAuxiliaryCycle();
+   if (auxiliary_cycle)
+   {
+#ifdef DECEPTUS_VRSFML
+      auxiliary_cycle->position = _sprite_position_px;
+#else
+      auxiliary_cycle->setPosition(_sprite_position_px);
+#endif
+   }
 }
 
 void Player::updatePixelRect()

--- a/src/game/player/player.cpp
+++ b/src/game/player/player.cpp
@@ -436,6 +436,14 @@ void Player::updateSpritePositions()
       auxiliary_cycle->setPosition(_sprite_position_px);
 #endif
    }
+
+   // the equipped items ride on the player, so they are placed from the same position the body is
+   SaveState::getPlayerInfo()._items.updateSpritePositions();
+}
+
+const sf::Vector2f& Player::getSpritePositionPx() const
+{
+   return _sprite_position_px;
 }
 
 void Player::updatePixelRect()

--- a/src/game/player/player.h
+++ b/src/game/player/player.h
@@ -465,6 +465,11 @@ private:
    float _impulse{0.0f};
 
    sf::Vector2f _position_px_f;
+
+   //!< where the player was before the last simulation step. the simulation runs at a fixed rate,
+   //!< so a frame drawn between two steps has to draw between these two positions or it repeats a
+   //!< state it has already shown - see RenderInterpolation
+   sf::Vector2f _position_px_f_previous;
    sf::Vector2i _position_px_i;
    sf::FloatRect _rect_px_f;
    sf::IntRect _rect_px_i;

--- a/src/game/player/player.h
+++ b/src/game/player/player.h
@@ -170,6 +170,12 @@ public:
    ///       between the last two of them. Sprite positions belong in update; draw draws.
    void updateSpritePositions();
 
+   /// \brief where the player's sprites are placed for the frame being drawn.
+   /// \return the interpolated position, i.e. not the simulation position from getPixelPositionFloat.
+   /// \note anything drawn on the player - the head torch, its helmet - has to use this, or it ends
+   ///       up a step away from the body it is supposed to sit on.
+   const sf::Vector2f& getSpritePositionPx() const override;
+
    /// \brief refreshes current world chunk based on player pixel position.
    void updateChunk();
 

--- a/src/game/player/player.h
+++ b/src/game/player/player.h
@@ -165,6 +165,11 @@ public:
    /// \brief recomputes cached player pixel-space rectangles from current position.
    void updatePixelRect();
 
+   /// \brief places the player's sprites for the frame about to be drawn.
+   /// \note called once per frame after that frame's simulation steps, so it can place the sprites
+   ///       between the last two of them. Sprite positions belong in update; draw draws.
+   void updateSpritePositions();
+
    /// \brief refreshes current world chunk based on player pixel position.
    void updateChunk();
 
@@ -467,9 +472,13 @@ private:
    sf::Vector2f _position_px_f;
 
    //!< where the player was before the last simulation step. the simulation runs at a fixed rate,
-   //!< so a frame drawn between two steps has to draw between these two positions or it repeats a
-   //!< state it has already shown - see RenderInterpolation
+   //!< so a frame drawn between two steps has to be placed between these two positions or it repeats
+   //!< a state it has already shown - see RenderInterpolation
    sf::Vector2f _position_px_f_previous;
+
+   //!< where the sprites are placed for the frame about to be drawn, i.e. the interpolated position
+   //!< plus the box2d origin offset. Set by updateSpritePositions once per frame
+   sf::Vector2f _sprite_position_px;
    sf::Vector2i _position_px_i;
    sf::FloatRect _rect_px_f;
    sf::IntRect _rect_px_i;

--- a/src/game/player/playerinterface.h
+++ b/src/game/player/playerinterface.h
@@ -32,6 +32,12 @@ public:
    /// \return pixel-space player position.
    virtual const sf::Vector2f& getPixelPositionFloat() const = 0;
 
+   /// \brief where the player's sprites are placed for the frame being drawn.
+   /// \return the interpolated position, as opposed to the simulation position above.
+   /// \note anything drawn on the player has to use this one, or it ends up a step away from the
+   ///       body it is supposed to sit on.
+   virtual const sf::Vector2f& getSpritePositionPx() const = 0;
+
    /// \brief gets current player position in integer pixel coordinates.
    /// \return pixel-space player position rounded to integers.
    virtual const sf::Vector2i& getPixelPositionInt() const = 0;


### PR DESCRIPTION
`Level::update` stepped the physics world by `PhysicsConfiguration::_time_step` exactly once per
frame, so the world advanced one step however long the frame took: double speed at 120 fps, roughly
eight times over on a desktop with vsync off, and slow motion below 60 - which is why a slow Switch
frame reads as slow motion rather than judder.

### Why it is one class and one loop rather than a change per subsystem

Everything below `Game::update` was written against the opposite assumption: called exactly once per
physics step, with a delta of `_time_step`. The player's jump and dash push with `ApplyForce` /
`ApplyLinearImpulse`, the conveyor belt state is reset immediately before the step, the contact
events are processed immediately after it. Teaching each of those about the frame rate would spread
frame rate compensation across all of them.

So instead this restores the assumption in the one place that drives them. `FixedTimeStep` banks
leftover frame time, and `Game::update` runs the whole simulation update as many whole steps as the
bank affords:

```cpp
const auto simulation_step_count = _fixed_time_step.consumeSteps(dt);
const auto simulation_dt = _fixed_time_step.getStepDuration();

for (auto simulation_step = 0; simulation_step < simulation_step_count; simulation_step++)
{
   EventSerializer::updateAll(simulation_dt);
   _level->update(simulation_dt);
   _player->update(simulation_dt);
   if (!_level || _level->isDirty())
   {
      break;  // lua can hand the level over for teardown from inside the update
   }
}
```

A frame faster than one step runs the loop zero times and draws the same state again. Input polling
and `updateGameState` stay per frame. The step length still comes from
`PhysicsConfiguration::_time_step`, so there is one source of truth.

Two details the accumulator has to get right:

- the step count is **clamped**, and the time behind the clamp is **discarded rather than banked** -
  keeping it leaves the simulation permanently in catch-up after one long frame, and each frame of
  catch-up costs more than the last
- it is **reset when a level finishes loading**, because loading took seconds of real time the
  simulation must not make up for

### Measured

Holding right for 1.5 s from the catacombs start, short enough to stay inside the starting room -
crossing a room boundary starts a fade, and a frame grabbed mid-fade says nothing about how far the
player walked. Differences are against master at 60 fps, over an animation noise floor of 0.18%:

| build | vsync | frame brightness | vs master @ 60 fps |
|---|---|---:|---:|
| master | on (60 fps) | 8.63 | reference |
| master | off (uncapped) | **2.76** | **6.65%** |
| this | on (60 fps) | 9.18 | 0.46% |
| this | off (uncapped) | 8.88 | 0.40% |

Master uncapped is the bug, and it is what proves the test has teeth: the player covers so much
ground in 1.5 s that he crosses the room boundary, hence the dark mid-fade frame. This branch matches
master at 60 fps, so the movement speed and feel are unchanged, and it no longer depends on the frame
rate.

Over a longer walk the two frame rates came out **pixel identical** - equal real time buys an equal
number of fixed steps, so the state matches exactly.

### Consequence worth knowing on the console

This trades slow motion for a lower frame rate. A frame at 25 fps used to run the world at 42% speed
with physics stepping 25 times a second; now it runs at full speed with physics stepping 60 times a
second, i.e. two or three update passes per frame. Correct speed, choppier picture, more cpu per
second - which cuts against the 60 fps work rather than helping it.

### Not covered yet

Only walking has been measured. Jumping, dashing and the other force-driven moves need the same
check - they use `ApplyForce` / `ApplyLinearImpulse`, so they are the cases most sensitive to how
many steps a frame runs.
