### PR TITLE
explain every setting in the configuration editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ lab/switch_smoke/__pycache__
 
 # emulator stdout captured by run_switch.bat
 logs/
+
+# written by imgui in the working directory whenever a debug editor is opened
+imgui.ini

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,8 @@ set(GAME_FILES
     src/game/debug/drawcallcounter.h
     src/game/debug/logui.cpp
     src/game/debug/logui.h
+    src/game/debug/settingsui.cpp
+    src/game/debug/settingsui.h
     src/game/debug/mechanismsample.h
     src/game/debug/mechanismschemawriter.cpp
     src/game/debug/mechanismschemawriter.h

--- a/src/game/camera/camerasystem.cpp
+++ b/src/game/camera/camerasystem.cpp
@@ -237,7 +237,8 @@ void CameraSystem::updateY(const sf::Time& delta_time)
 
    // have some acceleration in the y update velocity so it doesn't got at full speed instantly
    const auto y_update_start_time_s = _y_update_start_time.asSeconds();
-   const auto y_update_acceleration = _panic ? 2.0f : std::min(Easings::easeOutQuint(y_update_start_time_s), 1.0f);
+   const auto y_update_acceleration =
+      _panic ? camera_config.getPanicAccelerationFactorY() : std::min(Easings::easeOutQuint(y_update_start_time_s), 1.0f);
 
    _dy_px = player_y - _y_px;
    const auto dy = _dy_px * delta_time.asSeconds() * camera_config.getCameraVelocityFactorY() * y_update_acceleration;

--- a/src/game/camera/camerasystemconfiguration.cpp
+++ b/src/game/camera/camerasystemconfiguration.cpp
@@ -125,6 +125,11 @@ float CameraSystemConfiguration::getPanicLineDivider() const
    return _panic_line_divider;
 }
 
+float CameraSystemConfiguration::getPanicAccelerationFactorY() const
+{
+   return _panic_acceleration_factor_y;
+}
+
 float CameraSystemConfiguration::getCameraVelocityFactorY() const
 {
    return _camera_velocity_factor_y;

--- a/src/game/camera/camerasystemconfiguration.h
+++ b/src/game/camera/camerasystemconfiguration.h
@@ -42,6 +42,10 @@ struct CameraSystemConfiguration
    /// \return panic-line divider value.
    float getPanicLineDivider() const;
 
+   /// \brief returns how much faster the camera follows the player vertically while panicking.
+   /// \return multiplier applied to the vertical follow speed while panic mode is active.
+   float getPanicAccelerationFactorY() const;
+
    /// \brief returns the vertical anchor ratio used for camera top-left conversion.
    /// \return view ratio used by CameraSystem::getY().
    float getViewRatioY() const;

--- a/src/game/camera/camerasystemconfigurationui.cpp
+++ b/src/game/camera/camerasystemconfigurationui.cpp
@@ -1,6 +1,7 @@
 #include "camerasystemconfigurationui.h"
 
 #include "camerasystemconfiguration.h"
+#include "game/debug/settingsui.h"
 
 #pragma warning(push, 0)
 #include "imgui/imgui-SFML.h"
@@ -13,10 +14,10 @@
 CameraSystemConfigurationUi::CameraSystemConfigurationUi()
 #ifdef DECEPTUS_VRSFML
     : _render_window(std::make_unique<sf::RenderWindow>(
-         sf::RenderWindow::create(sf::WindowSettings{.size = {800u, 400u}, .title = "deceptus camera configuration"}).value()
+         sf::RenderWindow::create(sf::WindowSettings{.size = {800u, 620u}, .title = "deceptus camera configuration"}).value()
       ))
 #else
-    : _render_window(std::make_unique<sf::RenderWindow>(sf::VideoMode({800, 400}), "deceptus camera configuration"))
+    : _render_window(std::make_unique<sf::RenderWindow>(sf::VideoMode({800, 620}), "deceptus camera configuration"))
 #endif
 {
    if (!ImGui::SFML::Init(*_render_window.get()))
@@ -42,48 +43,6 @@ void CameraSystemConfigurationUi::processEvents()
 
 void CameraSystemConfigurationUi::draw()
 {
-   auto drawFloatElement = [](const std::string& name, auto* value, auto min, auto max)
-   {
-      std::stringstream stream_input;
-      std::stringstream stream_slider;
-      stream_input << "##" << name << "_input";
-      stream_slider << "##" << name << "_slider";
-
-      ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.2f);
-
-      if (ImGui::InputFloat(stream_input.str().c_str(), value, 0.1f, 1.0f, "%.3f"))
-      {
-         *value = std::clamp(*value, min, max);
-      }
-
-      ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.35f);
-      ImGui::SameLine();
-      ImGui::SliderFloat(stream_slider.str().c_str(), value, min, max);
-      ImGui::SameLine();
-      ImGui::Text("%s", name.c_str());
-   };
-
-   auto drawIntElement = [](const std::string& name, auto* value, auto min, auto max)
-   {
-      std::stringstream stream_input;
-      std::stringstream stream_slider;
-      stream_input << "##" << name << "input";
-      stream_slider << "##" << name << "slider";
-
-      ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.2f);
-
-      if (ImGui::InputInt(stream_input.str().c_str(), value))
-      {
-         *value = std::clamp(*value, min, max);
-      }
-
-      ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.35f);
-      ImGui::SameLine();
-      ImGui::SliderInt(stream_slider.str().c_str(), value, min, max);
-      ImGui::SameLine();
-      ImGui::Text("%s", name.c_str());
-   };
-
    auto& config = CameraSystemConfiguration::getInstance();
 
    ImGui::SFML::Update(*_render_window.get(), _clock.restart());
@@ -118,30 +77,143 @@ void CameraSystemConfigurationUi::draw()
    ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.50f);
    ImGuiTreeNodeFlags header_flags = ImGuiTreeNodeFlags_DefaultOpen;
 
