### PR TITLE
say copy rather than blit in the scaling comments

### DIFF
--- a/src/game/config/gameconfiguration.cpp
+++ b/src/game/config/gameconfiguration.cpp
@@ -226,7 +226,7 @@ GameConfiguration::WindowImagePlacement GameConfiguration::computeWindowImagePla
 {
    // the render texture is a whole multiple of the view in every mode, not just the pixel precise one.
    // the view is pixel art and rasterising it at a fraction of a pixel is what turns it to mush, so the
-   // fractional part of the fit is left to the blit, where it resamples an already finished image
+   // fractional part of the fit is left to the copy, where it resamples an already finished image
    const auto integer_scale = getViewScale();
    const auto texture_width = integer_scale * _view_width;
    const auto texture_height = integer_scale * _view_height;
@@ -236,7 +236,7 @@ GameConfiguration::WindowImagePlacement GameConfiguration::computeWindowImagePla
    if (_preserve_pixel_precision)
    {
       // whole numbers the entire way through. the offset has to land on a whole pixel as well: a window
-      // with an odd amount of space left over puts the true centre at x.5, and blitting a texture there
+      // with an odd amount of space left over puts the true centre at x.5, and copying a texture there
       // resamples every pixel of the frame - the one thing this mode exists to prevent. integer division
       // floors it instead, which leaves one bar a single pixel wider than the other
       const auto offset_x = (_video_mode_width - texture_width) / 2;
@@ -255,8 +255,8 @@ GameConfiguration::WindowImagePlacement GameConfiguration::computeWindowImagePla
 
    // a scale is only worth interpolating when it is not a whole number. keeping this with the placement
    // rather than deriving it from the flags matters: a window whose height is an exact multiple of the
-   // view pins the uniform factor to exactly 1, so keep aspect ends up blitting 1:1 just as pixel
-   // precision does, and smoothing a 1:1 blit can only make a scrolling image crawl
+   // view pins the uniform factor to exactly 1, so keep aspect ends up copying 1:1 just as pixel
+   // precision does, and smoothing a 1:1 copy can only make a scrolling image crawl
    const auto is_whole_number = [](float value) { return value == std::floor(value); };
 
    // both remaining modes resample, so here sub-pixel centring is the more accurate answer rather than

--- a/src/game/config/gameconfiguration.h
+++ b/src/game/config/gameconfiguration.h
@@ -17,8 +17,8 @@ struct GameConfiguration
    int32_t _view_height = 360;
    bool _fullscreen = false;
 
-   //!< blits the view at a whole number scale, so one view pixel always covers a whole number of screen
-   //!< pixels and nothing is resampled. whatever space is left over in the window becomes bars
+   //!< copies the view onto the window at a whole number scale, so one view pixel always covers a
+   //!< whole number of screen pixels and nothing is resampled. the space left over becomes bars
    bool _preserve_pixel_precision = false;
 
    //!< scales both axes by the same factor, so the view keeps its shape instead of being stretched to the
@@ -80,19 +80,19 @@ struct GameConfiguration
    {
       int32_t texture_width = 0;   //!< width of the render texture, always a whole multiple of the view
       int32_t texture_height = 0;  //!< height of the render texture, always a whole multiple of the view
-      float scale_x = 1.0f;        //!< horizontal factor the render texture is blitted with
-      float scale_y = 1.0f;        //!< vertical factor the render texture is blitted with
-      float offset_x = 0.0f;       //!< distance from the left window edge to the left edge of the blit
-      float offset_y = 0.0f;       //!< distance from the top window edge to the top edge of the blit
+      float scale_x = 1.0f;        //!< horizontal factor the render texture is copied with
+      float scale_y = 1.0f;        //!< vertical factor the render texture is copied with
+      float offset_x = 0.0f;       //!< distance from the left window edge to the left edge of the copy
+      float offset_y = 0.0f;       //!< distance from the top window edge to the top edge of the copy
 
-      //!< whether the blit lands view pixels on fractions of a screen pixel. only then is there
+      //!< whether the copy lands view pixels on fractions of a screen pixel. only then is there
       //!< anything between texels to interpolate, and only then is smoothing worth having
       bool resamples = false;
    };
 
-   /// \brief sizes the window render texture and works out the blit that puts it into the window.
-   /// \return the texture size together with the scale and offset the blit runs at.
-   /// \note the render texture is a whole multiple of the view in every behavior. only the blit differs,
+   /// \brief sizes the window render texture and works out the copy that puts it onto the window.
+   /// \return the texture size together with the scale and offset the copy runs at.
+   /// \note the render texture is a whole multiple of the view in every behavior. only the copy differs,
    ///       so switching behavior never resizes a render target or changes what the level draws.
    WindowImagePlacement computeWindowImagePlacement() const;
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -890,7 +890,7 @@ void Game::draw()
 #endif
 
 #ifdef DEVELOPMENT_MODE
-   _draw_section_timer.mark("window blit");
+   _draw_section_timer.mark("window copy");
 #endif
 
 #ifdef DEVELOPMENT_MODE

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -324,10 +324,10 @@ void Game::initializeRenderTargets()
    Log::Info() << "created window render texture: " << texture_width << " x " << texture_height;
 
 #ifndef DECEPTUS_VRSFML
-   // once the blit scale is not a whole number, nearest neighbour hands some view pixels one more screen
+   // once the copy scale is not a whole number, nearest neighbour hands some view pixels one more screen
    // pixel than their neighbours, and that uneven pattern crawls across the image as the camera moves.
-   // smoothing spreads the remainder out instead. a whole-number blit has nothing between texels to
-   // interpolate, so smoothing it can only smear a moving image - which is why this follows the blit and
+   // smoothing spreads the remainder out instead. a whole-number copy has nothing between texels to
+   // interpolate, so smoothing it can only smear a moving image - which is why this follows the copy and
    // not the option: keep aspect lands on 1:1 whenever one axis is an exact multiple of the view
    _window_render_texture->setSmooth(placement.resamples);
 #endif
@@ -1378,9 +1378,9 @@ void Game::toggleFullScreen()
 void Game::applyScalingOptions()
 {
 #ifndef DECEPTUS_VRSFML
-   // the scaling options move nothing but the blit, and the blit reads them fresh out of the config every
+   // the scaling options move nothing but the copy, and the copy reads them fresh out of the config every
    // frame, so there is nothing to rebuild here. the one piece of state that has to follow them is the
-   // filtering: a fractional blit has to interpolate and a pixel precise one must not.
+   // filtering: a fractional copy has to interpolate and a pixel precise one must not.
    //
    // this used to call initializeRenderTargets, which tore down and rebuilt every render texture on each
    // keypress even though not one of them depends on these options - their sizes come from the whole
@@ -1448,7 +1448,7 @@ void Game::adoptWindowSize(int32_t width, int32_t height)
    }
 
    // every render target is sized as a whole multiple of the view rather than to the window, so dragging
-   // a border around within one multiple leaves all of them at the right size and only moves the blit.
+   // a border around within one multiple leaves all of them at the right size and only moves the copy.
    // rebuilding the whole set per resize event would make dragging stutter for nothing
    if (config.getViewScale() == previous_view_scale)
    {


### PR DESCRIPTION
Same operation, clearer word: the finished frame is copied onto the window. Comments only, plus one profiling label.

- 19 comments across `gameconfiguration.h`, `gameconfiguration.cpp` and `game.cpp` — all of them written for the window scaling work in #452 and #455
- the `_draw_section_timer` section `"window blit"` renamed to `"window copy"`. Nothing reads it — no script, doc or config looks the label up — so this only changes the text in the profiling output

`level.cpp`'s `"gamma blit"` and the `postprocessingpass` doc comments are pre-existing and left alone.