### PR TITLE
default the player name to the switch account nickname

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,8 @@ set(GAME_FILES
     src/framework/tools/log.h
     src/framework/tools/logthread.cpp
     src/framework/tools/logthread.h
+    src/framework/tools/platformuser.cpp
+    src/framework/tools/platformuser.h
     src/framework/tools/resourcepool.h
     src/framework/tools/scopeexit.cpp
     src/framework/tools/scopeexit.h

--- a/src/framework/tools/platformuser.cpp
+++ b/src/framework/tools/platformuser.cpp
@@ -1,0 +1,99 @@
+#include "platformuser.h"
+
+#ifdef __SWITCH__
+#include <switch.h>
+#endif
+
+#include <cctype>
+#include <cstdlib>
+#include <string_view>
+
+namespace
+{
+
+#ifndef __SWITCH__
+std::string extractFirstName(std::string_view username)
+{
+   // heuristic 1: split CamelCase
+   for (std::size_t i = 1; i < username.size(); ++i)
+   {
+      if (std::isupper(static_cast<unsigned char>(username[i])))
+      {
+         return std::string(username.substr(0, i));
+      }
+   }
+
+   // heuristic 2: try underscores or dots
+   if (auto pos = username.find_first_of("._"); pos != std::string_view::npos)
+   {
+      return std::string(username.substr(0, pos));
+   }
+
+   // fallback: return full username
+   return std::string(username);
+}
+#endif
+
+}  // namespace
+
+namespace PlatformUser
+{
+
+std::string getUserName()
+{
+#ifdef __SWITCH__
+   if (R_FAILED(accountInitialize(AccountServiceType_Application)))
+   {
+      return {};
+   }
+
+   AccountUid account_uid{};
+
+   // a title started from the home menu carries a preselected user; a homebrew title takeover
+   // does not, so fall back to whoever unlocked the console last
+   if (R_FAILED(accountGetPreselectedUser(&account_uid)) && R_FAILED(accountGetLastOpenedUser(&account_uid)))
+   {
+      accountExit();
+      return {};
+   }
+
+   if (account_uid.uid[0] == 0 && account_uid.uid[1] == 0)
+   {
+      accountExit();
+      return {};
+   }
+
+   AccountProfile account_profile{};
+   if (R_FAILED(accountGetProfile(&account_profile, account_uid)))
+   {
+      accountExit();
+      return {};
+   }
+
+   AccountProfileBase account_profile_base{};
+   const auto profile_result = accountProfileGet(&account_profile, nullptr, &account_profile_base);
+   accountProfileClose(&account_profile);
+   accountExit();
+
+   if (R_FAILED(profile_result))
+   {
+      return {};
+   }
+
+   // the nickname field is a fixed size buffer and is not guaranteed to be null terminated
+   const std::string_view nickname(account_profile_base.nickname, sizeof(account_profile_base.nickname));
+   const auto terminator_position = nickname.find('\0');
+
+   // the nickname is a display name the player picked, so it is returned as-is instead of being
+   // run through the first-name heuristics that desktop account names need
+   return std::string(terminator_position == std::string_view::npos ? nickname : nickname.substr(0, terminator_position));
+#else
+   // probably requires a regular expression to filter out the unicode crap
+   auto* u1 = std::getenv("USERNAME");
+   auto* u2 = std::getenv("USER");
+   const std::string raw_name = u1 ? u1 : (u2 ? u2 : "");
+   return extractFirstName(raw_name);
+#endif
+}
+
+}  // namespace PlatformUser

--- a/src/framework/tools/platformuser.h
+++ b/src/framework/tools/platformuser.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+
+///
+/// \brief Resolves the name of the user the game is running for.
+///
+namespace PlatformUser
+{
+///
+/// \brief Returns the platform's idea of the current user's name.
+///
+/// On the switch this is the nickname of the console account the title was launched with. On
+/// desktop it is the account name from the environment, reduced to a first name. The result is
+/// raw platform data: it may be empty and may contain characters the caller cannot display.
+///
+/// \return User name, or an empty string when the platform has none to offer.
+///
+std::string getUserName();
+
+}  // namespace PlatformUser

--- a/src/menus/menuscreennameselect.cpp
+++ b/src/menus/menuscreennameselect.cpp
@@ -1,99 +1,21 @@
 #include "menuscreennameselect.h"
 
 #include "framework/tools/localization.h"
+#include "framework/tools/platformuser.h"
 #include "framework/tools/sfmlstring.h"
 #include "game/state/gamestate.h"
 #include "game/state/savestate.h"
 #include "menu.h"
 
-#ifdef __SWITCH__
-#include <switch.h>
-#endif
-
 #include <algorithm>
 #include <cstdlib>
 #include <iostream>
-#include <string_view>
 
 namespace
 {
 static const int32_t char_width = 19;
 static const int32_t char_height = 24;
 static const size_t max_length = 11;
-
-#ifndef __SWITCH__
-std::string extractFirstName(std::string_view username)
-{
-   // heuristic 1: split CamelCase
-   for (std::size_t i = 1; i < username.size(); ++i)
-   {
-      if (std::isupper(static_cast<unsigned char>(username[i])))
-      {
-         return std::string(username.substr(0, i));
-      }
-   }
-
-   // heuristic 2: try underscores or dots
-   if (auto pos = username.find_first_of("._"); pos != std::string_view::npos)
-   {
-      return std::string(username.substr(0, pos));
-   }
-
-   // fallback: return full username
-   return std::string(username);
-}
-#endif
-
-#ifdef __SWITCH__
-/// \brief reads the nickname of the console account the game was launched with.
-/// \return the account nickname, or an empty string if the account service is unavailable.
-std::string retrieveConsoleNickname()
-{
-   if (R_FAILED(accountInitialize(AccountServiceType_Application)))
-   {
-      return {};
-   }
-
-   AccountUid account_uid{};
-
-   // a title started from the home menu carries a preselected user; a homebrew title takeover
-   // does not, so fall back to whoever unlocked the console last
-   if (R_FAILED(accountGetPreselectedUser(&account_uid)) && R_FAILED(accountGetLastOpenedUser(&account_uid)))
-   {
-      accountExit();
-      return {};
-   }
-
-   if (account_uid.uid[0] == 0 && account_uid.uid[1] == 0)
-   {
-      accountExit();
-      return {};
-   }
-
-   AccountProfile account_profile{};
-   if (R_FAILED(accountGetProfile(&account_profile, account_uid)))
-   {
-      accountExit();
-      return {};
-   }
-
-   AccountProfileBase account_profile_base{};
-   const auto profile_result = accountProfileGet(&account_profile, nullptr, &account_profile_base);
-   accountProfileClose(&account_profile);
-   accountExit();
-
-   if (R_FAILED(profile_result))
-   {
-      return {};
-   }
-
-   // the nickname field is a fixed size buffer and is not guaranteed to be null terminated
-   const std::string_view nickname(account_profile_base.nickname, sizeof(account_profile_base.nickname));
-   const auto terminator_position = nickname.find('\0');
-
-   return std::string(terminator_position == std::string_view::npos ? nickname : nickname.substr(0, terminator_position));
-}
-#endif
 }  // namespace
 
 MenuScreenNameSelect::MenuScreenNameSelect()
@@ -315,22 +237,10 @@ std::string MenuScreenNameSelect::keepSupportedChars(std::string_view raw_name) 
 
 void MenuScreenNameSelect::retrieveUsername()
 {
-#ifdef __SWITCH__
-   // the console nickname is already a display name the player picked, so it is taken as-is
-   // instead of being run through the first-name heuristics that desktop account names need
-   std::string raw_name = retrieveConsoleNickname();
-#else
-   // probably requires a regular expression to filter out the unicode crap
-   auto* u1 = std::getenv("USERNAME");
-   auto* u2 = std::getenv("USER");
-   std::string raw_name = u1 ? u1 : (u2 ? u2 : "");
-   raw_name = extractFirstName(raw_name);
-#endif
-
    // the name is edited with the on-screen character grid, so the suggestion has to consist of
    // characters that grid can produce: anything else has no glyph in the menu font and could
    // not be typed back in after a delete
-   _name = keepSupportedChars(raw_name);
+   _name = keepSupportedChars(PlatformUser::getUserName());
 
    if (!_name.empty())
    {

--- a/src/menus/menuscreennameselect.cpp
+++ b/src/menus/menuscreennameselect.cpp
@@ -6,8 +6,14 @@
 #include "game/state/savestate.h"
 #include "menu.h"
 
+#ifdef __SWITCH__
+#include <switch.h>
+#endif
+
+#include <algorithm>
 #include <cstdlib>
 #include <iostream>
+#include <string_view>
 
 namespace
 {
@@ -15,6 +21,7 @@ static const int32_t char_width = 19;
 static const int32_t char_height = 24;
 static const size_t max_length = 11;
 
+#ifndef __SWITCH__
 std::string extractFirstName(std::string_view username)
 {
    // heuristic 1: split CamelCase
@@ -35,6 +42,58 @@ std::string extractFirstName(std::string_view username)
    // fallback: return full username
    return std::string(username);
 }
+#endif
+
+#ifdef __SWITCH__
+/// \brief reads the nickname of the console account the game was launched with.
+/// \return the account nickname, or an empty string if the account service is unavailable.
+std::string retrieveConsoleNickname()
+{
+   if (R_FAILED(accountInitialize(AccountServiceType_Application)))
+   {
+      return {};
+   }
+
+   AccountUid account_uid{};
+
+   // a title started from the home menu carries a preselected user; a homebrew title takeover
+   // does not, so fall back to whoever unlocked the console last
+   if (R_FAILED(accountGetPreselectedUser(&account_uid)) && R_FAILED(accountGetLastOpenedUser(&account_uid)))
+   {
+      accountExit();
+      return {};
+   }
+
+   if (account_uid.uid[0] == 0 && account_uid.uid[1] == 0)
+   {
+      accountExit();
+      return {};
+   }
+
+   AccountProfile account_profile{};
+   if (R_FAILED(accountGetProfile(&account_profile, account_uid)))
+   {
+      accountExit();
+      return {};
+   }
+
+   AccountProfileBase account_profile_base{};
+   const auto profile_result = accountProfileGet(&account_profile, nullptr, &account_profile_base);
+   accountProfileClose(&account_profile);
+   accountExit();
+
+   if (R_FAILED(profile_result))
+   {
+      return {};
+   }
+
+   // the nickname field is a fixed size buffer and is not guaranteed to be null terminated
+   const std::string_view nickname(account_profile_base.nickname, sizeof(account_profile_base.nickname));
+   const auto terminator_position = nickname.find('\0');
+
+   return std::string(terminator_position == std::string_view::npos ? nickname : nickname.substr(0, terminator_position));
+}
+#endif
 }  // namespace
 
 MenuScreenNameSelect::MenuScreenNameSelect()
@@ -234,13 +293,44 @@ void MenuScreenNameSelect::controllerButtonY()
    appendChar(c);
 }
 
+std::string MenuScreenNameSelect::keepSupportedChars(std::string_view raw_name) const
+{
+   std::string supported_name;
+
+   for (const auto raw_char : raw_name)
+   {
+      if (supported_name.size() == max_length)
+      {
+         break;
+      }
+
+      if (std::find(_chars.begin(), _chars.end(), raw_char) != _chars.end())
+      {
+         supported_name += raw_char;
+      }
+   }
+
+   return supported_name;
+}
+
 void MenuScreenNameSelect::retrieveUsername()
 {
+#ifdef __SWITCH__
+   // the console nickname is already a display name the player picked, so it is taken as-is
+   // instead of being run through the first-name heuristics that desktop account names need
+   std::string raw_name = retrieveConsoleNickname();
+#else
    // probably requires a regular expression to filter out the unicode crap
    auto* u1 = std::getenv("USERNAME");
    auto* u2 = std::getenv("USER");
    std::string raw_name = u1 ? u1 : (u2 ? u2 : "");
-   _name = extractFirstName(raw_name);
+   raw_name = extractFirstName(raw_name);
+#endif
+
+   // the name is edited with the on-screen character grid, so the suggestion has to consist of
+   // characters that grid can produce: anything else has no glyph in the menu font and could
+   // not be typed back in after a delete
+   _name = keepSupportedChars(raw_name);
 
    if (!_name.empty())
    {

--- a/src/menus/menuscreennameselect.h
+++ b/src/menus/menuscreennameselect.h
@@ -3,6 +3,7 @@
 #include "menuscreen.h"
 
 #include <array>
+#include <string_view>
 
 /// \brief name-entry screen that edits the player name before starting a new save slot.
 class MenuScreenNameSelect : public MenuScreen
@@ -65,8 +66,13 @@ private:
    /// \brief centers the rendered name text inside the name field.
    void updateText();
 
-   /// \brief seeds the entered name from environment username heuristics.
+   /// \brief seeds the entered name from the console account nickname or environment username heuristics.
    void retrieveUsername();
+
+   /// \brief strips every character the on-screen character grid cannot produce and clamps the length.
+   /// \param raw_name name as it came from the console account or from the environment.
+   /// \return name reduced to characters of the on-screen character grid.
+   std::string keepSupportedChars(std::string_view raw_name) const;
 
    std::string _name;
    std::array<char, 13 * 5> _chars;

--- a/src/menus/menuscreennameselect.h
+++ b/src/menus/menuscreennameselect.h
@@ -66,11 +66,11 @@ private:
    /// \brief centers the rendered name text inside the name field.
    void updateText();
 
-   /// \brief seeds the entered name from the console account nickname or environment username heuristics.
+   /// \brief seeds the entered name from the platform's user name.
    void retrieveUsername();
 
    /// \brief strips every character the on-screen character grid cannot produce and clamps the length.
-   /// \param raw_name name as it came from the console account or from the environment.
+   /// \param raw_name name as it came from the platform.
    /// \return name reduced to characters of the on-screen character grid.
    std::string keepSupportedChars(std::string_view raw_name) const;
 


### PR DESCRIPTION
The name select screen seeded its suggestion from the `USERNAME` / `USER` environment variables. Neither exists on the Switch, so the field came up empty there and every player had to type a name from scratch on the character grid.

### `PlatformUser`

`src/framework/tools/platformuser.{h,cpp}` — a namespace of free functions mirroring `GamePaths`: one thing resolved per platform, so the caller stays platform neutral.

```cpp
namespace PlatformUser
{
std::string getUserName();
}
```

On `__SWITCH__` that reads the console account nickname through libnx' account service:

- `accountGetPreselectedUser` first, since a title started from the home menu carries a preselected user
- `accountGetLastOpenedUser` as the fallback, because a homebrew title takeover does not
- `accountGetProfile` / `accountProfileGet` for the profile, and `nickname` off `AccountProfileBase`

`nickname` is a fixed 32 byte buffer that is not guaranteed to be null terminated, so it is bounded by an explicit terminator search. Every failure path returns an empty string, which leaves the screen behaving exactly as it does today.

The nickname is returned as-is: it is a display name the player already picked, so it skips the CamelCase / underscore first-name heuristics that desktop account names need — those exist to cut `MatthiasVarnholt` down to `Matthias`, and a nickname is already short. The desktop branch keeps those heuristics, moved over unchanged.

This also gets `<switch.h>` and a system service call out of a menu file, which was the wrong layer for them.

### Filtering

A nickname can hold anything the console keyboard allows — kana, emoji, spaces — so the suggestion passes through `keepSupportedChars`, which keeps only characters that appear in the screen's own `_chars` grid and clamps to `max_length`. Filtering against the grid rather than a character class or a font query is the point: a suggested character the grid cannot produce has no glyph in the menu font *and* could not be typed back in after a delete.

That stays on the screen rather than moving into `PlatformUser`, since it is tied to the character grid and field length, not to the platform. `retrieveUsername()` now has no preprocessor branches at all.

### Testing

- Both changed translation units compile clean with MSVC (only the pre-existing `ItemSystem` C4099 warning).
- The desktop path is unchanged apart from the new filter, which is a no-op for ASCII account names.
- **The Switch path is not build-verified** — the devkitPro container was not reachable here (Docker daemon down), so `build_switch.bat` has not run against this branch, and the nickname has not been read on hardware.