+   SettingsUi::beginSettings();
+
    if (ImGui::CollapsingHeader("horizontal", header_flags))
    {
-      drawFloatElement("camera velocity factor", &config._camera_velocity_factor_x, -0.1f, 10.0f);
-      drawFloatElement("camera lead factor", &config._camera_lead_factor_x, 0.0f, 1.0f);
-      drawFloatElement("focus zone divider", &config._focus_zone_divider, 0.1f, 100.0f);
-      drawFloatElement("target shift factor", &config._target_shift_factor, 0.1f, 2.0f);
-      drawIntElement("back in bounds tolerance", &config._back_in_bounds_tolerance_x, 1, 50);
-      ImGui::Checkbox("follow player orientation", &config._follow_player_orientation);
+      SettingsUi::drawFloat(
+         "camera velocity factor",
+         &config._camera_velocity_factor_x,
+         -0.1f,
+         10.0f,
+         "How quickly the camera closes the gap to where it is aiming. It covers this fraction of the "
+         "remaining distance every second, so higher is snappier and lower drifts.",
+         "This also sets how long the camera takes to reach a running player: roughly 3 divided by this, "
+         "in seconds. The lead factor below is measured against it, so changing this changes the lead too."
+      );
+      SettingsUi::drawFloat(
+         "camera lead factor",
+         &config._camera_lead_factor_x,
+         0.0f,
+         1.0f,
+         "How far ahead of the player the camera aims, as a fraction of the distance it would need in "
+         "order to travel at exactly the player's speed.",
+         "0 aims straight at the player, which leaves the camera standing still whenever a room edge "
+         "lets go of it. 1 asks for the whole distance, which cancels the easing and welds the camera to "
+         "the player. Higher values also drift a little further past the player when they stop."
+      );
+      SettingsUi::drawFloat(
+         "focus zone divider",
+         &config._focus_zone_divider,
+         0.1f,
+         100.0f,
+         "Sets the dead zone the player can move inside without the camera following: the view width "
+         "divided by this, to either side of centre.",
+         "Larger means a smaller dead zone, so 100 is very nearly no dead zone at all and the camera "
+         "follows almost any movement. It also scales the target shift factor below."
+      );
+      SettingsUi::drawFloat(
+         "target shift factor",
+         &config._target_shift_factor,
+         0.1f,
+         2.0f,
+         "How far the dead zone slides in the direction the player is facing, as a fraction of its own "
+         "half width, so the camera shows more of what is ahead.",
+         "Has no effect unless follow player orientation is on. Because it is a fraction of the dead "
+         "zone, a large focus zone divider leaves nothing for it to shift."
+      );
+      SettingsUi::drawInt(
+         "back in bounds tolerance",
+         &config._back_in_bounds_tolerance_x,
+         1,
+         50,
+         "How close to centre the camera has to get before it stops following again, in pixels. It is "
+         "what keeps the camera from chasing every last pixel.",
+         "Only bites while it is smaller than the dead zone above. At a focus zone divider of 100 the "
+         "dead zone is about 6 px, so anything above that never takes effect."
+      );
+      SettingsUi::drawBool(
+         "follow player orientation",
+         &config._follow_player_orientation,
+         "Slides the dead zone towards the direction the player is facing, so turning around shifts the "
+         "view rather than leaving the player centred.",
+         "Turning it on is what gives the target shift factor above something to do."
+      );
    }
 
    if (ImGui::CollapsingHeader("vertical", header_flags))
    {
-      drawFloatElement("camera velocity factor", &config._camera_velocity_factor_y, 0.1f, 10.0f);
-      drawFloatElement("view ratio", &config._view_ratio_y, 0.1f, 10.0f);
-      drawIntElement("back in bounds tolerance", &config._back_in_bounds_tolerance_y, 1, 50);
-      drawIntElement("player offset", &config._player_offset_y, -500, 500);
-      drawFloatElement("panic line divider", &config._panic_line_divider, 0.1f, 100.0f);
-      drawFloatElement("panic acceleration factor", &config._panic_acceleration_factor_y, 0.1f, 10.0f);
+      SettingsUi::drawFloat(
+         "camera velocity factor",
+         &config._camera_velocity_factor_y,
+         0.1f,
+         10.0f,
+         "How quickly the camera closes the vertical gap to the player, as a fraction of the remaining "
+         "distance per second.",
+         "The vertical follow also eases in over its first moments rather than starting at full speed, "
+         "so this is the speed it works up to, not the speed it starts at."
+      );
+      SettingsUi::drawFloat(
+         "view ratio",
+         &config._view_ratio_y,
+         0.1f,
+         10.0f,
+         "Where the player sits vertically: one view height divided by this, measured down from the top "
+         "edge of the view.",
+         "2 centres the player. Smaller values push them further down the screen, so 1.5 leaves them two "
+         "thirds of the way down and shows more of what is above."
+      );
+      SettingsUi::drawInt(
+         "back in bounds tolerance",
+         &config._back_in_bounds_tolerance_y,
+         1,
+         50,
+         "How close to its resting height the camera has to get before it stops following vertically, in "
+         "pixels.",
+         "Also what ends panic mode's grip once the player is back near the middle of the view."
+      );
+      SettingsUi::drawInt(
+         "player offset",
+         &config._player_offset_y,
+         -500,
+         500,
+         "Shifts the point the camera tracks this far below the player, in pixels.",
+         "A positive value moves the view down, so the player sits higher on screen and more of what is "
+         "below them is visible. It also moves the panic lines with it, since they are measured against "
+         "the same point."
+      );
+      SettingsUi::drawFloat(
+         "panic line divider",
+         &config._panic_line_divider,
+         0.1f,
+         100.0f,
+         "Sets how far the player may leave the middle of the view while airborne before the camera "
+         "starts chasing them: the view height divided by this, above and below centre.",
+         "Larger means the lines sit closer to centre, so the camera panics sooner. Normally the camera "
+         "does not follow at all while the player is in the air; this is what overrides that."
+      );
+      SettingsUi::drawFloat(
+         "panic acceleration factor",
+         &config._panic_acceleration_factor_y,
+         0.1f,
+         10.0f,
+         "How much faster than usual the camera follows vertically once it is panicking.",
+         "Multiplies the vertical velocity factor, and replaces the gentle ease-in the normal follow "
+         "uses, so it takes hold immediately."
+      );
    }
 
    if (ImGui::CollapsingHeader("various", header_flags))
    {
-      ImGui::Checkbox("camera shaking", &config._camera_shaking_enabled);
+      SettingsUi::drawBool(
+         "camera shaking",
+         &config._camera_shaking_enabled,
+         "Whether explosions and other impacts shake the view.",
+         "Off silences every shake at the source, so nothing else has to be tuned to stop it."
+      );
    }
+
+   SettingsUi::endSettings();
 
    ImGui::End();
 

--- a/src/game/debug/settingsui.cpp
+++ b/src/game/debug/settingsui.cpp
@@ -1,0 +1,168 @@
+#include "settingsui.h"
+
+#include "imgui/imgui.h"
+
+#include <algorithm>
+
+namespace
+{
+
+//!< the help belonging to the row the pointer is over, or to the widget being dragged. Cleared at the
+//!< start of every frame and filled in by whichever row reports itself hovered or active
+struct HoveredRow
+{
+   bool _present{false};
+   std::string _name;
+   std::string _range;
+   const char* _what{nullptr};
+   const char* _note{nullptr};
+};
+
+//!< being filled in during the frame currently being drawn
+HoveredRow __hovered;
+
+//!< what the pane showed on the previous frame. The pane's height has to be reserved before the rows
+//!< are drawn, and nothing is known about what will be pointed at until they have been - so the height
+//!< is measured from the previous frame's text. One frame of lag on it is not visible, and it beats a
+//!< fixed height, which either clips the longer notes or reserves empty space for the shorter ones
+HoveredRow __shown;
+
+/// \brief how much room the pane needs for the text it is about to show, wrapping included.
+float helpHeight(float wrap_width_px)
+{
+   const auto line_height = ImGui::GetTextLineHeightWithSpacing();
+   if (!__shown._present)
+   {
+      return line_height + ImGui::GetStyle().ItemSpacing.y * 2.0f;
+   }
+
+   auto height = line_height;  // the name and its range
+   for (const auto* text : {__shown._what, __shown._note})
+   {
+      if (text != nullptr)
+      {
+         height += ImGui::CalcTextSize(text, nullptr, false, wrap_width_px).y + ImGui::GetStyle().ItemSpacing.y;
+      }
+   }
+
+   return height + ImGui::GetStyle().ItemSpacing.y * 2.0f;
+}
+
+/// \brief records the row's help if any of its widgets is hovered or being dragged.
+/// \note called after each of the row's widgets, because ImGui reports hover for the item just drawn.
+///       Active as well as hovered: a slider being dragged stops being hovered as soon as the pointer
+///       leaves it, and the value is still the one being changed.
+void captureIfPointedAt(const std::string& name, const std::string& range, const char* what, const char* note)
+{
+   if (!ImGui::IsItemHovered() && !ImGui::IsItemActive())
+   {
+      return;
+   }
+
+   __hovered = HoveredRow{._present = true, ._name = name, ._range = range, ._what = what, ._note = note};
+}
+
+std::string formatRange(float min, float max)
+{
+   char buffer[64];
+   std::snprintf(buffer, sizeof(buffer), "%g to %g", min, max);
+   return buffer;
+}
+
+std::string formatRange(int32_t min, int32_t max)
+{
+   char buffer[64];
+   std::snprintf(buffer, sizeof(buffer), "%d to %d", min, max);
+   return buffer;
+}
+
+}  // namespace
+
+void SettingsUi::beginSettings()
+{
+   __hovered = HoveredRow{};
+
+   // the rows scroll, the help pane does not. A negative height leaves the child that much short of
+   // the bottom of the window, which is what keeps the pane in place
+   ImGui::BeginChild("settings", ImVec2{0.0f, -helpHeight(ImGui::GetContentRegionAvail().x)}, false);
+}
+
+void SettingsUi::endSettings()
+{
+   ImGui::EndChild();
+   ImGui::Separator();
+
+   __shown = __hovered;
+
+   if (!__shown._present)
+   {
+      ImGui::TextDisabled("point at a setting to read what it does");
+      return;
+   }
+
+   ImGui::TextUnformatted(__shown._name.c_str());
+   ImGui::SameLine();
+   ImGui::TextDisabled("(%s)", __shown._range.c_str());
+   ImGui::TextWrapped("%s", __shown._what != nullptr ? __shown._what : "");
+
+   if (__shown._note != nullptr)
+   {
+      ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+      ImGui::TextWrapped("%s", __shown._note);
+      ImGui::PopStyleColor();
+   }
+}
+
+void SettingsUi::drawFloat(const std::string& name, float* value, float min, float max, const char* what, const char* note)
+{
+   const auto range = formatRange(min, max);
+   const auto input_id = "##" + name + "_input";
+   const auto slider_id = "##" + name + "_slider";
+
+   ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.2f);
+
+   if (ImGui::InputFloat(input_id.c_str(), value, 0.1f, 1.0f, "%.3f"))
+   {
+      *value = std::clamp(*value, min, max);
+   }
+   captureIfPointedAt(name, range, what, note);
+
+   ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.35f);
+   ImGui::SameLine();
+   ImGui::SliderFloat(slider_id.c_str(), value, min, max);
+   captureIfPointedAt(name, range, what, note);
+
+   ImGui::SameLine();
+   ImGui::TextUnformatted(name.c_str());
+   captureIfPointedAt(name, range, what, note);
+}
+
+void SettingsUi::drawInt(const std::string& name, int32_t* value, int32_t min, int32_t max, const char* what, const char* note)
+{
+   const auto range = formatRange(min, max);
+   const auto input_id = "##" + name + "_input";
+   const auto slider_id = "##" + name + "_slider";
+
+   ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.2f);
+
+   if (ImGui::InputInt(input_id.c_str(), value))
+   {
+      *value = std::clamp(*value, min, max);
+   }
+   captureIfPointedAt(name, range, what, note);
+
+   ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.35f);
+   ImGui::SameLine();
+   ImGui::SliderInt(slider_id.c_str(), value, min, max);
+   captureIfPointedAt(name, range, what, note);
+
+   ImGui::SameLine();
+   ImGui::TextUnformatted(name.c_str());
+   captureIfPointedAt(name, range, what, note);
+}
+
+void SettingsUi::drawBool(const std::string& name, bool* value, const char* what, const char* note)
+{
+   ImGui::Checkbox(name.c_str(), value);
+   captureIfPointedAt(name, "on or off", what, note);
+}

