### PR TITLE
make scrolling smooth: whole simulation steps per frame, and a camera that leads the player

### DIFF
--- a/data/config/camera.json
+++ b/data/config/camera.json
@@ -3,6 +3,7 @@
         "back_in_bounds_tolerance_x": 10,
         "back_in_bounds_tolerance_y": 10,
         "velocity_factor_x": 4.0,
+        "lead_factor_x": 0.8,
         "follow_player_orientation" : false,
         "velocity_factor_y": 3.0,
         "focus_zone_divider": 100.0,

--- a/src/game/camera/cameraroomlock.cpp
+++ b/src/game/camera/cameraroomlock.cpp
@@ -149,6 +149,29 @@ bool CameraRoomLock::correctedCamera(float& x, float& y, float focus_offset)
    return _locked_left || _locked_right || _locked_top || _locked_bottom;
 }
 
+std::optional<CameraRoomLock::HorizontalLimits>
+CameraRoomLock::horizontalCameraLimits(const sf::Vector2f& player_position_px, float focus_offset)
+{
+   if (!_room || _room->_sub_rooms.empty())
+   {
+      return std::nullopt;
+   }
+
+   const auto sub_room_it = _room->findSubRoom(player_position_px);
+   if (sub_room_it == _room->_sub_rooms.end())
+   {
+      return std::nullopt;
+   }
+
+   const auto& sub_room = *sub_room_it;
+   const auto half_width = static_cast<float>(GameConfiguration::getInstance()._view_width / 2.0f);
+
+   return HorizontalLimits{
+      ._left_px = sub_room._rect.position.x + half_width + focus_offset,
+      ._right_px = sub_room._rect.position.x + sub_room._rect.size.x - half_width + focus_offset
+   };
+}
+
 void CameraRoomLock::setRoom(const std::shared_ptr<Room>& room)
 {
    _room = room;

--- a/src/game/camera/cameraroomlock.h
+++ b/src/game/camera/cameraroomlock.h
@@ -2,10 +2,28 @@
 
 #include <array>
 #include <memory>
+#include <optional>
 #include "game/level/room.h"
 
 namespace CameraRoomLock
 {
+
+/// \brief the range a camera center may take without the view reaching outside the room.
+struct HorizontalLimits
+{
+   float _left_px{0.0f};   //!< leftmost camera center that still keeps the view inside the room
+   float _right_px{0.0f};  //!< rightmost camera center that still keeps the view inside the room
+};
+
+/// \brief returns the horizontal range the camera center may take inside the player's sub-room.
+/// \param player_position_px player position, used to pick the sub-room to measure against.
+/// \param focus_offset horizontal focus-zone shift applied by the camera system.
+/// \return the range, or nothing when there is no room or no sub-room holding the player.
+/// \note deliberately looked up at the player rather than at the position being limited. The point
+///       being limited is by definition the one that may already be outside, and a lookup there finds
+///       no sub-room and would report no limits at all - exactly when they are needed.
+std::optional<HorizontalLimits> horizontalCameraLimits(const sf::Vector2f& player_position_px, float focus_offset);
+
 /// \brief checks whether the current camera view extends beyond the active sub-room bounds.
 /// \return boundary flags ordered as up, down, left, right; true means the view crosses that side.
 std::array<bool, 4> checkRoomBoundaries();

--- a/src/game/camera/camerasystem.cpp
+++ b/src/game/camera/camerasystem.cpp
@@ -68,11 +68,58 @@ void CameraSystem::updateX(const sf::Time& delta_time)
    const auto& camera_config = CameraSystemConfiguration::getInstance();
 
    auto player = PlayerRegistry::getFirst();
-   auto player_x_px = player->getPixelPositionFloat().x;
-   auto player_y_px = player->getPixelPositionFloat().y;
-   const auto room_corrected = CameraRoomLock::correctedCamera(player_x_px, player_y_px, _focus_offset_px);
-   _dx_px = (player_x_px - _x_px);
-   const auto dx_px = (_dx_px)*delta_time.asSeconds() * camera_config.getCameraVelocityFactorX();
+   const auto player_position_px = player->getPixelPositionFloat();
+   const auto velocity_factor = camera_config.getCameraVelocityFactorX();
+
+   // how fast the player is moving, in the camera's own units and time base. Read off two positions
+   // rather than taken from the physics body on purpose: the box2d delta is not the step duration, see
+   // FixedTimeStep, so a velocity in box2d units would need a conversion that has nothing to do with
+   // the camera
+   const auto player_velocity_px_per_s = (player_position_px.x - _previous_player_x_px) / delta_time.asSeconds();
+   _previous_player_x_px = player_position_px.x;
+
+   // the aim point is carried ahead of the player by the distance the camera needs in order to travel
+   // at the player's speed. The camera closes a fraction of its distance to the aim point every step,
+   // so its speed *is* that distance times the factor - aim straight at the player and the camera is
+   // left behind by exactly that distance for as long as the player keeps moving.
+   //
+   // The lead is built from a speed that takes a moment to catch up, and that is where the camera's own
+   // acceleration comes from. Leading by the full distance against the *current* speed would cancel the
+   // follow at every speed alike: no lag left, but no easing either, and the camera is welded to the
+   // player. Letting the lead's speed catch up at the same rate the camera does puts the easing back
+   // where it belongs - while the player is speeding up or slowing down the lead is still short and the
+   // camera eases towards the new speed, and once the speed is steady the lead is the whole distance
+   // and the camera sits on the player with nothing left over
+   _lead_velocity_px_per_s += (player_velocity_px_per_s - _lead_velocity_px_per_s) * delta_time.asSeconds() * velocity_factor;
+
+   const auto lead_px =
+      (velocity_factor > 0.0f) ? (_lead_velocity_px_per_s * camera_config.getCameraLeadFactorX() / velocity_factor) : 0.0f;
+
+   // the room lock still supplies the y target and reports whether any side is clamped, unchanged. It
+   // is handed the player's own position, never a led one: it looks the player up in a sub-room to find
+   // the rectangle to work against, and a lead can push that lookup outside the room, where it finds
+   // nothing and skips the clamp altogether
+   auto corrected_x_px = player_position_px.x;
+   auto corrected_y_px = player_position_px.y;
+   const auto room_corrected = CameraRoomLock::correctedCamera(corrected_x_px, corrected_y_px, _focus_offset_px);
+
+   // holding the aim point inside the room is what shapes both ends of a room crossing, and it does it
+   // without a special case at either end. Leaving a clamp, the aim point comes off the wall while the
+   // player is still a lead short of it, so the camera is already up to speed by the time the player
+   // passes - instead of standing on the clamp with nothing to move towards and needing the better part
+   // of a second to get going. Arriving at the far wall, the aim point reaches it a lead early, so the
+   // camera runs out of distance and decelerates into it
+   auto target_x_px = player_position_px.x + lead_px;
+   const auto limits = CameraRoomLock::horizontalCameraLimits(player_position_px, _focus_offset_px);
+   if (limits.has_value())
+   {
+      // a room narrower than the view cannot satisfy both ends at once, and correctedCamera settles
+      // that in favour of the left one, so settle it the same way here
+      target_x_px = std::max(limits->_left_px, std::min(target_x_px, limits->_right_px));
+   }
+
+   _dx_px = (target_x_px - _x_px);
+   const auto dx_px = (_dx_px)*delta_time.asSeconds() * velocity_factor;
    const auto f_center = _view_width_px / 2.0f;
    const auto f_range = _view_width_px / camera_config.getFocusZoneDivider();
 
@@ -97,8 +144,11 @@ void CameraSystem::updateX(const sf::Time& delta_time)
    _focus_zone_x1_px += _focus_offset_px;
    _focus_zone_center_px = ((_focus_zone_x0_px + _focus_zone_x1_px) / 2.0f);
 
-   // test if out of focus zone boundaries
-   const auto test = player_x_px - _focus_zone_center_px;
+   // test if out of focus zone boundaries. Measured against the point the camera is aiming at rather
+   // than the player: now that the lead cancels the trailing distance, a running player sits on the
+   // centre, so testing the player would find them inside the zone and stop the camera every few
+   // frames - the camera would judder along instead of running with them
+   const auto test = target_x_px - _focus_zone_center_px;
    const auto f0_px = _x_px - _focus_zone_x1_px;
    const auto f1_px = _x_px - _focus_zone_x0_px;
 
@@ -116,6 +166,14 @@ void CameraSystem::updateX(const sf::Time& delta_time)
    if (_focus_x_triggered || room_corrected)
    {
       _x_px += dx_px;
+   }
+
+   // and the same limits on the camera itself, not only on what it is aiming at. A room can change
+   // under a camera that is standing still, and the focus zone gate can hold it where it is, so being
+   // aimed inside the room is not on its own enough to have never been outside it
+   if (limits.has_value())
+   {
+      _x_px = std::max(limits->_left_px, std::min(_x_px, limits->_right_px));
    }
 }
 
@@ -218,6 +276,11 @@ void CameraSystem::syncNow()
 
    _x_px = player_x;
    _y_px = player_y;
+
+   // a teleport is not movement. Left alone, the jump would read as an enormous speed for one step and
+   // the lead would fling the camera across the room
+   _previous_player_x_px = player->getPixelPositionFloat().x;
+   _lead_velocity_px_per_s = 0.0f;
 }
 
 void CameraSystem::snapTo(float x_px, float y_px)
