### PR TITLE
keep debug info in windows release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -874,6 +874,16 @@ add_executable(
 target_sources(deceptus PRIVATE ${THIRD_PARTY_FILES})
 
 # set up third party libraries
+# release builds keep their debug info, or a crash dump is just a list of raw offsets. this sits ahead
+# of the dependencies so sfml's frames get line numbers too, which is usually where the interesting
+# ones are. /Zi does not affect optimisation. windows only, the other targets bring their own toolchains
+if(MSVC)
+    string(APPEND CMAKE_C_FLAGS_RELEASE " /Zi /FS")
+    string(APPEND CMAKE_CXX_FLAGS_RELEASE " /Zi /FS")
+    string(APPEND CMAKE_EXE_LINKER_FLAGS_RELEASE " /DEBUG")
+    string(APPEND CMAKE_SHARED_LINKER_FLAGS_RELEASE " /DEBUG")
+endif()
+
 include(FetchContent)
 
 # SFML configuration


### PR DESCRIPTION
Release builds now carry `/Zi` and `/DEBUG` on MSVC, so a crash or hang dump symbolises to files and lines instead of `deceptus+0x2618a0`.

The flags sit ahead of the dependency declarations rather than on the `deceptus` target, so SFML's frames get line numbers too — that is what made the stacks in #450 readable. The `RelWithDebInfo` option that was already there never fired, since `Release` is what gets built.

`/Zi` does not affect optimisation. Windows only; Switch and web are untouched.