--- a/src/game/debug/settingsui.h
+++ b/src/game/debug/settingsui.h
@@ -1,0 +1,55 @@
+#ifndef SETTINGSUI_H
+#define SETTINGSUI_H
+
+#include <cstdint>
+#include <string>
+
+/// \brief the settings rows the configuration editors are built from, and the help pane under them.
+///
+/// Every row carries its own explanation, and the pane at the bottom of the window shows the one
+/// belonging to whatever the pointer is over - or to whatever slider is being dragged, which is the
+/// reason this is a pane and not a tooltip: a tooltip disappears the moment a drag starts, which is
+/// exactly when the reader wants to know what the value does, and it covers the neighbouring rows
+/// while it is up.
+///
+/// The rows were previously a pair of lambdas copied into each editor verbatim. They live here so
+/// that a row only has to learn about its explanation once.
+namespace SettingsUi
+{
+
+/// \brief opens the scrolling region the rows are drawn into and forgets the previous frame's help.
+/// \note the region stops short of the bottom of the window by exactly the height of the help pane,
+///       so the pane stays put instead of scrolling away with the rows.
+void beginSettings();
+
+/// \brief closes the scrolling region and draws the help pane beneath it.
+void endSettings();
+
+/// \brief draws a float row: a number field, a slider, and the name.
+/// \param name row label, also the id the two widgets are keyed on.
+/// \param value edited in place; typing into the number field is clamped to the range.
+/// \param min lowest value the slider offers.
+/// \param max highest value the slider offers.
+/// \param what one sentence on what the value does, shown in the help pane.
+/// \param note what to watch out for: units, what it interacts with, when it takes effect. Optional.
+void drawFloat(const std::string& name, float* value, float min, float max, const char* what, const char* note = nullptr);
+
+/// \brief draws an integer row: a number field, a slider, and the name.
+/// \param name row label, also the id the two widgets are keyed on.
+/// \param value edited in place; typing into the number field is clamped to the range.
+/// \param min lowest value the slider offers.
+/// \param max highest value the slider offers.
+/// \param what one sentence on what the value does, shown in the help pane.
+/// \param note what to watch out for: units, what it interacts with, when it takes effect. Optional.
+void drawInt(const std::string& name, int32_t* value, int32_t min, int32_t max, const char* what, const char* note = nullptr);
+
+/// \brief draws a checkbox row.
+/// \param name checkbox label.
+/// \param value edited in place.
+/// \param what one sentence on what the value does, shown in the help pane.
+/// \param note what to watch out for: units, what it interacts with, when it takes effect. Optional.
+void drawBool(const std::string& name, bool* value, const char* what, const char* note = nullptr);
+
+}  // namespace SettingsUi
+
+#endif  // SETTINGSUI_H

--- a/src/game/physics/physicsconfiguration.cpp
+++ b/src/game/physics/physicsconfiguration.cpp
@@ -59,8 +59,8 @@ std::string PhysicsConfiguration::serialize()
           {"player_wall_slide_friction", _player_wall_slide_friction},
 
           {"player_wall_jump_frame_count", _player_wall_jump_frame_count},
-          {"player_wall_jump_vector_x", _player_wall_jump_vector_y},
-          {"player_wall_jump_vector_y", _player_wall_jump_vector_x},
+          {"player_wall_jump_vector_x", _player_wall_jump_vector_x},
+          {"player_wall_jump_vector_y", _player_wall_jump_vector_y},
           {"player_wall_jump_multiplier", _player_wall_jump_multiplier},
           {"player_wall_jump_multiplier_increment_per_frame", _player_wall_jump_multiplier_increment_per_frame},
           {"player_wall_jump_multiplier_scale_per_frame", _player_wall_jump_multiplier_scale_per_frame},

--- a/src/game/physics/physicsconfigurationui.cpp
+++ b/src/game/physics/physicsconfigurationui.cpp
@@ -1,4 +1,5 @@
 #include "physicsconfigurationui.h"
+#include "game/debug/settingsui.h"
 #include "physicsconfiguration.h"
 
 #pragma warning(push, 0)
@@ -11,7 +12,9 @@
 
 PhysicsConfigurationUi::PhysicsConfigurationUi()
 #ifdef DECEPTUS_VRSFML
-    : _render_window(std::make_unique<sf::RenderWindow>(sf::RenderWindow::create(sf::WindowSettings{.size = {800u, 800u}, .title = "deceptus physics configuration"}).value()))
+    : _render_window(std::make_unique<sf::RenderWindow>(
+         sf::RenderWindow::create(sf::WindowSettings{.size = {800u, 800u}, .title = "deceptus physics configuration"}).value()
+      ))
 #else
     : _render_window(std::make_unique<sf::RenderWindow>(sf::VideoMode({800, 800}), "deceptus physics configuration"))
 #endif