@@ -227,6 +290,8 @@ void CameraSystem::snapTo(float x_px, float y_px)
    _dx_px = 0.0f;
    _dy_px = 0.0f;
    _locked = true;
+   _previous_player_x_px = PlayerRegistry::getFirst()->getPixelPositionFloat().x;
+   _lead_velocity_px_per_s = 0.0f;
 }
 
 void CameraSystem::unlockCamera()

--- a/src/game/camera/camerasystem.h
+++ b/src/game/camera/camerasystem.h
@@ -110,6 +110,18 @@ private:
    float _dx_px = 0.0f;
    float _dy_px = 0.0f;
 
+   //!< where the player stood at the previous step, so how fast they are moving can be read off the
+   //!< two. Taken from the player's own position rather than from the physics body on purpose: the
+   //!< box2d delta is not the step duration, see FixedTimeStep, so a velocity in box2d units would
+   //!< have to be converted by a factor that has nothing to do with the camera
+   float _previous_player_x_px = 0.0f;
+
+   //!< the speed the lead is built from: the player's own, but taking the same time to catch up that
+   //!< the camera does. Holding it rather than using the player's current speed is what keeps the
+   //!< camera's acceleration - a lead built from the current speed cancels the follow at every speed
+   //!< alike and leaves the camera welded to the player
+   float _lead_velocity_px_per_s = 0.0f;
+
    float _focus_zone_x0_px = 0.0f;
    float _focus_zone_x1_px = 0.0f;
    float _focus_zone_center_px = 0.0f;

