### PR TITLE
never scale the view by a fraction

### DIFF
--- a/src/game/config/gameconfiguration.cpp
+++ b/src/game/config/gameconfiguration.cpp
@@ -196,6 +196,26 @@ GameConfiguration& GameConfiguration::getInstance()
    return __instance;
 }
 
+int32_t GameConfiguration::computeViewScale(int32_t video_mode_width, int32_t video_mode_height, int32_t view_width, int32_t view_height)
+{
+   if (view_width <= 0 || view_height <= 0)
+   {
+      Log::Warning() << "invalid view dimensions " << view_width << " x " << view_height;
+      return 1;
+   }
+
+   // integer division is the flooring
+   const auto scale_width = video_mode_width / view_width;
+   const auto scale_height = video_mode_height / view_height;
+
+   return std::max(1, std::min(scale_width, scale_height));
+}
+
+int32_t GameConfiguration::getViewScale() const
+{
+   return computeViewScale(_video_mode_width, _video_mode_height, _view_width, _view_height);
+}
+
 void GameConfiguration::resetAudioDefaults()
 {
    getInstance()._audio_volume_master = getDefaults()._audio_volume_master;

--- a/src/game/config/gameconfiguration.h
+++ b/src/game/config/gameconfiguration.h
@@ -50,6 +50,22 @@ struct GameConfiguration
    /// \param filename destination configuration file path.
    void serializeToFile(const std::string& filename = GamePaths::getPreferencesFile("game.json").string());
 
+   /// \brief largest whole number of screen pixels one view pixel may occupy.
+   /// \param video_mode_width width of the target the view is scaled into.
+   /// \param video_mode_height height of that target.
+   /// \param view_width width of the view, in view pixels.
+   /// \param view_height height of the view, in view pixels.
+   /// \return the scale, floored to a whole number and never below one.
+   /// \note the view is pixel art, so the scale must never be fractional. A window of 2560x1369 has
+   ///       a vertical ratio of 3.8, and rasterising the art at 3.8 puts a one pixel eye across 3.8
+   ///       screen pixels - it comes out as a smear. Flooring to 3 letterboxes the difference
+   ///       instead, and every pixel stays exact.
+   static int32_t computeViewScale(int32_t video_mode_width, int32_t video_mode_height, int32_t view_width, int32_t view_height);
+
+   /// \brief the view scale for the configured video mode and view.
+   /// \return the scale, floored to a whole number and never below one.
+   int32_t getViewScale() const;
+
    /// \brief returns the built-in default configuration values.
    /// \return shared default configuration object.
    static GameConfiguration& getDefaults();

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -299,15 +299,7 @@ void Game::initializeRenderTargets()
 
    // this the render texture size derived from the window dimensions. as opposed to the window
    // dimensions this one takes the view dimensions into regard and preserves an integer multiplier
-   const auto ratio_width = game_config._video_mode_width / game_config._view_width;
-   const auto ratio_height = game_config._video_mode_height / game_config._view_height;
-
-   auto size_ratio = std::min(ratio_width, ratio_height);
-   if (size_ratio < std::numeric_limits<float>::epsilon())
-   {
-      Log::Warning() << "invalid video mode dimensions";
-      size_ratio = 1.0f;
-   }
+   const auto size_ratio = game_config.getViewScale();
 
    const int32_t texture_width = size_ratio * game_config._view_width;
    const int32_t texture_height = size_ratio * game_config._view_height;
@@ -1315,9 +1307,7 @@ void Game::toggleFullScreen()
    _window->setMouseCursorVisible(!config._fullscreen);
 
    // recalculate render texture dimensions and offsets
-   const auto ratio_width = config._video_mode_width / config._view_width;
-   const auto ratio_height = config._video_mode_height / config._view_height;
-   auto size_ratio = std::min(ratio_width, ratio_height);
+   const auto size_ratio = config.getViewScale();
 
    const int32_t texture_width = size_ratio * config._view_width;
    const int32_t texture_height = size_ratio * config._view_height;

--- a/src/game/rendering/rendertargets.cpp
+++ b/src/game/rendering/rendertargets.cpp
@@ -34,10 +34,15 @@ void RenderTargets::create(uint32_t video_mode_width, uint32_t video_mode_height
    stencil_context_settings.stencilBits = 8;
 #endif
 
-   // calculate texture size based on view dimensions
-   const auto ratio_width = video_mode_width / view_width;
-   const auto ratio_height = video_mode_height / view_height;
-   const auto size_ratio = std::min(ratio_width, ratio_height);
+   // calculate texture size based on view dimensions. the scale has to be a whole number: the view
+   // is pixel art, and rasterising it at a fractional multiple lands single art pixels across screen
+   // pixel boundaries, which reads as a blurred edge rather than as a pixel
+   const auto size_ratio = static_cast<float>(GameConfiguration::computeViewScale(
+      static_cast<int32_t>(video_mode_width),
+      static_cast<int32_t>(video_mode_height),
+      static_cast<int32_t>(view_width),
+      static_cast<int32_t>(view_height)
+   ));
    view_to_texture_scale = 1.0f / size_ratio;
 
    const auto texture_width = static_cast<int32_t>(size_ratio * view_width);


### PR DESCRIPTION
The player's left eye was rendering as half a pixel.

The window render texture and the level render targets were sized by
`min(video_mode / view)`, **unfloored**. The comment above the first of them already claimed it
"preserves an integer multiplier" - it did not.

A maximised window on a 1440p display has a client area of **2560x1369**: 4.00 view widths but
**3.80** view heights, so the view was rasterised at 3.8x. The art is pixel art, so at 3.8x a single
art pixel lands across a screen pixel boundary and comes out as a blurred edge. Only window sizes
that happened to be an exact multiple of 640x360 ever looked right.

| | before | after |
|---|---|---|
| logged ratio | 3.8 | **3** |
| window render texture | 2433 x 1369 | **1920 x 1080** |

### Where the fix goes

Flooring the scale letterboxes the remainder, which the final blit already handles: windowed mode
draws the window texture 1:1 at `_render_texture_offset`, and the fullscreen path already floors its
own scale with `static_cast<int32_t>`. So only the texture sizing was ever wrong.

Three places computed that scale and none of them floored it - `Game::initializeRenderTargets`, the
resolution-change path, and `RenderTargets::create`. This adds
`GameConfiguration::computeViewScale` and has all three use it.

### Trade-off worth knowing

In a maximised 2560x1369 window the picture is now 1920x1080 centred, i.e. 320 px bars left and
right and 144 px top and bottom, where before it filled more of the window and was soft. Sharp and
letterboxed rather than large and blurred.

If the bars are not wanted, the other half of this would be snapping the *window* to a multiple of
640x360 on resize, so there is nothing left over to letterbox. That is a separate change and not in
here.