@@ -39,48 +42,6 @@ void PhysicsConfigurationUi::processEvents()
 
 void PhysicsConfigurationUi::draw()
 {
-   auto drawFloatElement = [](const std::string& name, auto* value, auto min, auto max)
-   {
-      std::stringstream stream_input;
-      std::stringstream stream_slider;
-      stream_input << "##" << name << "_input";
-      stream_slider << "##" << name << "_slider";
-
-      ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.2f);
-
-      if (ImGui::InputFloat(stream_input.str().c_str(), value, 0.1f, 1.0f, "%.3f"))
-      {
-         *value = std::clamp(*value, min, max);
-      }
-
-      ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.35f);
-      ImGui::SameLine();
-      ImGui::SliderFloat(stream_slider.str().c_str(), value, min, max);
-      ImGui::SameLine();
-      ImGui::Text("%s", name.c_str());
-   };
-
-   auto drawIntElement = [](const std::string& name, auto* value, auto min, auto max)
-   {
-      std::stringstream stream_input;
-      std::stringstream stream_slider;
-      stream_input << "##" << name << "input";
-      stream_slider << "##" << name << "slider";
-
-      ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.2f);
-
-      if (ImGui::InputInt(stream_input.str().c_str(), value))
-      {
-         *value = std::clamp(*value, min, max);
-      }
-
-      ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.35f);
-      ImGui::SameLine();
-      ImGui::SliderInt(stream_slider.str().c_str(), value, min, max);
-      ImGui::SameLine();
-      ImGui::Text("%s", name.c_str());
-   };
-
    auto& config = PhysicsConfiguration::getInstance();
 
    ImGui::SFML::Update(*_render_window.get(), _clock.restart());
@@ -115,32 +76,195 @@ void PhysicsConfigurationUi::draw()
    ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.50f);
    ImGuiTreeNodeFlags header_flags = ImGuiTreeNodeFlags_DefaultOpen;
 
+   SettingsUi::beginSettings();
+
    if (ImGui::CollapsingHeader("gravity", header_flags))
    {
-      drawFloatElement("global gravity (requires level reload)", &config._gravity, -50.0f, 50.0f);
-      drawFloatElement("gravity scale default", &config._gravity_scale_default, 0.1f, 3.0f);
-      drawFloatElement("gravity scale water", &config._gravity_scale_water, 0.1f, 1.0f);
-      drawFloatElement("gravity scale jump downward", &config._gravity_scale_jump_downward, 0.5f, 3.0f);
+      SettingsUi::drawFloat(
+         "global gravity (requires level reload)",
+         &config._gravity,
+         -50.0f,
+         50.0f,
+         "Downward acceleration for the whole box2d world, in box2d units.",
+         "The world is built with it, so nothing changes until the level is reloaded. Everything else "
+         "under gravity is a per body scale on top of this one number."
+      );
+      SettingsUi::drawFloat(
+         "gravity scale default",
+         &config._gravity_scale_default,
+         0.1f,
+         3.0f,
+         "How much of the world's gravity the player feels normally.",
+         "1 is the world value. This is also what the player is put back to on leaving water and on "
+         "landing, so it is the value the other two scales are departures from."
+      );
+      SettingsUi::drawFloat(
+         "gravity scale water",
+         &config._gravity_scale_water,
+         0.1f,
+         1.0f,
+         "How much gravity the player feels while in water, so how quickly they sink.",
+         "Works together with the buoyancy force under swimming, which pushes the other way. Lowering "
+         "this and raising that both make the player float, but only buoyancy also carries them upward."
+      );
+      SettingsUi::drawFloat(
+         "gravity scale jump downward",
+         &config._gravity_scale_jump_downward,
+         0.5f,
+         3.0f,
+         "How much gravity the player feels once a jump has used up its upward frames, so how sharply "
+         "the arc turns over into the fall.",
+         "Above 1 is the point: the fall is faster than the rise, which is what stops a jump feeling "
+         "floaty at the top. Reset to the default scale on landing."
+      );
    }
 
    if (ImGui::CollapsingHeader("player velocity", header_flags))
    {
-      drawFloatElement("speed max walk", &config._player_speed_max_walk, 0.1f, 20.0f);
-      drawFloatElement("speed max run", &config._player_speed_max_run, 0.1f, 20.0f);
-      drawFloatElement("speed max water", &config._player_speed_max_water, 0.1f, 20.0f);
-      drawFloatElement("speed max air", &config._player_speed_max_air, 0.1f, 20.0f);
-      drawFloatElement("friction", &config._player_friction, 0.0f, 1.0f);
-      drawFloatElement("jump strength", &config._player_jump_strength, 0.1f, 20.0f);
-      drawFloatElement("acceleration ground", &config._player_acceleration_ground, 0.01f, 1.0f);
-      drawFloatElement("deceleration ground", &config._player_deceleration_ground, 0.01f, 1.0f);
-      drawFloatElement("acceleration air", &config._player_acceleration_air, 0.01f, 1.0f);
-      drawFloatElement("deceleration air", &config._player_deceleration_air, 0.01f, 1.0f);
-      drawFloatElement("deceleration sword attack", &config._player_deceleration_sword_attack, 0.5f, 1.0f);
-      drawFloatElement("acceleration water", &config._player_acceleration_water, 0.01f, 1.0f);
-      drawFloatElement("deceleration water", &config._player_deceleration_water, 0.01f, 1.0f);
-      drawFloatElement("cap velocity horizontal", &config._player_max_velocity_horizontal, 0.1f, 30.0f);
-      drawFloatElement("cap velocity up", &config._player_max_velocity_up, 0.1f, 30.0f);
-      drawFloatElement("cap velocity down", &config._player_max_velocity_down, 0.1f, 30.0f);
+      SettingsUi::drawFloat(
+         "speed max walk",
+         &config._player_speed_max_walk,
+         0.1f,
+         20.0f,
+         "Top horizontal speed on the ground, in box2d units.",
+         "Acceleration below only decides how quickly this is reached, never how fast the player ends "
+         "up going. Jump height also reads this as its reference speed."
+      );
+      SettingsUi::drawFloat(
+         "speed max run",
+         &config._player_speed_max_run,
+         0.1f,
+         20.0f,
+         "Top horizontal speed while the run key is held.",
+         "Running was never wired up: Player::getMaxVelocity has that branch commented out. The value "
+         "survives only as the reference the jump speed bonus is scaled against, and even that path is "
+         "marked as probably dead."
+      );
+      SettingsUi::drawFloat(
+         "speed max water",
+         &config._player_speed_max_water,
+         0.1f,
+         20.0f,
+         "Top horizontal speed while in water.",
+         "Replaces the walk and air caps entirely as soon as the player is in water."
+      );
+      SettingsUi::drawFloat(
+         "speed max air",
+         &config._player_speed_max_air,
+         0.1f,
+         20.0f,
+         "Top horizontal speed while airborne.",
+         "Above the walk speed it lets the player gain ground by jumping, which is usually not what is "
+         "wanted; the default sits above it, so a run-and-jump does travel faster than a run."
+      );
+      SettingsUi::drawFloat(
+         "friction",
+         &config._player_friction,
+         0.0f,
+         1.0f,
+         "Surface friction on the player's own collision shapes, handed straight to box2d.",
+         "0 by default, because horizontal movement is driven by setting velocity rather than by "
+         "friction. Raising it fights that and mostly makes the player catch on geometry."
+      );
+      SettingsUi::drawFloat(
+         "jump strength",
+         &config._player_jump_strength,
+         0.1f,
+         20.0f,
+         "How hard the jump pushes upward. The force is this times the player's mass, spread over the "
+         "jump's frames.",
+         "Height comes out of this together with jump frame count and jump falloff, so all three move it."
+      );
+      SettingsUi::drawFloat(
+         "acceleration ground",
+         &config._player_acceleration_ground,
+         0.01f,
+         1.0f,
+         "How much speed a held direction key adds each simulation step on the ground.",
+         "Per step, and the simulation runs 60 of them a second, so 0.1 reaches a walk speed of 2.5 in "
+         "about 25 steps. Capped by speed max walk."
+      );
+      SettingsUi::drawFloat(
+         "deceleration ground",
+         &config._player_deceleration_ground,
+         0.01f,
+         1.0f,
+         "How much of the current speed is kept each step once no direction is held, on the ground.",
+         "A survival fraction, not a subtraction: 0.6 keeps 60% per step and stops almost at once, "
+         "while 0.95 slides. Also applied when the player turns against their own momentum."
+      );
+      SettingsUi::drawFloat(
+         "acceleration air",
+         &config._player_acceleration_air,
+         0.01f,
+         1.0f,
+         "How much speed a held direction key adds each step while airborne.",
+         "Lower than the ground value gives the jump commitment: the lower this is, the less the arc "
+         "can be steered once it has started."
+      );
+      SettingsUi::drawFloat(
+         "deceleration air",
+         &config._player_deceleration_air,
+         0.01f,
+         1.0f,
+         "How much of the current speed is kept each step with no direction held, while airborne.",
+         "Same survival fraction as the ground value. Keeping it high preserves the jump's momentum "
+         "when the key is let go mid-air."
+      );
+      SettingsUi::drawFloat(
+         "deceleration sword attack",
+         &config._player_deceleration_sword_attack,
+         0.5f,
+         1.0f,
+         "How much of the current horizontal speed is kept each step while a sword attack is running.",
+         "Below 1 roots the player into the swing. It is applied on top of the ordinary deceleration "
+         "for wherever they happen to be standing."
+      );
+      SettingsUi::drawFloat(
+         "acceleration water",
+         &config._player_acceleration_water,
+         0.01f,
+         1.0f,
+         "How much speed a held direction key adds each step in water.",
+         "Together with the water deceleration below this is what makes swimming feel heavy rather "
+         "than merely slow."
+      );
+      SettingsUi::drawFloat(
+         "deceleration water",
+         &config._player_deceleration_water,
+         0.01f,
+         1.0f,
+         "How much of the current speed is kept each step with no direction held, in water.",
+         "High values glide. Note this is a survival fraction like the others, so higher means less "
+         "damping, which is the opposite of what the name suggests."
+      );
+      SettingsUi::drawFloat(
+         "cap velocity horizontal",
+         &config._player_max_velocity_horizontal,
+         0.1f,
+         30.0f,
+         "Hard ceiling on horizontal speed, applied after everything else has had its say.",
+         "A backstop, not a tuning value: it is what stops a dash or a conveyor from launching the "
+         "player. Well above the ordinary speeds by design."
+      );
+      SettingsUi::drawFloat(
+         "cap velocity up",
+         &config._player_max_velocity_up,
+         0.1f,
+         30.0f,
+         "Hard ceiling on upward speed.",
+         "Set below the speed a jump or wall jump can reach and it clips the top off them, which reads "
+         "as the jump losing height for no visible reason."
+      );
+      SettingsUi::drawFloat(
+         "cap velocity down",
+         &config._player_max_velocity_down,
+         0.1f,
+         30.0f,
+         "Hard ceiling on falling speed, i.e. terminal velocity.",
+         "Also decides how hard the worst possible landing is, so it interacts with the hard landing "
+         "damage factor further down."
+      );
    }
 
    if (ImGui::CollapsingHeader("player jump", header_flags))
