### PR TITLE
smooth the blit only when it actually resamples

### DIFF
--- a/src/game/config/gameconfiguration.cpp
+++ b/src/game/config/gameconfiguration.cpp
@@ -247,9 +247,16 @@ GameConfiguration::WindowImagePlacement GameConfiguration::computeWindowImagePla
          .scale_x = 1.0f,
          .scale_y = 1.0f,
          .offset_x = static_cast<float>(offset_x),
-         .offset_y = static_cast<float>(offset_y)
+         .offset_y = static_cast<float>(offset_y),
+         .resamples = false
       };
    }
+
+   // a scale is only worth interpolating when it is not a whole number. keeping this with the placement
+   // rather than deriving it from the flags matters: a window whose height is an exact multiple of the
+   // view pins the uniform factor to exactly 1, so keep aspect ends up blitting 1:1 just as pixel
+   // precision does, and smoothing a 1:1 blit can only make a scrolling image crawl
+   const auto is_whole_number = [](float value) { return static_cast<float>(static_cast<int32_t>(value)) == value; };
 
    // both remaining modes resample, so here sub-pixel centring is the more accurate answer rather than
    // the thing to avoid, and the arithmetic runs in float
@@ -268,7 +275,8 @@ GameConfiguration::WindowImagePlacement GameConfiguration::computeWindowImagePla
          .scale_x = fill_scale_x,
          .scale_y = fill_scale_y,
          .offset_x = 0.0f,
-         .offset_y = 0.0f
+         .offset_y = 0.0f,
+         .resamples = !is_whole_number(fill_scale_x) || !is_whole_number(fill_scale_y)
       };
    }
 
@@ -284,7 +292,8 @@ GameConfiguration::WindowImagePlacement GameConfiguration::computeWindowImagePla
       .scale_x = uniform_scale,
       .scale_y = uniform_scale,
       .offset_x = (window_width - image_width) * 0.5f,
-      .offset_y = (window_height - image_height) * 0.5f
+      .offset_y = (window_height - image_height) * 0.5f,
+      .resamples = !is_whole_number(uniform_scale)
    };
 }
 

--- a/src/game/config/gameconfiguration.cpp
+++ b/src/game/config/gameconfiguration.cpp
@@ -1,6 +1,7 @@
 #include "gameconfiguration.h"
 
 #include <algorithm>
+#include <cmath>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -256,7 +257,7 @@ GameConfiguration::WindowImagePlacement GameConfiguration::computeWindowImagePla
    // rather than deriving it from the flags matters: a window whose height is an exact multiple of the
    // view pins the uniform factor to exactly 1, so keep aspect ends up blitting 1:1 just as pixel
    // precision does, and smoothing a 1:1 blit can only make a scrolling image crawl
-   const auto is_whole_number = [](float value) { return static_cast<float>(static_cast<int32_t>(value)) == value; };
+   const auto is_whole_number = [](float value) { return value == std::floor(value); };
 
    // both remaining modes resample, so here sub-pixel centring is the more accurate answer rather than
    // the thing to avoid, and the arithmetic runs in float

--- a/src/game/config/gameconfiguration.h
+++ b/src/game/config/gameconfiguration.h
@@ -84,6 +84,10 @@ struct GameConfiguration
       float scale_y = 1.0f;        //!< vertical factor the render texture is blitted with
       float offset_x = 0.0f;       //!< distance from the left window edge to the left edge of the blit
       float offset_y = 0.0f;       //!< distance from the top window edge to the top edge of the blit
+
+      //!< whether the blit lands view pixels on fractions of a screen pixel. only then is there
+      //!< anything between texels to interpolate, and only then is smoothing worth having
+      bool resamples = false;
    };
 
    /// \brief sizes the window render texture and works out the blit that puts it into the window.

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -326,9 +326,10 @@ void Game::initializeRenderTargets()
 #ifndef DECEPTUS_VRSFML
    // once the blit scale is not a whole number, nearest neighbour hands some view pixels one more screen
    // pixel than their neighbours, and that uneven pattern crawls across the image as the camera moves.
-   // smoothing spreads the remainder out instead. a pixel precise blit runs at scale 1 and must not be
-   // smoothed at all, or every pixel of the frame gets resampled for nothing
-   _window_render_texture->setSmooth(!game_config._preserve_pixel_precision);
+   // smoothing spreads the remainder out instead. a whole-number blit has nothing between texels to
+   // interpolate, so smoothing it can only smear a moving image - which is why this follows the blit and
+   // not the option: keep aspect lands on 1:1 whenever one axis is an exact multiple of the view
+   _window_render_texture->setSmooth(placement.resamples);
 #endif
 
    if (_level)
@@ -1402,7 +1403,7 @@ void Game::applyScalingOptions()
       adoptWindowSize(placement.texture_width, placement.texture_height);
    }
 
-   _window_render_texture->setSmooth(!config._preserve_pixel_precision);
+   _window_render_texture->setSmooth(config.computeWindowImagePlacement().resamples);
 #endif
 }
 


### PR DESCRIPTION
Follow-up to #452, which was merged without this.

Filtering was tied to the option rather than to the blit: anything but pixel precision turned `GL_LINEAR` on. But keep aspect lands on an exact 1:1 blit whenever one axis is a whole multiple of the view — fullscreen at 1920x1200 gives a uniform factor of exactly 1.0 and an offset of `(0, 60)`, which is bit for bit what pixel precision produces.

Smoothing that has nothing to interpolate. The sampler still blends, so any sub-texel misalignment becomes a weighting that shifts as the content moves underneath it, and scrolling edges crawl. Nearest neighbour snaps instead — which is why the same scene looked clean under pixel precision and jittery under keep aspect at the same resolution.

`WindowImagePlacement` now reports whether it resamples, and both `setSmooth` sites follow that. Whole-number scales — 1:1 and integer magnification alike — stay nearest in every mode; only a genuinely fractional scale is smoothed.

Verified at 1920x1200 fullscreen: ratio 3, render texture 1920x1080, unchanged geometry.