### PR TITLE
link the switch build doc from the documentation index

### DIFF
--- a/doc/readme.md
+++ b/doc/readme.md
@@ -100,14 +100,7 @@
 ## Development
 
 - [Development Hotkeys](development_hotkeys.md)<br>
-- [Building and Running for the Nintendo Switch](switch_build.md#building-and-running-for-the-nintendo-switch)<br>
-    - [Prerequisites](switch_build.md#prerequisites)<br>
-    - [Build](switch_build.md#build)<br>
-    - [Verify the build](switch_build.md#verify-the-build)<br>
-    - [Run it in Ryujinx](switch_build.md#run-it-in-ryujinx)<br>
-    - [Run it on hardware](switch_build.md#run-it-on-hardware)<br>
-    - [Diagnostic builds](switch_build.md#diagnostic-builds)<br>
-    - [Working on the port itself](switch_build.md#working-on-the-port-itself)<br>
+- [Building and Running for the Nintendo Switch](switch_build.md)<br>
 
 
 ## Creating Your Own Enemies

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -100,6 +100,14 @@
 ## Development
 
 - [Development Hotkeys](development_hotkeys.md)<br>
+- [Building and Running for the Nintendo Switch](switch_build.md#building-and-running-for-the-nintendo-switch)<br>
+    - [Prerequisites](switch_build.md#prerequisites)<br>
+    - [Build](switch_build.md#build)<br>
+    - [Verify the build](switch_build.md#verify-the-build)<br>
+    - [Run it in Ryujinx](switch_build.md#run-it-in-ryujinx)<br>
+    - [Run it on hardware](switch_build.md#run-it-on-hardware)<br>
+    - [Diagnostic builds](switch_build.md#diagnostic-builds)<br>
+    - [Working on the port itself](switch_build.md#working-on-the-port-itself)<br>
 
 
 ## Creating Your Own Enemies


### PR DESCRIPTION
`doc/switch_build.md` is 305 lines — prerequisites, build, CI, verifying the `.nro`, Ryujinx,
hardware, reading the log, diagnostic builds, working on the port — and the documentation index
never mentioned it. Its only inbound link was one line at the bottom of the Switch section on the
main page, which matters because the main page calls `doc/readme.md` "the complete documentation".

The `## Development` section contained exactly one entry, the hotkeys. It now carries the Switch
build doc as a second one line link.

Not included: `switch_port_status.md` and `wasm_port_status.md` at the repository root. Those read
as working notes on the ports rather than documentation.
