### PR TITLE
drop three leftover debug prints from the log

### DIFF
--- a/src/game/mechanisms/gamemechanismobserver.cpp
+++ b/src/game/mechanisms/gamemechanismobserver.cpp
@@ -28,11 +28,8 @@ void GameMechanismObserver::onEvent(
    const LuaVariant& value
 )
 {
-   Log::Info() << _event_listeners.size();
-
    for (const auto& listener : _event_listeners)
    {
-      Log::Info() << "notifying event receiver";
       listener(object_id, object_group, event_name, value);
    }
 }

--- a/src/game/player/playercontrols.cpp
+++ b/src/game/player/playercontrols.cpp
@@ -520,8 +520,6 @@ int PlayerControls::getKeysPressed() const
 
 void PlayerControls::setKeysPressed(int32_t keysPressed)
 {
-   Log::Info() << "setKeysPressed";
-
    _keys_pressed = keysPressed;
 }
 


### PR DESCRIPTION
Three log statements that carried nothing a reader could act on.

`GameMechanismObserver::onEvent` logged `_event_listeners.size()` as a bare number with no label,
then `notifying event receiver` once per listener, so a single mechanism event produced a burst
like this:

```
gamemechanismobserver.cpp:31: 2
gamemechanismobserver.cpp:35: notifying event receiver
gamemechanismobserver.cpp:35: notifying event receiver
```

`PlayerControls::setKeysPressed` logged its own name on every control state change, so simply
walking around filled the console with `setKeysPressed`.

Builds and links clean. Nothing in the render path is touched.