@@ -155,73 +279,352 @@ void PhysicsConfigurationUi::draw()
          jump_frame_count_min_max = jump_frame_count_min_min;
       }
 
-      drawIntElement("jump frame count", &config._player_jump_frame_count, jump_frame_count_min, jump_frame_count_max);
-      drawIntElement(
-         "jump frame count minimum", &config._player_jump_frame_count_minimum, jump_frame_count_min_min, jump_frame_count_min_max
+      SettingsUi::drawInt(
+         "jump frame count",
+         &config._player_jump_frame_count,
+         jump_frame_count_min,
+         jump_frame_count_max,
+         "For how many simulation steps the jump keeps pushing upward while the button is held.",
+         "This is what makes the jump variable: releasing early ends the push early. Steps, not "
+         "milliseconds, so at 60 steps a second 9 frames is about 150 ms."
       );
-      drawIntElement("jump after contact lost [ms]", &config._player_jump_after_contact_lost_ms, jump_frame_count_min_min, 200);
-      drawIntElement("jump buffer [ms]", &config._player_jump_buffer_ms, 10, 200);
-      drawIntElement("jump minimal duration [ms]", &config._player_jump_minimal_duration_ms, 20, 200);
-      drawFloatElement("jump falloff", &config._player_jump_falloff, 1.0f, 20.0f);
-      drawFloatElement("jump speed factor", &config._player_jump_speed_factor, 0.0f, 0.5f);
-      drawFloatElement("jump impulse factor", &config._player_jump_impulse_factor, 1.0f, 20.0f);
-      drawFloatElement("minimum jump interval [ms]", &config._player_minimum_jump_interval_ms, 100.0f, 200.0f);
+      SettingsUi::drawInt(
+         "jump frame count minimum",
+         &config._player_jump_frame_count_minimum,
+         jump_frame_count_min_min,
+         jump_frame_count_min_max,
+         "How many of those steps run even if the button is released immediately, so a tap still "
+         "produces a real hop.",
+         "Capped at one below the jump frame count, since it cannot outlast the jump it belongs to."
+      );
+      SettingsUi::drawInt(
+         "jump after contact lost [ms]",
+         &config._player_jump_after_contact_lost_ms,
+         jump_frame_count_min_min,
+         200,
+         "How long after walking off an edge a jump is still accepted. Coyote time.",
+         "Forgives being a frame or two late off a ledge. Too generous and the player can jump out of "
+         "thin air well after leaving the ground."
+      );
+      SettingsUi::drawInt(
+         "jump buffer [ms]",
+         &config._player_jump_buffer_ms,
+         10,
+         200,
+         "How long before landing a jump press is remembered, so it fires on touchdown instead of "
+         "being dropped.",
+         "The mirror of coyote time: that one forgives pressing late, this one forgives pressing early."
+      );
+      SettingsUi::drawInt(
+         "jump minimal duration [ms]",
+         &config._player_jump_minimal_duration_ms,
+         20,
+         200,
+         "The jump keeps pushing for at least this long no matter what the button does.",
+         "Overlaps with jump frame count minimum, which does the same job counted in steps. Whichever "
+         "is the more generous of the two is the one that decides a tap."
+      );
+      SettingsUi::drawFloat(
+         "jump falloff",
+         &config._player_jump_falloff,
+         1.0f,
+         20.0f,
+         "Divides the jump force, so it trades directly against jump strength.",
+         "A divisor: higher means a weaker jump. Strength and falloff together set the height, which "
+         "is why neither on its own reads as the obvious height knob."
+      );
+      SettingsUi::drawFloat(
+         "jump speed factor",
+         &config._player_jump_speed_factor,
+         0.0f,
+         0.5f,
+         "How much extra height a jump gains for already moving faster than walking speed.",
+         "Only bites while the player is above walk speed, which on the ground they cannot be, so this "
+         "mostly does nothing today. Scaled against speed max run."
+      );
+      SettingsUi::drawFloat(
+         "jump impulse factor",
+         &config._player_jump_impulse_factor,
+         1.0f,
+         20.0f,
+         "The one-off upward kick used where a jump has to start instantly rather than build up: this "
+         "times the player's mass.",
+         "NOT SAVED. It is missing from the json, so anything set here is gone on the next reload or "
+         "restart."
+      );
+      SettingsUi::drawFloat(
+         "minimum jump interval [ms]",
+         &config._player_minimum_jump_interval_ms,
+         100.0f,
+         200.0f,
+         "The shortest time allowed between two jumps, which is what stops jump spam.",
+         "NOT SAVED. Missing from the json as well, so it goes back to its built-in value on reload."
+      );
    }
 
    if (ImGui::CollapsingHeader("player attack dash", header_flags))
    {
-      drawIntElement("attack dash frame count", &config._player_attack_dash_frame_count, 1, 100);
-      drawFloatElement("attack dash multiplier", &config._player_attack_dash_multiplier, 1.0f, 100.0f);
-      drawFloatElement("attack dash multiplier dec. per frame", &config._player_attack_dash_multiplier_decrement_per_frame, 0.1f, 10.0f);
-      drawFloatElement("attack dash multiplier scale per frame", &config._player_attack_dash_multiplier_scale_per_frame, 0.1f, 5.0f);
+      SettingsUi::drawInt(
+         "attack dash frame count",
+         &config._player_attack_dash_frame_count,
+         1,
+         100,
+         "For how many simulation steps the lunge that comes with an attack pushes the player forward.",
+         "Its force is built from the dash vector down under player dash, so that value moves both."
+      );
+      SettingsUi::drawFloat(
+         "attack dash multiplier",
+         &config._player_attack_dash_multiplier,
+         1.0f,
+         100.0f,
+         "How hard the attack lunge starts out.",
+         "It only ever falls from here, by the decrement below, so this is the peak of the lunge."
+      );
+      SettingsUi::drawFloat(
+         "attack dash multiplier dec. per frame",
+         &config._player_attack_dash_multiplier_decrement_per_frame,
+         0.1f,
+         10.0f,
+         "How much of the lunge's strength is taken away each step.",
+         "Subtracted, so larger values make a shorter, sharper lunge. Set it high enough to reach zero "
+         "before the frame count runs out and the lunge simply stops early."
+      );
+      SettingsUi::drawFloat(
+         "attack dash multiplier scale per frame",
+         &config._player_attack_dash_multiplier_scale_per_frame,
+         0.1f,
+         5.0f,
+         "A plain multiplier on the lunge force.",
+         "Despite the name it is applied to the force rather than accumulated into the strength, so it "
+         "scales the whole lunge evenly instead of compounding over its frames."
+      );
    }
 
    if (ImGui::CollapsingHeader("player dash", header_flags))
    {
-      drawIntElement("dash frame count", &config._player_dash_frame_count, 1, 100);
-      drawFloatElement("dash multiplier", &config._player_dash_multiplier, 1.0f, 100.0f);
-      drawFloatElement("dash multiplier inc. per frame", &config._player_dash_multiplier_increment_per_frame, -10.0f, -0.1f);
-      drawFloatElement("dash multiplier scale per frame", &config._player_dash_multiplier_scale_per_frame, 0.1f, 5.0f);
-      drawFloatElement("dash vector", &config._player_dash_vector, 0.1f, 50.0f);
+      SettingsUi::drawInt(
+         "dash frame count",
+         &config._player_dash_frame_count,
+         1,
+         100,
+         "For how many simulation steps a dash pushes the player sideways.",
+         "Gravity is switched off for the whole dash, so this is also how long the player hangs in the "
+         "air. A dash needs the Dash skill, costs stamina, and cannot restart within a second."
+      );
+      SettingsUi::drawFloat(
+         "dash multiplier",
+         &config._player_dash_multiplier,
+         1.0f,
+         100.0f,
+         "How hard the dash starts out.",
+         "The two values below change it as the dash runs, so this is only its opening strength."
+      );
+      SettingsUi::drawFloat(
+         "dash multiplier inc. per frame",
+         &config._player_dash_multiplier_increment_per_frame,
+         -10.0f,
+         -0.1f,
+         "How much the dash's strength changes each step. Negative, so it fades.",
+         "If it reaches zero before the frame count is up, the rest of the dash pushes backwards. Keep "
+         "frame count times this below the starting multiplier."
+      );
+      SettingsUi::drawFloat(
+         "dash multiplier scale per frame",
+         &config._player_dash_multiplier_scale_per_frame,
+         0.1f,
+         5.0f,
+         "A multiplier applied to the dash's strength every step.",
+         "This one really does compound, because it is applied to the stored strength: anything above "
+         "1 grows the dash exponentially over its frames. 1 leaves it alone."
+      );
+      SettingsUi::drawFloat(
+         "dash vector",
+         &config._player_dash_vector,
+         0.1f,
+         50.0f,
+         "The force one unit of dash strength is worth, times the player's mass.",
+         "Shared with the attack lunge above, so changing it retunes both."
+      );
    }
 
    if (ImGui::CollapsingHeader("wall slide", header_flags))
    {
-      drawFloatElement("wall slide friction", &config._player_wall_slide_friction, 0.0f, 1.0f);
+      SettingsUi::drawFloat(
+         "wall slide friction",
+         &config._player_wall_slide_friction,
+         0.0f,
+         1.0f,
+         "How strongly sliding down a wall is braked. The force opposes the player's own velocity, "
+         "scaled by this.",
+         "0 is a free fall down the wall, 1 nearly pins them to it. Wall sliding is also the state a "
+         "wall jump has to be launched from."
+      );
    }
 
    if (ImGui::CollapsingHeader("wall jump", header_flags))
    {
-      drawIntElement("wall jump frame count", &config._player_wall_jump_frame_count, 1, 50);
-      drawFloatElement("wall jump vector x", &config._player_wall_jump_vector_x, 0.0f, 20.0f);
-      drawFloatElement("wall jump vector y", &config._player_wall_jump_vector_y, 0.0f, 20.0f);
-      drawFloatElement("wall jump multiplier", &config._player_wall_jump_multiplier, 1.0f, 50.0f);
-      drawFloatElement("wall jump multiplier inc. per frame", &config._player_wall_jump_multiplier_increment_per_frame, -10.0f, -0.1f);
-      drawFloatElement("wall jump multiplier scale per frame", &config._player_wall_jump_multiplier_scale_per_frame, 0.1f, 5.0f);
-      drawFloatElement("wall jump extra force", &config._player_wall_jump_extra_force, 0.0f, 5.0f);
-      drawIntElement("wall jump lock key duration [ms]", &config._player_wall_jump_lock_key_duration_ms, 0, 2000);
+      SettingsUi::drawInt(
+         "wall jump frame count",
+         &config._player_wall_jump_frame_count,
+         1,
+         50,
+         "For how many simulation steps the wall jump keeps pushing away from the wall.",
+         "Runs alongside the key lock further down, which is what stops the player steering straight "
+         "back into the wall they just left."
+      );
+      SettingsUi::drawFloat(
+         "wall jump vector x",
+         &config._player_wall_jump_vector_x,
+         0.0f,
+         20.0f,
+         "How hard the wall jump throws the player away from the wall, times their mass.",
+         "This against the y value below is the angle of the launch. The player's velocity is zeroed "
+         "first, so the wall jump does not inherit the fall."
+      );
+      SettingsUi::drawFloat(
+         "wall jump vector y",
+         &config._player_wall_jump_vector_y,
+         0.0f,
+         20.0f,
+         "How hard the wall jump throws the player upward, times their mass.",
+         "Small against the x value gives a long flat leap, large gives a climb up the wall."
+      );
+      SettingsUi::drawFloat(
+         "wall jump multiplier",
+         &config._player_wall_jump_multiplier,
+         1.0f,
+         50.0f,
+         "How hard the wall jump's push starts out, before the two values below wear it down.",
+         "Mirrors the dash: a starting strength that is changed every step while the jump runs."
+      );
+      SettingsUi::drawFloat(
+         "wall jump multiplier inc. per frame",
+         &config._player_wall_jump_multiplier_increment_per_frame,
+         -10.0f,
+         -0.1f,
+         "How much the wall jump's strength changes each step. Negative, so it fades.",
+         "As with the dash, letting it cross zero inside the frame count turns the push around."
+      );
+      SettingsUi::drawFloat(
+         "wall jump multiplier scale per frame",
+         &config._player_wall_jump_multiplier_scale_per_frame,
+         0.1f,
+         5.0f,
+         "A multiplier applied to the wall jump's strength every step.",
+         "1 leaves it alone. Above 1 compounds over the jump's frames."
+      );
+      SettingsUi::drawFloat(
+         "wall jump extra force",
+         &config._player_wall_jump_extra_force,
+         0.0f,
+         5.0f,
+         "Extra push given to a jump that has to overcome an existing fall, scaled by how fast the "
+         "player is already falling.",
+         "Used by the wall jump and the double jump, not by an ordinary jump, so that neither is eaten "
+         "by the fall it starts from."
+      );
+      SettingsUi::drawInt(
+         "wall jump lock key duration [ms]",
+         &config._player_wall_jump_lock_key_duration_ms,
+         0,
+         2000,
+         "How long the direction keys are forced after a wall jump: away from the wall held, back "
+         "towards it ignored.",
+         "Too short and holding towards the wall cancels the jump on the spot; too long and the player "
+         "cannot steer at all after one."
+      );
    }
 
    if (ImGui::CollapsingHeader("double jump", header_flags))
    {
-      drawFloatElement("double jump factor", &config._player_double_jump_factor, 1.0f, 20.0f);
+      SettingsUi::drawFloat(
+         "double jump factor",
+         &config._player_double_jump_factor,
+         1.0f,
+         20.0f,
+         "The upward kick of the second jump: this times the player's mass, applied in one go.",
+         "A single impulse rather than a push over several frames, so unlike the first jump its height "
+         "does not depend on how long the button is held."
+      );
    }
 
    if (ImGui::CollapsingHeader("hard landing", header_flags))
    {
-      ImGui::Checkbox("hard landing damage enabled", &config._player_hard_landing_damage_enabled);
-      drawFloatElement("hard landing damage factor", &config._player_hard_landing_damage_factor, 0.0f, 50.0f);
-      drawFloatElement("hard landing delay [s]", &config._player_hard_landing_delay_s, 0.0f, 5.0f);
+      SettingsUi::drawBool(
+         "hard landing damage enabled",
+         &config._player_hard_landing_damage_enabled,
+         "Whether landing hard enough costs health.",
+         "Off still leaves the landing itself: the player is stunned for the delay below either way."
+      );
+      SettingsUi::drawFloat(
+         "hard landing damage factor",
+         &config._player_hard_landing_damage_factor,
+         0.0f,
+         50.0f,
+         "How much health a hard landing costs, per unit of landing impulse above the threshold.",
+         "Measured against the impulse, so the ceiling on falling speed up under player velocity sets "
+         "the worst case this can produce."
+      );
+      SettingsUi::drawFloat(
+         "hard landing delay [s]",
+         &config._player_hard_landing_delay_s,
+         0.0f,
+         5.0f,
+         "How long the player is stuck in the landing before they can move again.",
+         "Applies whether or not the damage above is enabled, so this is the knob for how punishing a "
+         "long fall feels."
+      );
    }
 
    if (ImGui::CollapsingHeader("swimming", header_flags))
    {
-      drawFloatElement("in water force jump button", &config._player_in_water_force_jump_button, -10.0f, 0.0f);
-      drawIntElement("in water time to allow jump button [ms]", &config._player_in_water_time_to_allow_jump_button_ms, 0, 2000);
-      drawFloatElement("in water linear velocity y clamp min", &config._player_in_water_linear_velocity_y_clamp_min, -5.0f, 0.0f);
-      drawFloatElement("in water linear velocity y clamp max", &config._player_in_water_linear_velocity_y_clamp_max, 0.0f, 5.0f);
-      drawFloatElement("in water buoyancy force", &config._in_water_buoyancy_force, 0.0f, 0.2f);
+      SettingsUi::drawFloat(
+         "in water force jump button",
+         &config._player_in_water_force_jump_button,
+         -10.0f,
+         0.0f,
+         "The upward force holding the jump button gives while in water, i.e. how the player swims up.",
+         "Negative is upward here, because box2d's y axis points down. Only applied after the delay "
+         "below has passed."
+      );
+      SettingsUi::drawInt(
+         "in water time to allow jump button [ms]",
+         &config._player_in_water_time_to_allow_jump_button_ms,
+         0,
+         2000,
+         "How long after entering water the jump button starts pushing upward instead of jumping.",
+         "It exists so that diving in does not immediately bounce the player back out on a button they "
+         "were already holding."
+      );
+      SettingsUi::drawFloat(
+         "in water linear velocity y clamp min",
+         &config._player_in_water_linear_velocity_y_clamp_min,
+         -5.0f,
+         0.0f,
+         "Fastest the player may rise in water. Negative is upward.",
+         "The pair of clamps is what keeps swimming feeling like water rather than like flight, "
+         "whatever buoyancy and the jump force add up to."
+      );
+      SettingsUi::drawFloat(
+         "in water linear velocity y clamp max",
+         &config._player_in_water_linear_velocity_y_clamp_max,
+         0.0f,
+         5.0f,
+         "Fastest the player may sink in water.",
+         "Independent of the ordinary falling ceiling, so entering water always slows the fall."
+      );
+      SettingsUi::drawFloat(
+         "in water buoyancy force",
+         &config._in_water_buoyancy_force,
+         0.0f,
+         0.2f,
+         "Constant upward force on a submerged player, as a fraction of the world's gravity.",
+         "Above the water gravity scale the player floats up on their own. Together with that scale it "
+         "decides whether water is something to sink in or something to bob in."
+      );
    }
