### PR TITLE
say who owns the artwork in plain english

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,5 +246,5 @@ The engine is released under
 [Creative Commons Attribution-NonCommercial 4.0 International](LICENSE.md) and is free to use on
 those terms.
 
-The artwork is not. It is copyright dstar and is in this repository so that the engine has a game
-to run, not for reuse. If you want to use any of it, ask first.
+The artwork is not. dstar owns it. It is in this repository so that the engine has a game to run,
+and it is not licensed for reuse, so ask first if you want to use any of it.


### PR DESCRIPTION
Follow-up to #460. The license section said the artwork "is copyright dstar", which is the legal
notice shorthand ("Copyright © dstar") dropped into a running sentence, where it just reads like a
word is missing.

Before:

> The artwork is not. It is copyright dstar and is in this repository so that the engine has a game
> to run, not for reuse. If you want to use any of it, ask first.

After:

> The artwork is not. dstar owns it. It is in this repository so that the engine has a game to run,
> and it is not licensed for reuse, so ask first if you want to use any of it.

Same meaning, no legalese.
