### PR TITLE
let the loader context die before the main thread draws the new level

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -474,66 +474,79 @@ void Game::processPendingLevelLoad()
 
    const auto level_loader = [this, loading_mode]()
    {
-   // create an opengl context for this thread
+      // the loader context lives in a scope of its own so that it is gone - deactivated *and*
+      // destroyed - before _level_loading_finished lets the main thread start drawing. see the note
+      // at the end of the scope
+      {
+         // create an opengl context for this thread
 #ifndef DECEPTUS_VRSFML
-      sf::Context loader_context;
-      loader_context.setActive(true);
+         sf::Context loader_context;
+         loader_context.setActive(true);
 #endif
 
-      // load level
-      const auto level_item = Levels::readLevelItem(SaveState::getCurrent()._level_index);
-      _level = std::make_shared<Level>(_render_targets);
-      LevelRegistry::setCurrent(_level);
-      _level->setDescriptionFilename(level_item._level_name);
-      _level->setLoadingMode(loading_mode);
-      _level->initialize();
+         // load level
+         const auto level_item = Levels::readLevelItem(SaveState::getCurrent()._level_index);
+         _level = std::make_shared<Level>(_render_targets);
+         LevelRegistry::setCurrent(_level);
+         _level->setDescriptionFilename(level_item._level_name);
+         _level->setLoadingMode(loading_mode);
+         _level->initialize();
 
-      // put the player in there
-      _player->setWorld(_level->getWorld());
-      _player->initializeLevel();
+         // put the player in there
+         _player->setWorld(_level->getWorld());
+         _player->initializeLevel();
 
-      // re-equip items now that level and player are both live; items deserialized before the
-      // level was ready (e.g. head torch) had their onEquipped() silently no-op at that point
-      SaveState::getPlayerInfo()._items.reinitializeEquippedItems();
+         // re-equip items now that level and player are both live; items deserialized before the
+         // level was ready (e.g. head torch) had their onEquipped() silently no-op at that point
+         SaveState::getPlayerInfo()._items.reinitializeEquippedItems();
 
-      // jump back to stored position, that's only for debugging purposes, not for checkpoints
-      if (_restore_previous_position)
-      {
-         _restore_previous_position = false;
-         _player->setBodyViaPixelPosition(_stored_position.x, _stored_position.y);
+         // jump back to stored position, that's only for debugging purposes, not for checkpoints
+         if (_restore_previous_position)
+         {
+            _restore_previous_position = false;
+            _player->setBodyViaPixelPosition(_stored_position.x, _stored_position.y);
+         }
+
+         _player->updatePixelRect();
+
+         Log::Info() << "level loading finished: " << level_item._level_name;
+
+         // loading took seconds of real time that the simulation must not make up for, or the first
+         // frame back would run its whole catch-up allowance at once
+         _fixed_time_step.reset();
+
+         playLevelMusic();
+
+         // before synchronizing the camera with the player position, the camera needs to know its room limitations
+         _level->syncRoom();
+
+         CameraSystem::getInstance().syncNow();
+         GameClock::getInstance().reset();
+
+         _info_layer->setLoading(false);
+
+         // notify listeners
+         for (const auto& callback : _level_loaded_callbacks)
+         {
+            callback();
+         }
+
+         _level_loaded_callbacks.clear();
+
+#ifndef DECEPTUS_VRSFML
+         loader_context.setActive(false);
+#endif
       }
 
-      _player->updatePixelRect();
-
-      Log::Info() << "level loading finished: " << level_item._level_name;
-
+      // only now is the loader out of the driver, and only now may the main thread draw.
+      //
+      // raising this flag is what releases Game::update and Game::draw onto the new level, so raising
+      // it while the loader was still inside its scope let the main thread draw at the same moment the
+      // context destructor ran. ~WglContext calls wglMakeCurrent and wglDeleteContext, both of which
+      // take the driver's own lock, and a draw already inside that lock never gets out: the main thread
+      // sits in sf::RenderTarget::drawPrimitives, the loader in sf::Context::~Context, and whichever got
+      // there first decides whether the frame lives. It hung about half of the time on an Intel iGPU.
       _level_loading_finished = true;
-
-      // loading took seconds of real time that the simulation must not make up for, or the first
-      // frame back would run its whole catch-up allowance at once
-      _fixed_time_step.reset();
-
-      playLevelMusic();
-
-      // before synchronizing the camera with the player position, the camera needs to know its room limitations
-      _level->syncRoom();
-
-      CameraSystem::getInstance().syncNow();
-      GameClock::getInstance().reset();
-
-      _info_layer->setLoading(false);
-
-      // notify listeners
-      for (const auto& callback : _level_loaded_callbacks)
-      {
-         callback();
-      }
-
-      _level_loaded_callbacks.clear();
-
-#ifndef DECEPTUS_VRSFML
-      loader_context.setActive(false);
-#endif
    };
 
    // Loading synchronously on the VRSFML targets is not a threading limitation, whatever the


### PR DESCRIPTION
The game deadlocked about half of all level loads, a couple of seconds after `level loading finished`, and went Not Responding. It happens on master and is unrelated to any feature work.

## Cause

`processPendingLevelLoad` runs the loader on a `std::async` thread that brings up an `sf::Context` of its own. `_level_loading_finished` is what releases `Game::update` and `Game::draw` onto the new level, and it was raised in the middle of that lambda, while the loader's context was still alive. The context is then destroyed when the lambda's scope ends — by which time the main thread is already drawing.

`~WglContext` calls `wglMakeCurrent` and `wglDeleteContext`. Both take the GL driver's own lock, and a draw already inside that lock never comes out. Whichever thread got there first decided whether the frame lived.

Symbolised stacks from a hung process:

```
main thread    Game::loop -> Game::draw (game.cpp:755) -> Level::draw (level.cpp:1763)
               -> sf::Sprite::draw -> sf::RenderTarget::drawPrimitives   [blocked in the GL driver]
loader thread  processPendingLevelLoad's lambda (game.cpp:547)
               -> sf::Context::~Context -> sf::priv::WglContext::~WglContext   [blocked]
```

## Change

The loader context gets a scope of its own, and the flag is raised after that scope closes — so the loader is out of the driver before the first frame of the new level is drawn. One file, no behaviour change beyond the ordering.

## Evidence

`L` is bound to `reloadLevel()`, so reloading in a loop hits the window repeatedly.

| build | result |
| --- | --- |
| before, 10x level reload | hung on the first reload |
| after, 10x level reload | 11 loads, all clean |
| before, repeated launches | hung on attempt 0 |
| after, repeated launches | 8 of 8 clean |

Reproduced on an Intel iGPU. Detect the hang with `IsHungAppWindow` or the frozen fps counter in the window title — not with `PrintWindow`, which can wedge the driver by itself and so makes a useless observer.

## Other targets

The loader context is inside `#ifndef DECEPTUS_VRSFML`, and Switch and web take the synchronous `level_loader()` path with no second context, so the change is inert there. Verified anyway: the Switch build compiles, and in Ryujinx it boots, loads a level, walks and transitions rooms at 120 FPS.