--- a/src/game/camera/camerasystemconfiguration.cpp
+++ b/src/game/camera/camerasystemconfiguration.cpp
@@ -31,6 +31,7 @@ std::string CameraSystemConfiguration::serialize()
    json config = {
       {"CameraSystemConfiguration",
        {{"velocity_factor_x", _camera_velocity_factor_x},
+        {"lead_factor_x", _camera_lead_factor_x},
         {"focus_zone_divider", _focus_zone_divider},
         {"target_shift_factor", _target_shift_factor},
         {"back_in_bounds_tolerance_x", _back_in_bounds_tolerance_x},
@@ -56,6 +57,7 @@ void CameraSystemConfiguration::deserialize(const std::string& data)
    const auto camera_config = config["CameraSystemConfiguration"];
 
    _camera_velocity_factor_x = camera_config["velocity_factor_x"].get<float>();
+   _camera_lead_factor_x = camera_config["lead_factor_x"].get<float>();
    _focus_zone_divider = camera_config["focus_zone_divider"].get<float>();
    _target_shift_factor = camera_config["target_shift_factor"].get<float>();
    _back_in_bounds_tolerance_x = camera_config["back_in_bounds_tolerance_x"].get<int32_t>();
@@ -146,4 +148,9 @@ float CameraSystemConfiguration::getFocusZoneDivider() const
 float CameraSystemConfiguration::getCameraVelocityFactorX() const
 {
    return _camera_velocity_factor_x;
+}
+
+float CameraSystemConfiguration::getCameraLeadFactorX() const
+{
+   return _camera_lead_factor_x;
 }

--- a/src/game/camera/camerasystemconfiguration.h
+++ b/src/game/camera/camerasystemconfiguration.h
@@ -14,6 +14,10 @@ struct CameraSystemConfiguration
    /// \return velocity factor applied during x-axis camera updates.
    float getCameraVelocityFactorX() const;
 
+   /// \brief returns how much of the player's speed the camera is aimed ahead by.
+   /// \return fraction of the follow's own time constant, 0 aims at the player, 1 cancels the easing.
+   float getCameraLeadFactorX() const;
+
    /// \brief returns the divisor used to derive horizontal focus-zone half-width from view width.
    /// \return focus-zone divider value.
    float getFocusZoneDivider() const;
@@ -68,6 +72,13 @@ struct CameraSystemConfiguration
 
    // x
    float _camera_velocity_factor_x = 4.0f;
+
+   //!< how far ahead of the player the camera aims, as a fraction of the follow's own time constant.
+   //!< 0 aims straight at the player, which leaves the camera standing still whenever a room clamp
+   //!< lets go of it; 1 aims exactly the distance the camera needs to keep up, which cancels the
+   //!< easing entirely and glues the camera to the player. In between it keeps its easing but starts
+   //!< the hand-off out of a clamp at this fraction of the player's speed instead of at nothing
+   float _camera_lead_factor_x = 0.8f;
    float _focus_zone_divider = 6.0f;
    float _target_shift_factor = 0.75f;
    int32_t _back_in_bounds_tolerance_x = 10;

--- a/src/game/camera/camerasystemconfigurationui.cpp
+++ b/src/game/camera/camerasystemconfigurationui.cpp
@@ -121,6 +121,7 @@ void CameraSystemConfigurationUi::draw()
    if (ImGui::CollapsingHeader("horizontal", header_flags))
    {
       drawFloatElement("camera velocity factor", &config._camera_velocity_factor_x, -0.1f, 10.0f);
+      drawFloatElement("camera lead factor", &config._camera_lead_factor_x, 0.0f, 1.0f);
       drawFloatElement("focus zone divider", &config._focus_zone_divider, 0.1f, 100.0f);
       drawFloatElement("target shift factor", &config._target_shift_factor, 0.1f, 2.0f);
       drawIntElement("back in bounds tolerance", &config._back_in_bounds_tolerance_x, 1, 50);

--- a/src/game/physics/fixedtimestep.cpp
+++ b/src/game/physics/fixedtimestep.cpp
@@ -1,6 +1,48 @@
 #include "fixedtimestep.h"
 
+#include <cmath>
+
 #include "game/physics/renderinterpolation.h"
+
+namespace
+{
+
+//!< how far a frame may sit from a whole number of steps and still be taken to be that many.
+//!< 0.15 of a step is 2.5 ms, which covers the spread a vsynced frame arrives with
+constexpr auto snap_tolerance_in_steps = 0.15f;
+
+/// \brief rounds a frame time that is nearly a whole number of steps to exactly that many.
+///
+/// A vsynced frame is meant to be one step and measures 15.7 to 18.2 ms against a step of 16.667 ms,
+/// so banking the difference makes the bank wander across a step boundary once or twice a second: one
+/// frame runs no step and draws the state it just drew, the next runs two and moves everything twice
+/// as far. Nothing is wrong with the average speed, which is why this reads as the scrolling being
+/// uneven rather than as the game running fast or slow.
+///
+/// Snapping spends the frame on whole steps instead, so a run at the step rate takes exactly one step
+/// per frame however the frame times scatter. A frame that is not near a whole number of steps - half
+/// a step at 120 Hz, a third at 180 - is left alone and banked as before, and so is a frame too short
+/// to pay for one.
+///
+/// The tolerance is what decides which refresh rates count as "the step rate": 0.15 of a step spans
+/// 52 to 71 Hz, which takes in the 59.94 and 60 Hz a 60 Hz panel actually reports and leaves 50, 72
+/// and 75 Hz outside. A display inside that span but not at 60 - 65 Hz, say - is deliberately run at
+/// its own rate rather than at 60, i.e. 8% fast and smooth rather than at the right speed with a
+/// visible hitch every dozen frames. Nothing here runs at real time anyway, see the class note.
+float snapToWholeSteps(float frame_duration_s, float step_duration_s)
+{
+   const auto steps_in_frame = frame_duration_s / step_duration_s;
+   const auto whole_steps = std::round(steps_in_frame);
+
+   if (whole_steps < 1.0f || std::fabs(steps_in_frame - whole_steps) > snap_tolerance_in_steps)
+   {
+      return frame_duration_s;
+   }
+
+   return whole_steps * step_duration_s;
+}
+
+}  // namespace
 
 int32_t FixedTimeStep::consumeSteps(const sf::Time& dt)
 {
@@ -10,7 +52,7 @@ int32_t FixedTimeStep::consumeSteps(const sf::Time& dt)
       return 1;
    }
 
-   _accumulated_s += dt.asSeconds();
+   _accumulated_s += snapToWholeSteps(dt.asSeconds(), step_duration_s);
 
    auto step_count = static_cast<int32_t>(_accumulated_s / step_duration_s);
 

--- a/src/game/physics/fixedtimestep.h
+++ b/src/game/physics/fixedtimestep.h
@@ -28,6 +28,9 @@ public:
    /// \brief adds a frame's worth of time and reports how many steps it pays for.
    /// \param dt time elapsed since the previous frame.
    /// \return number of simulation steps to run this frame, never more than the catch-up limit.
+   /// \note a frame time that is nearly a whole number of steps is taken to be exactly that many
+   ///       rather than banked to the microsecond, so a run at the step rate takes one step per frame
+   ///       instead of alternating between none and two. See snapToWholeSteps.
    /// \note the time behind the limit is discarded rather than banked. Keeping it would leave the
    ///       simulation permanently in catch-up after a single long frame - a level load, a breakpoint
    ///       - and each frame of catch-up costs more time, so it never gets out.


### PR DESCRIPTION
Two independent faults made scrolling feel wrong. Both were measured with temporary per-frame
instrumentation (frame time, steps run, camera x, view x, player x) rather than judged by eye; the
instrumentation is not part of this change.

## 1. The frame time was banked to the microsecond

`FixedTimeStep` banks whatever frame time is left over after paying for whole steps. With vsync on, a
frame that is meant to buy exactly one step measures **16.75 ms on average and scatters from 15.7 to
18.2 ms** against a step of 16.667 ms. That difference goes into the bank, the bank wanders, and every
time it crosses a step boundary you get one frame that runs no step (drawing the state it just drew)
followed by one that runs two (moving everything twice as far). The average speed is correct, which is
exactly why it reads as the scrolling being unsteady rather than as the game running fast or slow.

Render interpolation would hide it, but it is off by design, so the frame shows the raw simulation
state. It hits the player, the mechanisms and the camera alike.

A frame time within 0.15 of a step of a whole number of steps is now taken to be exactly that many.

| | frames | 0-step | 2-step | step-count changes | steps/s |
|---|---|---|---|---|---|
| before, ct-cannon-fodder | 2340 | 22 | 33 | 92 (2.36 /s) | 59.99 |
| before, ct-bomberdrome | 2292 | 7 | 13 | 36 (0.94 /s) | 59.98 |
| before, inc-room1 | 2340 | 22 | 35 | 93 (2.38 /s) | 59.99 |
| after, ct-cannon-fodder | 2340 | **0** | **0** | **0** | 59.62 |

Per-step distance is untouched at 3.43 px. The step rate lands on the panel's real rate instead of a
nominal 60, i.e. 0.62% slower.

The tolerance is the whole design: 0.15 of a step spans 52 to 71 Hz, which takes in the 59.94 and 60 Hz
a 60 Hz panel actually reports and leaves 50, 72 and 75 Hz outside. A display inside that span but not
at 60 is deliberately run at its own rate. Above the step rate nothing snaps and nothing changes.

## 2. The camera restarted from a standstill at every room clamp

The camera closes a fraction of its distance to its target every step, so its speed *is* that distance
times the factor. While a room clamp holds it, the clamp sits exactly where the player will be when the
clamp lets go — so the distance is zero, and the camera sets off at **0.01 px per frame** while the
player is already at full pace. It needed **57 frames (0.95 s)** to reach a running player, in a room
whose entire scrollable width is crossed in 72.

The target is now carried ahead by the distance the camera needs in order to travel at the player's
speed, and that aim point is held inside the room. That single clamp shapes both ends of a room
crossing with no special case at either end: it comes off the near wall while the player is still a
lead short of it, so the camera is up to speed by the time they pass, and it reaches the far wall a
lead early, so the camera runs out of distance and decelerates into it.

The lead is built from a speed that takes the same time to catch up that the camera does, and that is
where the camera's own acceleration comes from. Built from the player's *current* speed, a full lead
cancels the follow at every speed alike — no lag left, but no easing either, and the camera is welded
to the player. `lead_factor_x` in `data/config/camera.json` scales how much of the distance it asks
for; shipped at 0.8.

Four clamp crossings per value, ct-cannon-fodder:

| lead_factor_x | camera starts | at the crossing | +10f | +20f | trail at a steady run | drift on stopping |
|---|---|---|---|---|---|---|
| 0.0 — before | on the clamp | 0% | 46% | 73% | +58 px | none |
| 0.5 | 20 px early | 36% | 68% | 84% | +32 px | 3.4 px |
| **0.8 — shipped** | 34 px early | **53%** | 77% | 88% | **+17 px** | 7.3 px |
| 1.0 | 44 px early | 62% | 81% | 91% | +6 px | 11.1 px |

Every value keeps the easing: the departure ramp is monotone on 100% of frames and the approach to the
far clamp decelerates on 96–100% of them. Away from a room transition the scroll never changes by more
than 0.6 px between frames in any run, so there is no hitch left once the player is at full speed
either, and the view never reaches outside a room.

### Two things this depends on

- **The lead must never reach `CameraRoomLock`'s sub-room lookup.** `correctedCamera` uses the same
  position for `findSubRoom` and for the edge tests, so a led position near a room edge finds no
  sub-room, returns false *without clamping*, and the view slid 96 px out of the room. Hence
  `horizontalCameraLimits`, which looks the player up and returns the limits so the caller clamps what
  it likes.
- **`correctedCamera` reports whether *any* side is clamped.** In a room taller than the view the
  bottom one is held for most of its height, so reading that as "x is clamped" suppressed the lead
  everywhere.

The focus zone is measured against the aim point rather than the player for a related reason: with the
trail gone a running player sits on the focus centre, so testing the player closes the gate every few
frames and the camera judders along instead of running with them.

## Ruled out, with evidence

- **Camera easing as a cause of the stutter.** Traced through a full accelerate-and-settle cycle: the
  view ramps 0.46 → 3.09 px per frame and decays 0.75 → 0.03 without a single break. The camera's
  motion was always smooth — it was too slow, which is fault 2, not the stutter.
- **The room lock as a cause of the stutter.** The clamp is entered and left continuously and the focus
  offset cancels out exactly in `getX()`. The room boundary is where the camera is *pinned*, which is
  why the player's stutter is naked there.
- **Sub-pixel snapping.** The render target is a whole multiple of the view, so the picture quantises
  to one physical pixel, the floor of what any renderer can do. Nothing is rounded in the engine.
- **The redundant frame limiter.** `setFramerateLimit(60)` is set alongside vsync. It is worth at most
  the 0.08 ms systematic drift and is not what makes the bank wander; left alone.

## Known and pre-existing

At a room *transition* the player briefly reaches 327 px off a 320 px half view, i.e. just past the
screen edge. Measured identical before and after this change.
