### PR TITLE
tidy up the main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![WASM](https://github.com/varnholt/deceptus_engine/actions/workflows/wasm.yml/badge.svg)](https://github.com/varnholt/deceptus_engine/actions/workflows/wasm.yml)
 [![Switch](https://github.com/varnholt/deceptus_engine/actions/workflows/switch.yml/badge.svg)](https://github.com/varnholt/deceptus_engine/actions/workflows/switch.yml)
 
-A C++23/lua-based platformer game engine<br>
+A C++23/Lua-based platformer game engine<br>
 Levels are drawn in Tiled, enemies and cutscenes are scripted in Lua, and the engine renders them
 with deferred lighting, baked ambient occlusion, water, weather and parallax. Box2D does the game
 physics, SFML the rendering, SDL the game controller support.
@@ -24,7 +24,7 @@ The clip is also available as an [MP4](doc/screenshots/gameplay.mp4) at full res
 
 # Get a Build
 
-Every push to `master` is built for all five targets. These links always give you the newest
+Every push to `master` is built for all five platforms. These links always give you the newest
 successful build and need no GitHub account:
 
 |Platform|Download|
@@ -111,8 +111,9 @@ gravity flip, ambient light, zoom, and recording and replaying player input — 
 [development_hotkeys.md](doc/development_hotkeys.md).
 
 All of this instrumentation is compiled into the desktop builds by default. The web and Switch
-builds leave it out, since neither has a window to put it in; `-DDECEPTUS_DEVELOPMENT_MODE=ON`
-puts it back for a profiling run.
+builds ship without it, because it is overhead in a build meant to run fast and on the Switch
+every report is a write to the sd card. `-DDECEPTUS_DEVELOPMENT_MODE=ON` puts it back for a
+profiling run.
 
 
 # Documentation
@@ -130,17 +131,9 @@ The complete documentation lives in [doc/readme.md](doc/readme.md). The most tra
 |Development hotkeys|[development_hotkeys.md](doc/development_hotkeys.md)|
 
 
-# Credits
-
-|What|Who|
-|-|-|
-|Artwork|dstar|
-|Code|mueslee (Matthias Varnholt)|
-
-
 # How to Build
 
-For the three desktop targets, only a compiler, CMake and the platform's development headers are
+For the three desktop platforms, only a compiler, CMake and the platform's development headers are
 needed. SFML 3, SDL 3, Lua 5.4 and GLEW are downloaded and built by CMake via `FetchContent`;
 Box2D, ImGui, tinyxml2 and glm are vendored in the source tree.
 
@@ -154,7 +147,7 @@ differ. Their cross compilers are not something you install next to a system com
 builds wrap a container and there is nothing to set up locally.
 
 ## Windows
-```bash
+```bat
 cmake -B build -A x64 -DCMAKE_BUILD_TYPE=Release
 cmake --build build --config Release --parallel
 ```
@@ -233,8 +226,18 @@ HOME menu — or it runs out of memory during asset loading.
 Ryujinx, and how to work on the port itself.
 
 
-# Contribute and Talk to Us!
-If you're a musician, graphic artist, level designer or programmer, or just want to hang out and chat, [please join us on Discord!](https://discord.gg/EZpkbGDaWD)
+# Contributing
+
+If you're a musician, graphic artist, level designer or programmer, or just want to hang out and
+chat, [please join us on Discord!](https://discord.gg/EZpkbGDaWD)
+
+
+# Credits
+
+|What|Who|
+|-|-|
+|Artwork|dstar|
+|Code|mueslee (Matthias Varnholt)|
 
 
 # License

--- a/README.md
+++ b/README.md
@@ -150,9 +150,8 @@ gcc 13 or Clang 15 will not do.
 
 [Web](#web-webassembly) and [Nintendo Switch](#nintendo-switch-homebrew) come out of the same
 CMake project as the rest, with `EMSCRIPTEN` and `NINTENDO_SWITCH` branches where the platforms
-differ. They have sections of their own further down only because their cross compilers are not
-something you install next to a system compiler — each build wraps a container instead, so there
-is nothing to set up locally.
+differ. Their cross compilers are not something you install next to a system compiler, so both
+builds wrap a container and there is nothing to set up locally.
 
 ## Windows
 ```bash
@@ -184,15 +183,6 @@ brew install llvm glm ninja
 
 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
 cmake --build build --parallel
-```
-
-## Running
-
-The game reads `data/` relative to the working directory, so run it from the repository root:
-
-```bash
-./build/deceptus            # Linux, macOS
-build\Release\deceptus.exe  # Windows
 ```
 
 ## Web (WebAssembly)

--- a/README.md
+++ b/README.md
@@ -140,12 +140,19 @@ The complete documentation lives in [doc/readme.md](doc/readme.md). The most tra
 
 # How to Build
 
-Only a compiler, CMake and the platform's development headers are needed. SFML 3, SDL 3,
-Lua 5.4 and GLEW are downloaded and built by CMake via `FetchContent`; Box2D, ImGui, tinyxml2
-and glm are vendored in the source tree.
+For the three desktop targets, only a compiler, CMake and the platform's development headers are
+needed. SFML 3, SDL 3, Lua 5.4 and GLEW are downloaded and built by CMake via `FetchContent`;
+Box2D, ImGui, tinyxml2 and glm are vendored in the source tree.
 
 The engine uses C++23, so the compiler has to be recent. CI builds with gcc 14, MSVC 2022,
-Homebrew LLVM and the latest Emscripten. Anything older than gcc 13 or Clang 15 will not do.
+Homebrew LLVM, the latest Emscripten and devkitPro's aarch64 toolchain. Anything older than
+gcc 13 or Clang 15 will not do.
+
+[Web](#web-webassembly) and [Nintendo Switch](#nintendo-switch-homebrew) come out of the same
+CMake project as the rest, with `EMSCRIPTEN` and `NINTENDO_SWITCH` branches where the platforms
+differ. They have sections of their own further down only because their cross compilers are not
+something you install next to a system compiler — each build wraps a container instead, so there
+is nothing to set up locally.
 
 ## Windows
 ```bash

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ chat, [please join us on Discord!](https://discord.gg/EZpkbGDaWD)
 |What|Who|
 |-|-|
 |Artwork|dstar|
-|Code|mueslee (Matthias Varnholt)|
+|Code|Matthias Varnholt|
 
 
 # License


### PR DESCRIPTION
Started as the build introduction still describing a four target project, grew into the
consistency pass that followed.

**The build introduction predated the Switch.** `0bc39b81 docs(readme): refresh the front page`
wrote it on 2026-08-03; `3abdb56a mention the switch alongside the other targets in the readme`
appended the Switch on 2026-08-16 without revisiting the top. So it claimed "only a compiler,
CMake and the platform's development headers are needed", which holds for the three desktop
platforms and not the two cross compiled ones, and listed a CI toolchain set without devkitPro,
even though `switch.yml` builds in `devkitpro/devkita64:20260219`. Both fixed, and a paragraph now
says outright that Web and Switch are the same CMake project behind `EMSCRIPTEN` and
`NINTENDO_SWITCH` branches.

**Dropped the `Running` section.** It explained how to start a binary to people who had already
built it, and it sat between the three desktop sections and the two cross compiled ones, which is
what made the ordering look arbitrary. How to Build is now five platform sections and nothing else.

**Moved `Credits`.** It sat between Documentation and How to Build, splitting the two sections a
developer wants from each other. It now sits with Contributing and License, and credits the code
to Matthias Varnholt rather than to mueslee.

**Consistency.** Lua was lowercase in the first line of prose. "targets" and "platforms" were used
interchangeably for the same five things; it is platforms everywhere now, matching the table
header. The Windows build block was fenced `bash` while holding cmake calls for a Windows shell.
"Contribute and Talk to Us!" was the only heading phrased as an address to the reader, the only
one with an exclamation mark, the only one with no blank line under it, and the only body not
wrapped like the rest of the file.

**One correction.** The note on `DEVELOPMENT_MODE` said the web and Switch builds leave the
instrumentation out "since neither has a window to put it in". That is the reason for the
profiling ui alone — it also removes the debug draw and the console, which need no window.
`CMakeLists.txt` gives the real reasons: the cost of the whole diagnostic apparatus, and the sd
card write per report on the console.