+
+   SettingsUi::endSettings();
 
    ImGui::End();
 

--- a/src/game/physics/physicsconfigurationui.cpp
+++ b/src/game/physics/physicsconfigurationui.cpp
@@ -95,8 +95,9 @@ void PhysicsConfigurationUi::draw()
          0.1f,
          3.0f,
          "How much of the world's gravity the player feels normally.",
-         "1 is the world value. This is also what the player is put back to on leaving water and on "
-         "landing, so it is the value the other two scales are departures from."
+         "NOT SAVED - it is missing from the json, so it returns to 1 on the next reload. This is also "
+         "what the player is put back to on leaving water and on landing, so the other two scales are "
+         "departures from it."
       );
       SettingsUi::drawFloat(
          "gravity scale water",
@@ -104,8 +105,9 @@ void PhysicsConfigurationUi::draw()
          0.1f,
          1.0f,
          "How much gravity the player feels while in water, so how quickly they sink.",
-         "Works together with the buoyancy force under swimming, which pushes the other way. Lowering "
-         "this and raising that both make the player float, but only buoyancy also carries them upward."
+         "NOT SAVED, like the other two scales. Works against the buoyancy force under swimming, which "
+         "pushes the other way: lowering this and raising that both make the player float, but only "
+         "buoyancy also carries them upward."
       );
       SettingsUi::drawFloat(
          "gravity scale jump downward",
@@ -114,8 +116,9 @@ void PhysicsConfigurationUi::draw()
          3.0f,
          "How much gravity the player feels once a jump has used up its upward frames, so how sharply "
          "the arc turns over into the fall.",
-         "Above 1 is the point: the fall is faster than the rise, which is what stops a jump feeling "
-         "floaty at the top. Reset to the default scale on landing."
+         "NOT SAVED, like the other two scales. Above 1 is the point - the fall is faster than the "
+         "rise, which is what stops a jump feeling floaty at the top. Reset to the default scale on "
+         "landing."
       );
    }
 
@@ -154,8 +157,8 @@ void PhysicsConfigurationUi::draw()
          0.1f,
          20.0f,
          "Top horizontal speed while airborne.",
-         "Above the walk speed it lets the player gain ground by jumping, which is usually not what is "
-         "wanted; the default sits above it, so a run-and-jump does travel faster than a run."
+         "Above the walk speed it would let the player gain ground by jumping. It currently ships just "
+         "below it, 2.4 against 2.5, so a jump costs a sliver of speed rather than buying any."
       );
       SettingsUi::drawFloat(
          "friction",
@@ -181,8 +184,8 @@ void PhysicsConfigurationUi::draw()
          0.01f,
          1.0f,
          "How much speed a held direction key adds each simulation step on the ground.",
-         "Per step, and the simulation runs 60 of them a second, so 0.1 reaches a walk speed of 2.5 in "
-         "about 25 steps. Capped by speed max walk."
+         "Per step, and the simulation runs 60 of them a second, so the shipped 0.5 reaches the walk "
+         "speed of 2.5 in five steps, under a tenth of a second. Capped by speed max walk."
       );
       SettingsUi::drawFloat(
          "deceleration ground",
@@ -190,8 +193,9 @@ void PhysicsConfigurationUi::draw()
          0.01f,
          1.0f,
          "How much of the current speed is kept each step once no direction is held, on the ground.",
-         "A survival fraction, not a subtraction: 0.6 keeps 60% per step and stops almost at once, "
-         "while 0.95 slides. Also applied when the player turns against their own momentum."
+         "A survival fraction, not a subtraction. The shipped 0.1 keeps a tenth of the speed per step, "
+         "so the player stops within a few frames; 0.95 would slide. Also applied when they turn "
+         "against their own momentum."
       );
       SettingsUi::drawFloat(
          "acceleration air",
@@ -199,8 +203,8 @@ void PhysicsConfigurationUi::draw()
          0.01f,
          1.0f,
          "How much speed a held direction key adds each step while airborne.",
-         "Lower than the ground value gives the jump commitment: the lower this is, the less the arc "
-         "can be steered once it has started."
+         "Currently the same as the ground value, so the arc can be steered as freely as a walk. "
+         "Lowering it below the ground value is what would give a jump commitment."
       );
       SettingsUi::drawFloat(
          "deceleration air",
@@ -208,8 +212,9 @@ void PhysicsConfigurationUi::draw()
          0.01f,
          1.0f,
          "How much of the current speed is kept each step with no direction held, while airborne.",
-         "Same survival fraction as the ground value. Keeping it high preserves the jump's momentum "
-         "when the key is let go mid-air."
+         "Same survival fraction as on the ground, and shipped lower - 0.05 against 0.1 - so letting "
+         "go mid-air kills horizontal speed faster than it does on the ground. Raise it to keep the "
+         "jump's momentum."
       );
       SettingsUi::drawFloat(
          "deceleration sword attack",
@@ -425,8 +430,9 @@ void PhysicsConfigurationUi::draw()
          -10.0f,
          -0.1f,
          "How much the dash's strength changes each step. Negative, so it fades.",
-         "If it reaches zero before the frame count is up, the rest of the dash pushes backwards. Keep "
-         "frame count times this below the starting multiplier."
+         "If it reaches zero before the frame count is up, the rest of the dash pushes backwards. The "
+         "shipped values are tuned to land on zero exactly as the dash ends: 40 strength losing 1 over "
+         "40 frames."
       );
       SettingsUi::drawFloat(
          "dash multiplier scale per frame",
@@ -503,7 +509,8 @@ void PhysicsConfigurationUi::draw()
          -10.0f,
          -0.1f,
          "How much the wall jump's strength changes each step. Negative, so it fades.",
-         "As with the dash, letting it cross zero inside the frame count turns the push around."
+         "As with the dash, letting it cross zero inside the frame count turns the push around, and the "
+         "shipped values land on zero exactly as the jump ends: 20 losing 1 over 20 frames."
       );
       SettingsUi::drawFloat(
          "wall jump multiplier scale per frame",


### PR DESCRIPTION
> Stacked on #457, so the base is `fix/scroll-smoothness` and the diff here is only this work.
> GitHub retargets it to `master` automatically once #457 merges.

Neither configuration editor said anything about what its values do, and several of them cannot be
worked out from the name. Every row now carries a plain sentence, and where there is something to know
a second line for it.

## The UX choice

The help sits in a **pane pinned to the bottom of the window**, showing whatever the pointer is over â€”
or whatever slider is currently being dragged.

A tooltip was the obvious alternative and is worse here: it disappears the moment a drag starts, which
is exactly when the reader wants to know what the value does, and while it is up it covers the
neighbouring rows. The pane stays put, survives the drag, and has room for two lines rather than a
fragment.

Its height is measured from the text it is about to show, using what was pointed at on the previous
frame, so a long note is never clipped and a short one does not reserve empty space.

## What the notes are for

The second line is where the things that are not guessable go:

- **Units and what the number really is.** Every "deceleration" is the fraction of speed *kept* per
  simulation step, not an amount subtracted â€” so higher means *less* damping, the opposite of what the
  name suggests.
- **What a value is measured against.** Jump height comes out of jump strength and jump falloff
  together, falloff being a divisor, which is why neither reads as the height knob. The camera's lead
  factor is a fraction of the velocity factor's own time constant, so changing one changes the other.
- **Where a name lies.** `dash multiplier scale per frame` compounds, because it is applied to the
  stored strength; the attack-dash one with the same name does not, because it is applied to the force.
- **Settings that are not what they look like:**
  - `speed max run` â€” running was never wired up; `Player::getMaxVelocity` has that branch commented
    out. It survives only as the reference the jump speed bonus is scaled against, and that path is
    itself marked as probably dead.
  - `jump speed factor` â€” only bites above walk speed, which on the ground the player cannot be.
  - `jump impulse factor` and `minimum jump interval [ms]` â€” **not saved**. They are missing from the
    json, so anything set in the editor is gone on the next reload.

## Two bugs the survey turned up

Both were found by trying to write an honest description of a setting, and both are separate commits.

- **`panic acceleration factor` did nothing.** Serialized, deserialized, had a slider, and
  `CameraSystem::updateY` used a hardcoded `2.0f` instead of reading it. Its default *is* 2.0f, so
  wiring it up changes no behaviour â€” it only makes the slider real.
- **The physics editor transposed the wall jump vector on save.** `serialize()` wrote
  `_player_wall_jump_vector_y` under the key `player_wall_jump_vector_x` and vice versa, while
  `deserialize()` read both straight. One use of *File â†’ Save Physics* and the next launch had a wall
  jump pushing 1 sideways and 6 upward instead of 6 and 1. `data/config/physics.json` is hand-written
  and correct, so the game has always behaved â€” the bug sat waiting in the editor.

## Shape of the change

The rows were two lambdas copied verbatim into both editors. They move into `SettingsUi` so a row only
learns about its explanation once, and gain a checkbox variant so those can be described too. 56 rows
across the two editors are converted.

The log and profiling windows are read-only viewers with no settings, so nothing to do there.

`imgui.ini` is now gitignored â€” imgui writes it into the working directory as soon as an editor is
opened.

## Verified

Both editors were driven and captured: the pane pins correctly, shows the name with its range, the
explanation, and the note dimmed beneath it, and follows the pointer.

Reading the physics pane back is what caught a whole class of mistake in my own notes - several were
written against the struct defaults rather than against `data/config/physics.json`, which overrides most
of them. A wrong note is worse than no note, so they are corrected in their own commit:

| setting | the note said | the game ships |
|---|---|---|
| `speed max air` | above walk speed, so a run-and-jump gains ground | 2.4 against a walk of 2.5, so it costs a sliver |
| `acceleration ground` | 0.1, reaching walk speed in ~25 steps | 0.5, reaching it in 5 |
| `deceleration ground` | example worked through 0.6 | 0.1 |
| `acceleration air` | lower than the ground value | equal to it |
| `deceleration air` | high, preserving momentum | 0.05 against the ground's 0.1, so it loses speed faster |

Three more settings turn out not to be persisted at all - the three gravity scales, marked
`// not in json` in the header - and now say so, alongside the two jump values already flagged. Both
fading multipliers also turn out to be tuned to hit zero exactly as their move ends (40 losing 1 over 40
frames for the dash, 20 over 20 for the wall jump), which is worth knowing before either frame count is
touched.

## Not covered

`lab/animation_editor` and `lab/cutscene_editor` are left alone deliberately. They are document editors
rather than settings editors: their fields are properties of the thing being authored (`Time (seconds)`,
`Target X`, `Frame Size`) rather than tuning knobs with units and interactions, so they are largely
self-describing. They are also separate CMake targets, and cutscene semantics already live in
`data/scripts/cutscene.md`. Happy to extend `SettingsUi` to them if you want the consistency.

