### PR TITLE
measure the update half of the frame

### DIFF
--- a/lab/tile_opacity/compare_captures.py
+++ b/lab/tile_opacity/compare_captures.py
@@ -1,0 +1,97 @@
+"""Diffs two captures of the same spot and says where they differ, not just how much.
+
+    uv run --with pillow --with numpy python compare_captures.py a.png b.png [more pairs...]
+
+A frame wide mean hides the failure this is looking for. A missing image layer, a frozen particle
+effect or a dropped tile block barely moves the average over 1280 x 720, so the worst 64 px cell is
+reported next to it - that is the number that goes to 100% when something structural is gone.
+
+Water, candles, fireflies and the idle animation move on their own, so two captures of the same build
+differ regardless. Earlier sessions measured that floor at the catacombs checkpoints as about 2.4% of
+the frame, and up to 100% of a single cell at the noisiest spot. Read a result against that, never
+against zero.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+CELL_PX = 64
+DIFFERENCE_THRESHOLD = 16
+
+
+def best_aligned_difference(image_a: np.ndarray, image_b: np.ndarray) -> tuple[np.ndarray, tuple[int, int]]:
+    """Returns the smallest difference over small whole-pixel shifts, and the shift that produced it.
+
+    The camera does not settle on exactly the same pixel between two runs, and a one or two pixel
+    offset lights up every wall edge in the scene. That once read as a 16.84% regression in the water
+    room which collapsed to 3.63% after realigning by dy=2. So the shift is searched before anything
+    is concluded, and reported so a large one is visible rather than silently corrected away.
+    """
+    search_px = 3
+    best_difference = None
+    best_shift = (0, 0)
+
+    for shift_y in range(-search_px, search_px + 1):
+        for shift_x in range(-search_px, search_px + 1):
+            shifted_b = np.roll(np.roll(image_b, shift_y, axis=0), shift_x, axis=1)
+            # the wrapped border is meaningless, so both are cropped by the search radius
+            crop_a = image_a[search_px:-search_px, search_px:-search_px]
+            crop_b = shifted_b[search_px:-search_px, search_px:-search_px]
+            difference = np.abs(crop_a - crop_b).max(axis=2)
+
+            if best_difference is None or difference.mean() < best_difference.mean():
+                best_difference = difference
+                best_shift = (shift_x, shift_y)
+
+    return best_difference, best_shift
+
+
+def compare(path_a: Path, path_b: Path) -> None:
+    image_a = np.asarray(Image.open(path_a).convert("RGB")).astype(np.int16)
+    image_b = np.asarray(Image.open(path_b).convert("RGB")).astype(np.int16)
+
+    if image_a.shape != image_b.shape:
+        print(f"{path_a.name} vs {path_b.name}: size mismatch {image_a.shape} vs {image_b.shape}")
+        return
+
+    difference, shift = best_aligned_difference(image_a, image_b)
+    changed = difference > DIFFERENCE_THRESHOLD
+
+    height, width = changed.shape
+    worst_cell = 0.0
+    worst_position = (0, 0)
+    for top in range(0, height - CELL_PX + 1, CELL_PX):
+        for left in range(0, width - CELL_PX + 1, CELL_PX):
+            cell = changed[top : top + CELL_PX, left : left + CELL_PX].mean() * 100.0
+            if cell > worst_cell:
+                worst_cell = cell
+                worst_position = (left, top)
+
+    print(
+        f"{path_a.stem} vs {path_b.stem}: frame {changed.mean() * 100:6.2f}%  "
+        f"worst 64px cell {worst_cell:6.1f}% at {worst_position}  mean |d| {difference.mean():5.2f}  "
+        f"max {difference.max():3d}  aligned by {shift}"
+    )
+
+    amplified = np.clip(difference[:, :, np.newaxis].repeat(3, axis=2) * 6, 0, 255).astype(np.uint8)
+    output_path = path_a.parent / f"diff_{path_a.stem}__{path_b.stem}.png"
+    Image.fromarray(amplified).save(output_path)
+
+
+def main() -> int:
+    arguments = [Path(argument) for argument in sys.argv[1:]]
+    if len(arguments) < 2 or len(arguments) % 2 != 0:
+        print(__doc__)
+        return 1
+
+    for index in range(0, len(arguments), 2):
+        compare(arguments[index], arguments[index + 1])
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lab/tile_opacity/probe_update_sections.py
+++ b/lab/tile_opacity/probe_update_sections.py
@@ -1,0 +1,242 @@
+"""Breaks the update half of the frame into its phases on the desktop build.
+
+Every previous profiling pass treated update as one number, because that is all the report showed.
+On real switch hardware that number is about half the frame - roughly 10 ms of a 20.5 ms frame at
+48 fps, against 2.8 ms in Ryujinx, which is why it looked negligible for so long. Ryujinx JITs the
+guest's ARM code onto a desktop cpu, so it makes cpu work look cheap in exactly the same way it
+makes fill look cheap.
+
+    uv run --with pywin32 --with pillow python probe_update_sections.py [runs]
+
+Two things differ from the render probes, both on purpose:
+
+- **vsync stays ON.** The simulation runs a whole number of fixed 1/60 s steps per frame, so at
+  60 fps a frame runs exactly one step and every phase reads as its true per step cost. With vsync
+  off the desktop runs at several hundred fps, most frames consume no step at all, and every level
+  phase comes out divided by however many frames went by between two steps. The update phases are
+  measured before the swap, so vsync cannot inflate them the way it inflates a render section.
+- **the render sections are worthless in this run** for the same reason - the vsync wait lands
+  inside one of them. Use benchmark_render_profile.py for those.
+"""
+
+import json
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "lab" / "map_render"))
+
+import drive_desktop as desktop  # noqa: E402
+
+CATACOMBS_LEVEL = "data/level-catacombs/level.json"
+GAME_CONFIGURATION_PATH = desktop.SETTINGS_DIRECTORY / "game.json"
+GAME_CONFIGURATION_BACKUP_PATH = desktop.SETTINGS_DIRECTORY / "game.json.update_probe_backup"
+OUTPUT_DIRECTORY = Path(__file__).resolve().parent / "out"
+
+SETTLE_SECONDS = 6.0
+SAMPLE_SECONDS = 30.0
+
+VK_F10 = 0x79
+
+UPDATE_SECTION_PATTERN = re.compile(r"profiling: update sections over (\d+) frames \|(.*)")
+FPS_PATTERN = re.compile(r"profiling: fps ([0-9.]+) over \d+ frames \|(.*)")
+
+
+def back_up_settings() -> None:
+    if GAME_CONFIGURATION_PATH.exists() and not GAME_CONFIGURATION_BACKUP_PATH.exists():
+        shutil.copy2(GAME_CONFIGURATION_PATH, GAME_CONFIGURATION_BACKUP_PATH)
+        print(f"backed up {GAME_CONFIGURATION_PATH.name}")
+
+
+def restore_settings() -> None:
+    if GAME_CONFIGURATION_BACKUP_PATH.exists():
+        shutil.copy2(GAME_CONFIGURATION_BACKUP_PATH, GAME_CONFIGURATION_PATH)
+        GAME_CONFIGURATION_BACKUP_PATH.unlink()
+        print("restored game.json")
+
+
+def configure() -> None:
+    configuration = json.loads(GAME_CONFIGURATION_PATH.read_text())
+    section = configuration["GameConfiguration"]
+    # see the module docstring: vsync on is what pins the frame to one simulation step
+    section["vsync"] = True
+    section["fullscreen"] = False
+    GAME_CONFIGURATION_PATH.write_text(json.dumps(configuration, indent=4))
+
+
+def install_save(checkpoint: int) -> None:
+    if desktop.SAVE_STATE_PATH.exists() and not desktop.SAVE_STATE_BACKUP_PATH.exists():
+        shutil.copy2(desktop.SAVE_STATE_PATH, desktop.SAVE_STATE_BACKUP_PATH)
+
+    slots = json.loads(desktop.SAVE_STATE_PATH.read_text()) if desktop.SAVE_STATE_PATH.exists() else [{}, {}, {}]
+    slots[0] = {
+        "levelindex": 0,
+        "checkpoints": {CATACOMBS_LEVEL: checkpoint},
+        # null, not {} - Level::loadSaveState indexes a const nlohmann json
+        "levelstate": None,
+        "playerinfo": slots[0].get("playerinfo", {}) if slots else {},
+    }
+    slots[0]["playerinfo"]["name"] = "catacombs"
+    desktop.SAVE_STATE_PATH.write_text(json.dumps(slots, indent=4))
+
+
+def wait_for_level(stdout_path: Path, timeout_s: float) -> bool:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if stdout_path.exists():
+            text = stdout_path.read_text(encoding="utf-8", errors="replace")
+            if "level loading finished" in text:
+                return True
+        time.sleep(1.0)
+
+    return False
+
+
+def parse_entries(body: str) -> dict:
+    entries = {}
+    for entry in body.split("|"):
+        entry = entry.strip()
+        if not entry:
+            continue
+        name, _, value = entry.rpartition(" ")
+        try:
+            entries[name.strip()] = float(value)
+        except ValueError:
+            continue
+
+    return entries
+
+
+def parse_report(stdout_path: Path) -> dict:
+    text = stdout_path.read_text(encoding="utf-8", errors="replace")
+
+    update_reports = []
+    for match in UPDATE_SECTION_PATTERN.finditer(text):
+        entries = parse_entries(match.group(2))
+        if entries:
+            entries["_frames"] = float(match.group(1))
+            update_reports.append(entries)
+
+    frame_reports = []
+    for match in FPS_PATTERN.finditer(text):
+        entries = parse_entries(match.group(2))
+        entries["fps"] = float(match.group(1))
+        frame_reports.append(entries)
+
+    return {"update": update_reports, "frames": frame_reports}
+
+
+def run_once(run_index: int, checkpoint: int) -> dict:
+    configure()
+    install_save(checkpoint)
+
+    executable = REPO_ROOT / "build_rel" / "deceptus.exe"
+    stdout_path = OUTPUT_DIRECTORY / f"stdout_update_cp{checkpoint}_{run_index}.txt"
+
+    with stdout_path.open("w", encoding="utf-8", errors="replace") as log_file:
+        process = subprocess.Popen([str(executable)], cwd=str(REPO_ROOT), stdout=log_file, stderr=subprocess.STDOUT)
+        try:
+            print("  waiting for the main menu")
+            time.sleep(14)
+
+            handle = None
+            for attempt in range(6):
+                handle = desktop.focus_window()
+                if not handle:
+                    print("  no game window - did it die during start up?")
+                    return {"loaded": False}
+
+                desktop.send_key(handle, desktop.VK_RETURN, settle_s=2.0)
+                desktop.send_key(handle, desktop.VK_RETURN, settle_s=2.0)
+
+                print(f"  waiting for the level to load (attempt {attempt + 1})")
+                if wait_for_level(stdout_path, timeout_s=25.0):
+                    break
+
+                print("  still in the menu, retrying")
+            else:
+                print("  FAILED to load the level - not sampling")
+                return {"loaded": False}
+
+            # F10 opens the profiling window; without it the desktop build writes no report at all
+            desktop.send_key(handle, VK_F10, settle_s=1.0)
+
+            time.sleep(SETTLE_SECONDS)
+            print(f"  sampling for {SAMPLE_SECONDS:.0f}s")
+            time.sleep(SAMPLE_SECONDS)
+        finally:
+            if process.poll() is None:
+                process.kill()
+                process.wait(timeout=10)
+            subprocess.run(["taskkill", "/F", "/IM", "deceptus.exe"], capture_output=True)
+
+    report = parse_report(stdout_path)
+    report["loaded"] = True
+    report["log"] = stdout_path.name
+    return report
+
+
+def median_of(reports: list[dict], group: str, key: str) -> float | None:
+    values = [entry[key] for report in reports for entry in report.get(group, []) if key in entry]
+    return statistics.median(values) if values else None
+
+
+def main() -> int:
+    run_count = int(sys.argv[1]) if len(sys.argv) > 1 and sys.argv[1].isdigit() else 1
+    checkpoint = int(sys.argv[2]) if len(sys.argv) > 2 and sys.argv[2].isdigit() else 3
+
+    executable = REPO_ROOT / "build_rel" / "deceptus.exe"
+    if not executable.exists():
+        print(f"desktop build not found at {executable}")
+        return 1
+
+    OUTPUT_DIRECTORY.mkdir(exist_ok=True)
+    back_up_settings()
+
+    reports = []
+    try:
+        for run_index in range(run_count):
+            print(f"run {run_index + 1}/{run_count} at checkpoint {checkpoint}")
+            report = run_once(run_index, checkpoint)
+            if report.get("loaded"):
+                reports.append(report)
+    finally:
+        restore_settings()
+        desktop.restore_save_state()
+
+    if not reports:
+        print("no usable runs")
+        return 1
+
+    # skip nothing here: the update phases are not distorted by what happened before F10 the way the
+    # per layer fill counters are, because they are averaged over the report window rather than
+    # accumulated since the counter was last cleared
+    names = []
+    for report in reports:
+        for entry in report.get("update", []):
+            for name in entry:
+                if name not in names and not name.startswith("_"):
+                    names.append(name)
+
+    print()
+    print(f"fps {median_of(reports, 'frames', 'fps')}  update {median_of(reports, 'frames', 'update')} ms")
+    print()
+    print("update phases, worst first (ms per frame, median over reports)")
+    ranked = sorted(
+        ((name, median_of(reports, "update", name)) for name in names),
+        key=lambda item: -(item[1] or 0.0),
+    )
+    for name, value in ranked:
+        marker = "  <- span, contains the level phases" if name == "level update" else ""
+        print(f"  {value:7.3f}  {name}{marker}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/game/debug/drawcallcounter.cpp
+++ b/src/game/debug/drawcallcounter.cpp
@@ -196,17 +196,39 @@ void DrawCallCounter::countAmbientOcclusionPixels(
    );
 }
 
-void DrawCallCounter::countImageLayerPixels(const sf::RenderTarget& target, const sf::RenderStates& states, const sf::Sprite& sprite)
+void DrawCallCounter::countImageLayerPixels(
+   const sf::RenderTarget& target,
+   const sf::RenderStates& states,
+   const sf::Sprite& sprite,
+   const std::string& layer_name
+)
 {
    const auto& view = resolveView(target, states);
    const auto bounds = sprite.getGlobalBounds();
 
-   image_layer_pixels_submitted += static_cast<int64_t>(
+   const auto pixels = static_cast<int64_t>(
       static_cast<double>(visibleArea(
          getClipRectPx(view), bounds.position.x, bounds.position.y, bounds.position.x + bounds.size.x, bounds.position.y + bounds.size.y
       )) *
       getTargetFillScale(target)
    );
+
+   image_layer_pixels_submitted += pixels;
+
+   // accumulated by name across the report window, like the tile map layers are. a layer that is
+   // loaded but entirely off screen lands here with zero pixels and a draw count, which is worth
+   // seeing on its own: it costs a draw call and a view change without putting anything on screen
+   const auto entry =
+      std::ranges::find_if(image_layer_pixels, [&layer_name](const auto& layer) { return layer._layer_name == layer_name; });
+   if (entry != image_layer_pixels.end())
+   {
+      entry->_pixels_submitted += pixels;
+      entry->_draw_count++;
+   }
+   else
+   {
+      image_layer_pixels.push_back({layer_name, pixels, 1});
+   }
 }
 
 #endif  // DEVELOPMENT_MODE

--- a/src/game/debug/drawcallcounter.h
+++ b/src/game/debug/drawcallcounter.h
@@ -87,6 +87,23 @@ struct TileMapLayerPixels
 //! the counts stay unscaled while it is.
 inline sf::Vector2u reference_target_size{0, 0};
 
+///
+/// \brief One image layer and the pixels it has submitted since the last report.
+///
+struct ImageLayerPixels
+{
+   std::string _layer_name;
+   int64_t _pixels_submitted{0};
+   int32_t _draw_count{0};  //!< times the layer was drawn over the window
+};
+
+//! Per layer breakdown of the image layer fill. Image layers turned out to be the second biggest
+//! fill item in the catacombs after the tiles - 2.01x of the frame against 5.46x - and unlike the
+//! tiles they are unaffected by the render target profile, because they draw into the image group.
+//! A total that size is either a couple of full screen room overlays, which is art and has to stay,
+//! or a pile of layers nobody meant to be on screen at once; the names are what tells those apart.
+inline std::vector<ImageLayerPixels> image_layer_pixels;
+
 //! Per layer breakdown of the tile fill, accumulated across the report window rather than reset
 //! every frame. Answers whether a handful of layers own the overdraw or it is spread evenly across
 //! all of them, which is what decides between dropping layers and rejecting hidden fragments.
@@ -161,8 +178,14 @@ void countAmbientOcclusionPixels(
 /// \param target render target the sprite went to.
 /// \param states render states the sprite was drawn with; carries the parallax view when there is one.
 /// \param sprite the sprite that was drawn.
+/// \param layer_name the layer's TMX name, so the fill can be attributed to it by name.
 ///
-void countImageLayerPixels(const sf::RenderTarget& target, const sf::RenderStates& states, const sf::Sprite& sprite);
+void countImageLayerPixels(
+   const sf::RenderTarget& target,
+   const sf::RenderStates& states,
+   const sf::Sprite& sprite,
+   const std::string& layer_name
+);
 }  // namespace DrawCallCounter
 
 #endif  // DEVELOPMENT_MODE

--- a/src/game/debug/mechanismsample.h
+++ b/src/game/debug/mechanismsample.h
@@ -2,13 +2,21 @@
 
 #ifdef DEVELOPMENT_MODE
 
+#include <cstdint>
 #include <string>
 
 struct MechanismSample
 {
    std::string name;       //!< mechanism type name from objectName()
-   float update_ms{0.0f};  //!< average update cost this frame in milliseconds
-   float draw_ms{0.0f};    //!< average draw cost this frame in milliseconds
+   float update_ms{0.0f};  //!< total update cost of every instance of this type, for the sampled frame
+   float draw_ms{0.0f};    //!< total draw cost of every instance of this type, for the sampled frame
+   int32_t count{0};       //!< instances of this type that were updated in that frame
+
+   //!< These are totals rather than per-instance averages on purpose. The average said a SmokeEffect
+   //!< costs 0.061 ms and left it at that, which cannot be ranked against anything - fifteen cheap
+   //!< instances outweigh one expensive one, and the frame pays the total. The count is kept so the
+   //!< per-instance figure is still derivable, and so "why is this type expensive" separates into
+   //!< "each one is slow" and "there are a lot of them".
 };
 
 #endif  // DEVELOPMENT_MODE

--- a/src/game/debug/profilingui.cpp
+++ b/src/game/debug/profilingui.cpp
@@ -2,6 +2,36 @@
 
 #ifdef DEVELOPMENT_MODE
 #include "game/debug/drawcallcounter.h"
+
+#include <algorithm>
+#include <ranges>
+
+namespace
+{
+///
+/// \brief Adds one frame's sections into a running total, matching them up by name.
+///
+/// The draw sections can be accumulated by index because Game::draw runs its passes exactly once
+/// per frame. The update sections cannot: the simulation runs a whole number of fixed steps per
+/// frame, so the list changes length from frame to frame and a section that only exists on a two
+/// step frame would otherwise shift every later entry into the wrong slot.
+///
+void accumulateSectionsByName(std::vector<RenderSectionSample>& total, const std::vector<RenderSectionSample>& frame)
+{
+   for (const auto& sample : frame)
+   {
+      const auto match = std::ranges::find_if(total, [&sample](const auto& entry) { return entry.name == sample.name; });
+      if (match != total.end())
+      {
+         match->duration_ms += sample.duration_ms;
+      }
+      else
+      {
+         total.push_back(sample);
+      }
+   }
+}
+}  // namespace
 #endif
 
 #if defined(DEVELOPMENT_MODE) && !defined(DECEPTUS_VRSFML)
@@ -90,6 +120,69 @@ void logRenderSections(const std::vector<RenderSectionSample>& samples, int32_t 
    Log::Info() << section_line.str();
 }
 
+// the update half of the frame, which the report only ever showed as one number. worth its own line
+// because a section here can be entered more than once per frame: the simulation runs whole fixed
+// steps, so below the step rate a frame really does pay for every phase twice
+void logUpdateSections(const std::vector<RenderSectionSample>& samples, int32_t frames)
+{
+   auto section_total_ms = 0.0f;
+
+   std::ostringstream update_line;
+   update_line << std::fixed << std::setprecision(3) << "profiling: update sections over " << frames << " frames |";
+   for (const auto& sample : samples)
+   {
+      const auto average_ms = sample.duration_ms / static_cast<float>(frames);
+      update_line << " " << sample.name << " " << average_ms << " |";
+
+      // Level::update reports its own phases and "level update" is the span that contains them, so
+      // counting both would total the level's cost twice
+      if (sample.name != "level update")
+      {
+         section_total_ms += average_ms;
+      }
+   }
+
+   update_line << " TOTAL " << section_total_ms;
+   Log::Info() << update_line.str();
+}
+
+// the imgui window has shown these all along, but nothing wrote them to the log, so a benchmark run
+// could not read them - and "mechanisms" is the biggest single phase of the update once the lua
+// nodes are dealt with. worst first, totals rather than per instance averages
+void logMechanismTimings(const std::vector<MechanismSample>& samples)
+{
+   if (samples.empty())
+   {
+      return;
+   }
+
+   constexpr auto reported_count = 8u;
+   std::ostringstream mechanism_line;
+   mechanism_line << std::fixed << std::setprecision(3) << "profiling: mechanism totals |";
+   for (auto sample_index = 0u; sample_index < std::min<size_t>(reported_count, samples.size()); sample_index++)
+   {
+      const auto& sample = samples[sample_index];
+      mechanism_line << " " << sample.name << " x" << sample.count << " update " << sample.update_ms << " draw " << sample.draw_ms << " |";
+   }
+   mechanism_line << " " << samples.size() << " types";
+   Log::Info() << mechanism_line.str();
+}
+
+// the step count belongs next to the update phases: it is what says whether a high update figure is
+// a phase getting slower or the frame merely dropping below the step rate and paying for the
+// simulation twice
+void logSimulationSteps(const float* steps, int32_t count)
+{
+   if (count <= 0)
+   {
+      return;
+   }
+
+   const auto average = std::accumulate(steps, steps + count, 0.0f) / static_cast<float>(count);
+   Log::Info() << std::fixed << "profiling: simulation steps per frame min " << *std::min_element(steps, steps + count) << " avg "
+               << average << " max " << *std::max_element(steps, steps + count);
+}
+
 // draw call counts carry over to other hardware unchanged, unlike a timing, so they belong next to
 // the sections rather than only in the imgui window
 void logDrawCounts(
@@ -161,6 +254,35 @@ void logTileMapLayerFill(int32_t frames, float view_area)
    DrawCallCounter::tilemap_layer_pixels.clear();
 }
 
+// the same breakdown for the image layers, which turned out to be the second biggest fill item after
+// the tiles and are the one the render target profile cannot touch. worst first, so the answer to
+// "which of the forty seven is that" is the front of the line
+void logImageLayerFill(int32_t frames, float view_area)
+{
+   if (DrawCallCounter::image_layer_pixels.empty() || frames <= 0 || view_area <= 0.0f)
+   {
+      return;
+   }
+
+   auto layers = DrawCallCounter::image_layer_pixels;
+   std::ranges::sort(layers, [](const auto& lhs, const auto& rhs) { return lhs._pixels_submitted > rhs._pixels_submitted; });
+
+   constexpr auto reported_layer_count = 8u;
+   std::ostringstream layer_line;
+   layer_line << std::fixed << std::setprecision(2) << "profiling: image layer fill |";
+   for (auto layer_index = 0u; layer_index < std::min<size_t>(reported_layer_count, layers.size()); layer_index++)
+   {
+      const auto& layer = layers[layer_index];
+      const auto overdraw = static_cast<float>(layer._pixels_submitted) / static_cast<float>(frames) / view_area;
+      const auto draws_per_frame = static_cast<float>(layer._draw_count) / static_cast<float>(frames);
+      layer_line << " " << layer._layer_name << " " << overdraw << "x in " << draws_per_frame << " draws |";
+   }
+   layer_line << " " << layers.size() << " layers drawn";
+   Log::Info() << layer_line.str();
+
+   DrawCallCounter::image_layer_pixels.clear();
+}
+
 }  // namespace
 
 void ProfilingUi::draw()
@@ -214,6 +336,17 @@ void ProfilingUi::draw()
    ImGui::Text("update time");
    drawTimingGraph("##update", _update_times_ms.data(), sample_count, _write_index, target_update_ms);
 
+   if (!_update_section_timings.empty())
+   {
+      ImGui::Spacing();
+      ImGui::Text("update sections   (summed over the frame's simulation steps)");
+      const auto update_frames = std::max(_update_section_frames, 1);
+      for (const auto& sample : _update_section_timings)
+      {
+         ImGui::Text("%.3f ms  %s", sample.duration_ms / static_cast<float>(update_frames), sample.name.c_str());
+      }
+   }
+
    ImGui::Spacing();
    ImGui::Text("draw time (scene + swap)");
    drawTimingGraph("##draw", _draw_times_ms.data(), sample_count, _write_index, target_draw_ms);
@@ -252,6 +385,17 @@ void ProfilingUi::draw()
          logTileMapLayerFill(
             section_frames, static_cast<float>(GameConfiguration::getInstance()._view_width * GameConfiguration::getInstance()._view_height)
          );
+         logImageLayerFill(
+            section_frames, static_cast<float>(GameConfiguration::getInstance()._view_width * GameConfiguration::getInstance()._view_height)
+         );
+         logSimulationSteps(_simulation_steps.data(), _samples_written);
+         logMechanismTimings(_mechanism_timings);
+         if (!_update_section_timings.empty())
+         {
+            logUpdateSections(_update_section_timings, std::max(_update_section_frames, 1));
+            _update_section_timings.clear();
+            _update_section_frames = 0;
+         }
          _render_section_timings.clear();
          _render_section_frames = 0;
       }
@@ -308,7 +452,7 @@ void ProfilingUi::draw()
 
          ImGui::Dummy(ImVec2(max_bar_width, bar_height));
          ImGui::SameLine(0.0f, 8.0f);
-         ImGui::Text("%.3f ms  %s", total_ms, sample.name.c_str());
+         ImGui::Text("%.3f ms  %s x%d", total_ms, sample.name.c_str(), sample.count);
          ImGui::SetCursorPosY(ImGui::GetCursorPosY() + bar_row_spacing);
       }
       ImGui::EndChild();
@@ -365,6 +509,11 @@ void ProfilingUi::recordWindowDisplay(sf::Time display_time)
    _window_display_times_ms[_write_index] = display_time.asSeconds() * 1000.0f;
 }
 
+void ProfilingUi::recordSimulationSteps(int32_t step_count)
+{
+   _simulation_steps[_write_index] = static_cast<float>(step_count);
+}
+
 void ProfilingUi::updateMechanismTimings(std::vector<MechanismSample> timings)
 {
    if (_mechanism_update_clock.getElapsedTime().asSeconds() < 0.5f)
@@ -391,6 +540,17 @@ void ProfilingUi::updateRenderSectionTimings(std::vector<RenderSectionSample> ti
       _render_section_timings[section_index].duration_ms += timings[section_index].duration_ms;
    }
    _render_section_frames++;
+}
+
+void ProfilingUi::updateUpdateSectionTimings(std::vector<RenderSectionSample> timings)
+{
+   if (timings.empty())
+   {
+      return;
+   }
+
+   accumulateSectionsByName(_update_section_timings, timings);
+   _update_section_frames++;
 }
 
 bool ProfilingUi::isMechanismProfilingWanted() const
@@ -479,6 +639,35 @@ void logTileMapLayerFill(int32_t frames, float view_area)
    DrawCallCounter::tilemap_layer_pixels.clear();
 }
 
+// the same breakdown for the image layers, which turned out to be the second biggest fill item after
+// the tiles and are the one the render target profile cannot touch, because they draw into the image
+// group. worst first, so the answer to "which of the forty seven is that" is the front of the line
+void logImageLayerFill(int32_t frames, float view_area)
+{
+   if (DrawCallCounter::image_layer_pixels.empty() || frames <= 0 || view_area <= 0.0f)
+   {
+      return;
+   }
+
+   auto layers = DrawCallCounter::image_layer_pixels;
+   std::ranges::sort(layers, [](const auto& lhs, const auto& rhs) { return lhs._pixels_submitted > rhs._pixels_submitted; });
+
+   constexpr auto reported_layer_count = 8u;
+   std::ostringstream layer_line;
+   layer_line << std::fixed << std::setprecision(2) << "profiling: image layer fill |";
+   for (auto layer_index = 0u; layer_index < std::min<size_t>(reported_layer_count, layers.size()); layer_index++)
+   {
+      const auto& layer = layers[layer_index];
+      const auto overdraw = static_cast<float>(layer._pixels_submitted) / static_cast<float>(frames) / view_area;
+      const auto draws_per_frame = static_cast<float>(layer._draw_count) / static_cast<float>(frames);
+      layer_line << " " << layer._layer_name << " " << overdraw << "x in " << draws_per_frame << " draws |";
+   }
+   layer_line << " " << layers.size() << " layers drawn";
+   Log::Info() << layer_line.str();
+
+   DrawCallCounter::image_layer_pixels.clear();
+}
+
 }  // namespace
 
 ProfilingUi::ProfilingUi() = default;
@@ -514,7 +703,9 @@ void ProfilingUi::draw()
    report << std::fixed << std::setprecision(2) << "profiling: fps " << average_fps << " over " << _samples_written << " frames"
           << " | " << formatSummary("wall", wall_summary) << " | " << formatSummary("frame", frame_summary) << " | "
           << formatSummary("update", update_summary) << " | " << formatSummary("draw", draw_summary) << " | "
-          << formatSummary("swap", display_summary) << " | mechanism timing: " << (_mechanism_profiling_wanted ? "on" : "off")
+          << formatSummary("swap", display_summary) << " | "
+          << formatSummary("steps", summarizeSamples(_simulation_steps.data(), _samples_written))
+          << " | mechanism timing: " << (_mechanism_profiling_wanted ? "on" : "off")
           << " | vsync: " << (GameConfiguration::getInstance()._vsync_enabled ? "on" : "off");
    Log::Info() << report.str();
 
@@ -582,13 +773,39 @@ void ProfilingUi::draw()
       Log::Info() << section_line.str();
    }
 
+   if (!_update_section_timings.empty())
+   {
+      const auto update_frames = std::max(_update_section_frames, 1);
+      auto update_total_ms = 0.0f;
+
+      std::ostringstream update_line;
+      update_line << std::fixed << std::setprecision(3) << "profiling: update sections over " << update_frames << " frames |";
+      for (const auto& sample : _update_section_timings)
+      {
+         const auto average_ms = sample.duration_ms / static_cast<float>(update_frames);
+         update_line << " " << sample.name << " " << average_ms << " |";
+
+         // Level::update reports its own phases and "level update" is the span that contains them,
+         // so counting both would total the level's cost twice
+         if (sample.name != "level update")
+         {
+            update_total_ms += average_ms;
+         }
+      }
+
+      update_line << " TOTAL " << update_total_ms << " | measured update " << update_summary.average_ms << " | unaccounted "
+                  << (update_summary.average_ms - update_total_ms);
+      Log::Info() << update_line.str();
+   }
+
    logTileMapLayerFill(std::max(_render_section_frames, 1), static_cast<float>(view_area));
+   logImageLayerFill(std::max(_render_section_frames, 1), static_cast<float>(view_area));
 
    for (const auto& sample : _mechanism_timings)
    {
       std::ostringstream mechanism_line;
-      mechanism_line << std::fixed << std::setprecision(3) << "profiling: mechanism " << sample.name << " update " << sample.update_ms
-                     << " ms draw " << sample.draw_ms << " ms";
+      mechanism_line << std::fixed << std::setprecision(3) << "profiling: mechanism " << sample.name << " x" << sample.count << " update "
+                     << sample.update_ms << " ms draw " << sample.draw_ms << " ms (totals, not per instance)";
       Log::Info() << mechanism_line.str();
    }
 
@@ -598,6 +815,8 @@ void ProfilingUi::draw()
    _mechanism_timings.clear();
    _render_section_timings.clear();
    _render_section_frames = 0;
+   _update_section_timings.clear();
+   _update_section_frames = 0;
 
    _samples_written = 0;
    _write_index = 0;
@@ -647,6 +866,11 @@ void ProfilingUi::recordWindowDisplay(sf::Time display_time)
    _window_display_times_ms[_write_index] = display_time.asSeconds() * 1000.0f;
 }
 
+void ProfilingUi::recordSimulationSteps(int32_t step_count)
+{
+   _simulation_steps[_write_index] = static_cast<float>(step_count);
+}
+
 void ProfilingUi::updateMechanismTimings(std::vector<MechanismSample> timings)
 {
    if (_mechanism_update_clock.getElapsedTime().asSeconds() < 0.5f)
@@ -679,6 +903,17 @@ void ProfilingUi::updateRenderSectionTimings(std::vector<RenderSectionSample> ti
       _render_section_timings[section_index].duration_ms += timings[section_index].duration_ms;
    }
    _render_section_frames++;
+}
+
+void ProfilingUi::updateUpdateSectionTimings(std::vector<RenderSectionSample> timings)
+{
+   if (timings.empty())
+   {
+      return;
+   }
+
+   accumulateSectionsByName(_update_section_timings, timings);
+   _update_section_frames++;
 }
 
 bool ProfilingUi::isMechanismProfilingWanted() const

--- a/src/game/debug/profilingui.h
+++ b/src/game/debug/profilingui.h
@@ -23,8 +23,27 @@ struct ProfilingUi
    bool isOpen() const;
    void recordFrame(sf::Time frame_time, sf::Time update_time, sf::Time draw_time);
    void recordWindowDisplay(sf::Time display_time);
+
+   ///
+   /// \brief Records how many fixed simulation steps the frame being measured ran.
+   ///
+   /// Without this the update time cannot be read at all: a frame below the step rate runs the whole
+   /// simulation twice, so a doubled update figure means the frame was slow rather than that a phase
+   /// got more expensive. It is also what tells a real regression apart from the feedback the fixed
+   /// step introduces, where a slower frame buys itself more steps and so more update.
+   ///
+   void recordSimulationSteps(int32_t step_count);
    void updateMechanismTimings(std::vector<MechanismSample> timings);
    void updateRenderSectionTimings(std::vector<RenderSectionSample> timings);
+
+   ///
+   /// \brief Accumulates the phases of one frame's update, so they can be averaged over the window.
+   ///
+   /// Accumulated by name rather than by index: the simulation runs a whole number of fixed steps
+   /// per frame, so the same phase appears once on one frame and twice on the next, and the list
+   /// even changes length when a frame runs a different number of steps.
+   ///
+   void updateUpdateSectionTimings(std::vector<RenderSectionSample> timings);
 
    ///
    /// \brief Tells whether the level should time each mechanism separately this frame.
@@ -47,6 +66,7 @@ private:
    std::array<float, sample_count> _update_times_ms{};
    std::array<float, sample_count> _draw_times_ms{};
    std::array<float, sample_count> _window_display_times_ms{};
+   std::array<float, sample_count> _simulation_steps{};                    //!< fixed simulation steps that frame ran
    std::array<float, sample_count> _tilemap_draw_calls{};                  //!< tile map draw calls issued in that frame
    std::array<float, sample_count> _tilemap_target_switches{};             //!< render target changes between those draws
    std::array<float, sample_count> _ambient_occlusion_draw_calls{};        //!< ao draw calls issued in that frame
@@ -62,6 +82,8 @@ private:
    std::vector<MechanismSample> _mechanism_timings;
    std::vector<RenderSectionSample> _render_section_timings;
    int32_t _render_section_frames{0};  //!< frames accumulated into _render_section_timings so far
+   std::vector<RenderSectionSample> _update_section_timings;
+   int32_t _update_section_frames{0};  //!< frames accumulated into _update_section_timings so far
    sf::Clock _mechanism_update_clock;
    sf::Clock _log_clock;                    //!< paces the reports the log-based flavour writes
    bool _mechanism_profiling_wanted{true};  //!< alternated after every report, see isMechanismProfilingWanted()

--- a/src/game/debug/updatesectiontimer.h
+++ b/src/game/debug/updatesectiontimer.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#ifdef DEVELOPMENT_MODE
+
+#include "game/debug/rendersectionsample.h"
+
+#include <chrono>
+#include <string_view>
+#include <vector>
+
+/// \brief accumulates cpu side durations between named marks across the simulation steps of one frame.
+///
+/// The draw side can push one sample per mark and average by index, because Game::draw runs its
+/// passes exactly once per frame. The update side cannot: the simulation is stepped a whole number
+/// of times per frame, so at 48 fps a frame runs one step or two and the same section is entered
+/// once or twice. Accumulating by name instead of by position is what lets a section keep its
+/// identity across that, and it makes the reported figure the per frame cost rather than the per
+/// step one - which is the number that has to fit in the frame budget.
+///
+/// Why by position does not work. Two consecutive frames at 48 fps, marks in call order:
+///
+///        frame N (1 step)              frame N+1 (2 steps)
+///        ------------------            --------------------------------------
+///     0  game systems                  game systems
+///     1  game controller               game controller
+///     2  physics step        <-.        physics step        \
+///     3  mechanisms            |        mechanisms           }  step 1
+///     4  lua nodes             |        lua nodes           /
+///     5  player update         |        physics step        \
+///     6  sprite positions      |        mechanisms           }  step 2
+///                              |        lua nodes           /
+///                              |        player update
+///                              |        sprite positions
+///                              |
+///        index 6 means          `------ index 6 means "mechanisms", second time round
+///        "sprite positions"
+///
+/// So the lists differ in length and the same index means a different phase. Adding frame N+1 into
+/// frame N by index would file the second step's physics under "player update". By name, the two
+/// "physics step" entries land in the same slot and the frame reports what it really paid: two steps
+/// worth. beginPass() is what separates the steps - it restarts the clock at the top of each one so
+/// the first mark of step 2 is not charged for whatever ran between the steps.
+class UpdateSectionTimer
+{
+public:
+   /// \brief drops the previous frame's durations and starts a new measurement.
+   /// \param enabled when false the timer stays inert, so callers can gate on a profiling flag
+   ///        without branching around every mark.
+   void beginFrame(bool enabled)
+   {
+      _samples.clear();
+      _enabled = enabled;
+
+      if (!_enabled)
+      {
+         return;
+      }
+
+      _mark = std::chrono::high_resolution_clock::now();
+   }
+
+   /// \brief restarts the clock without dropping what the frame has accumulated so far.
+   /// \note call this at the top of a section group that runs more than once per frame. Without it
+   ///       the first mark of the second simulation step would be charged for everything that ran
+   ///       between the two steps.
+   void beginPass()
+   {
+      if (!_enabled)
+      {
+         return;
+      }
+
+      _mark = std::chrono::high_resolution_clock::now();
+   }
+
+   /// \brief closes the running section under the given name and opens the next one.
+   /// \param name label the elapsed time is added to; a name seen again in the same frame
+   ///        accumulates rather than producing a second entry.
+   void mark(const char* name)
+   {
+      if (!_enabled)
+      {
+         return;
+      }
+
+      const auto now = std::chrono::high_resolution_clock::now();
+      const auto elapsed_ms = std::chrono::duration<float, std::milli>(now - _mark).count();
+      _mark = now;
+
+      // the sections are entered in the same order every step, so this search hits on its first
+      // comparison in the steady state. it is a search rather than a cursor so that a step cut
+      // short - a lua script asking for a level change mid update - cannot shift every later
+      // section into the wrong slot
+      for (auto& sample : _samples)
+      {
+         if (std::string_view{sample.name} == std::string_view{name})
+         {
+            sample.duration_ms += elapsed_ms;
+            return;
+         }
+      }
+
+      _samples.push_back({name, elapsed_ms});
+   }
+
+   /// \brief returns the sections recorded since the last beginFrame(), in first-seen order.
+   const std::vector<RenderSectionSample>& samples() const
+   {
+      return _samples;
+   }
+
+private:
+   std::vector<RenderSectionSample> _samples;             //!< one entry per distinct name, in first-seen order
+   std::chrono::high_resolution_clock::time_point _mark;  //!< when the currently open section started
+   bool _enabled{false};                                  //!< whether beginFrame() armed the timer
+};
+
+#endif  // DEVELOPMENT_MODE

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1153,6 +1153,7 @@ void Game::update()
    }
 
    _info_layer->update(dt);
+   markUpdateSection("game systems");
 
    if (game_mode == ExecutionMode::Paused)
    {
@@ -1171,6 +1172,7 @@ void Game::update()
       {
          updateGameController();
          updateGameControllerForGame();
+         markUpdateSection("game controller");
 
          // the simulation is stepped at a fixed rate rather than once per frame. everything below
          // this line was written expecting to run exactly once per physics step, with a delta of
@@ -1183,12 +1185,41 @@ void Game::update()
          const auto simulation_step_count = _fixed_time_step.consumeSteps(dt);
          const auto simulation_dt = _fixed_time_step.getStepDuration();
 
+         // The step count is recorded because without it the update timings cannot be read at all,
+         // and because it is the mechanism behind the frame rate cliff on the console:
+         //
+         //   frame time                     steps run   update cost   what it does to the next frame
+         //   ---------------------------    ---------   -----------   ------------------------------
+         //   under 16.67 ms  (>= 60 fps)        1          1 x s      stays there
+         //   16.67 - 33.3 ms (30-60 fps)      1 or 2     1-2 x s      the 2-step frames are slower
+         //                                                           still, which buys more 2-step
+         //                                                           frames -> it settles below 60
+         //
+         //   |<-- 16.67 -->|<-- 16.67 -->|          s = cost of one simulation step, ~7.9 ms on
+         //   +------+------+------+------+              hardware
+         //   | step |      | step | step |
+         //   +------+------+------+------+          A frame just over the line pays for two steps,
+         //    ^frame N      ^frame N+1              i.e. ~7.9 ms more than one just under it.
+         //
+         // So a saving near the boundary is worth far more than its face value: crossing back under
+         // 16.67 ms removes a whole step. It also means a high "update" figure in a report can mean
+         // either a slow phase or merely a slow frame, and the step count is the only way to tell.
+#ifdef DEVELOPMENT_MODE
+         if (_profiling_ui)
+         {
+            _profiling_ui->recordSimulationSteps(simulation_step_count);
+         }
+#endif
+
          for (auto simulation_step = 0; simulation_step < simulation_step_count; simulation_step++)
          {
             EventSerializer::updateAll(simulation_dt);
 
             _level->update(simulation_dt);
+            markUpdateSection("level update");
+
             _player->update(simulation_dt);
+            markUpdateSection("player update");
 
             // a lua script can request a level change from inside the update above, which hands
             // _level over for teardown. Stepping it again would run a level that is already gone or
@@ -1206,6 +1237,7 @@ void Game::update()
             _level->updateSpritePositions();
             _player->updateSpritePositions();
          }
+         markUpdateSection("sprite positions");
 
 #ifndef DECEPTUS_VRSFML
          if (DebugDrawStates::_draw_test_scene)
@@ -1219,6 +1251,7 @@ void Game::update()
 
          // this might trigger level-reloading, so this ought to be the last drawing call in the loop
          updateGameState(dt);
+         markUpdateSection("game state");
 
          // a lua script can request a level change from inside the update above, which hands _level
          // over for teardown, so it is not necessarily still there by the time we get here
@@ -1237,10 +1270,35 @@ void Game::timedUpdate()
 {
 #ifdef DEVELOPMENT_MODE
    sf::Clock update_clock;
+   const auto update_profiling_enabled = (_profiling_ui != nullptr) && _profiling_ui->isMechanismProfilingWanted();
+   _update_section_timer.beginFrame(update_profiling_enabled);
+   if (_level)
+   {
+      _level->beginUpdateSectionTiming(update_profiling_enabled);
+   }
 #endif
    update();
 #ifdef DEVELOPMENT_MODE
    _profiling_update_elapsed = update_clock.getElapsedTime();
+
+   if (_profiling_ui && _level && _level_loading_finished)
+   {
+      // Level::update reports its own phases and "level update" is the span that contains them, the
+      // same relationship the draw sections already have between "level draw" and its passes
+      auto section_timings = _update_section_timer.samples();
+      const auto level_sections = _level->getUpdateSectionTimings();
+      section_timings.insert(section_timings.end(), level_sections.begin(), level_sections.end());
+      _profiling_ui->updateUpdateSectionTimings(std::move(section_timings));
+   }
+#endif
+}
+
+void Game::markUpdateSection(const char* name)
+{
+#ifdef DEVELOPMENT_MODE
+   _update_section_timer.mark(name);
+#else
+   (void)name;
 #endif
 }
 

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -14,6 +14,7 @@
 #ifdef DEVELOPMENT_MODE
 #include "game/debug/profilingui.h"
 #include "game/debug/rendersectiontimer.h"
+#include "game/debug/updatesectiontimer.h"
 #endif
 #include "game/ingamemenu/ingamemenu.h"
 #include "game/io/eventserializer.h"
@@ -89,6 +90,10 @@ private:
 
    /// \brief calls draw() and submits frame timings to the profiling ui.
    void timedDraw();
+
+   /// \brief closes the running update section and opens the next one.
+   /// \param name label the elapsed time is added to.
+   void markUpdateSection(const char* name);
 
    /// \brief carries out a level load requested by loadLevel(), if one is pending.
    ///
@@ -212,6 +217,11 @@ private:
    //! Level::draw reports its own passes; this covers everything else Game::draw does, so the
    //! sections add up to the measured draw time instead of leaving an unexplained remainder
    RenderSectionTimer _draw_section_timer;
+
+   //! the same accounting for the update half of the frame, which the report only ever showed as a
+   //! single number. it accumulates by name rather than by position because the simulation runs a
+   //! whole number of fixed steps per frame, so a section can be entered more than once
+   UpdateSectionTimer _update_section_timer;
 #endif
 
    std::shared_ptr<EventSerializer> _global_event_serializer;

--- a/src/game/level/level.cpp
+++ b/src/game/level/level.cpp
@@ -78,6 +78,7 @@
 #endif
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <thread>
 
 // #define MECHANISM_TIMING_ENABLED 1
@@ -106,19 +107,21 @@ struct MechanismTiming
       draw_count++;
    }
 
-   float getAverageUpdateMs() const
+   float getTotalUpdateMs() const
    {
-      return (update_count > 0) ? std::chrono::duration<float, std::milli>(update_duration).count() / static_cast<float>(update_count)
-                                : 0.0f;
+      return std::chrono::duration<float, std::milli>(update_duration).count();
    }
 
-   float getAverageDrawMs() const
+   float getTotalDrawMs() const
    {
-      return (draw_count > 0) ? std::chrono::duration<float, std::milli>(draw_duration).count() / static_cast<float>(draw_count) : 0.0f;
+      return std::chrono::duration<float, std::milli>(draw_duration).count();
    }
 };
 
-std::unordered_map<std::string, MechanismTiming> timing_data;
+// keyed on the view rather than on a string: objectName() hands back a literal, so keying on
+// std::string meant a heap allocation and a free for every mechanism, every frame, purely to look
+// up the slot it goes in. that is instrumentation cost showing up inside the numbers being measured
+std::unordered_map<std::string_view, MechanismTiming> timing_data;
 
 }  // namespace
 #endif
@@ -1102,7 +1105,7 @@ void Level::drawMechanismsAtZ(
 #ifdef DEVELOPMENT_MODE
          if (_mechanism_profiling_enabled)
          {
-            const auto mechanism_name = std::string{mechanism->objectName()};
+            const auto mechanism_name = mechanism->objectName();
             const auto time_start = std::chrono::high_resolution_clock::now();
             mechanism->draw(color, normal, states);
             timing_data[mechanism_name].addDrawTime(std::chrono::high_resolution_clock::now() - time_start);
@@ -1928,28 +1931,40 @@ const std::shared_ptr<LightSystem::LightInstance>& Level::getPlayerLight() const
 
 void Level::update(const sf::Time& dt)
 {
+   beginUpdateSectionPass();
+
    Projectile::update(dt);
+   markUpdateSection("projectiles");
 
    updateMechanismVolumes();
+   markUpdateSection("mechanism volumes");
+
    updateCameraSystem(dt);
    updateViews();
+   markUpdateSection("camera");
 
    // clear conveyor belt state BEFORE updating the world
    // i.e. all objects on the belt are cleared here, then in Step() they are re-collected
    ConveyorBelt::resetBeltState();
 
    _world->Step(PhysicsConfiguration::getInstance()._time_step, 8, 3);
+   markUpdateSection("physics step");
+
    GameContactListener::getInstance().processEvents();
+   markUpdateSection("contact events");
 
    CameraPanorama::getInstance().update();
    _boom_effect.update(dt);
+   markUpdateSection("panorama and boom");
 
    AnimationPlayer::getInstance().update(dt);
+   markUpdateSection("animation player");
 
    for (auto& tile_map : _tile_maps)
    {
       tile_map->update(dt);
    }
+   markUpdateSection("tile map animations");
 
    const auto& player_chunk = PlayerRegistry::getFirst()->getChunk();
 
@@ -1969,7 +1984,7 @@ void Level::update(const sf::Time& dt)
 #ifdef DEVELOPMENT_MODE
             if (_mechanism_profiling_enabled)
             {
-               const auto mechanism_name = std::string{mechanism->objectName()};
+               const auto mechanism_name = mechanism->objectName();
                const auto time_start = std::chrono::high_resolution_clock::now();
                mechanism->update(dt);
                timing_data[mechanism_name].addUpdateTime(std::chrono::high_resolution_clock::now() - time_start);
@@ -1985,22 +2000,29 @@ void Level::update(const sf::Time& dt)
       }
    }
 
+   markUpdateSection("mechanisms");
+
    for (auto& layer : _mechanism_registry.getImageLayers())
    {
       layer->update(dt);
    }
+   markUpdateSection("image layers");
 
    _level_script.update(dt);
+   markUpdateSection("level script");
 
    LuaInterface::instance().update(
       dt, [&player_chunk](const std::shared_ptr<GameMechanism>& mechanism) { return checkUpdateMechanism(player_chunk, mechanism); }
    );
+   markUpdateSection("lua nodes");
 
    updatePlayerLight();
+   markUpdateSection("player light");
 
    _volume_updater->setRoomId(RoomUpdater::getCurrentId());
    _volume_updater->update();
    _volume_updater->updateProjectiles(Projectile::getProjectiles());
+   markUpdateSection("volume updater");
 }
 
 const std::shared_ptr<b2World>& Level::getWorld() const
@@ -2207,7 +2229,7 @@ std::vector<MechanismSample> Level::getMechanismTimings(int32_t top_n) const
    samples.reserve(timing_data.size());
    for (const auto& [name, timing] : timing_data)
    {
-      samples.push_back({name, timing.getAverageUpdateMs(), timing.getAverageDrawMs()});
+      samples.push_back({std::string{name}, timing.getTotalUpdateMs(), timing.getTotalDrawMs(), timing.update_count});
    }
    std::ranges::sort(
       samples,
@@ -2230,7 +2252,33 @@ std::vector<RenderSectionSample> Level::getRenderSectionTimings() const
 {
    return _render_section_timer.samples();
 }
+
+std::vector<RenderSectionSample> Level::getUpdateSectionTimings() const
+{
+   return _update_section_timer.samples();
+}
+
+void Level::beginUpdateSectionTiming(bool enabled)
+{
+   _update_section_timer.beginFrame(enabled);
+}
 #endif
+
+void Level::beginUpdateSectionPass()
+{
+#ifdef DEVELOPMENT_MODE
+   _update_section_timer.beginPass();
+#endif
+}
+
+void Level::markUpdateSection(const char* name)
+{
+#ifdef DEVELOPMENT_MODE
+   _update_section_timer.mark(name);
+#else
+   (void)name;
+#endif
+}
 
 void Level::beginRenderSectionTiming()
 {

--- a/src/game/level/level.h
+++ b/src/game/level/level.h
@@ -52,6 +52,7 @@
 #include "game/debug/mechanismsample.h"
 #include "game/debug/rendersectionsample.h"
 #include "game/debug/rendersectiontimer.h"
+#include "game/debug/updatesectiontimer.h"
 #endif
 
 class Bouncer;
@@ -133,6 +134,18 @@ public:
    /// machine the cost therefore shows up wherever the driver next blocks, not necessarily in the
    /// pass that caused it.
    std::vector<RenderSectionSample> getRenderSectionTimings() const;
+
+   /// \brief returns the cpu cost of each phase of Level::update, summed over the frame.
+   ///
+   /// The simulation runs a whole number of fixed steps per frame, so a section entered twice in
+   /// one frame reports both entries added together. That makes these directly comparable to the
+   /// measured update time, and it is why a frame below the step rate shows a higher figure: it
+   /// really does pay for the phase twice.
+   std::vector<RenderSectionSample> getUpdateSectionTimings() const;
+
+   /// \brief starts an update section measurement for one frame.
+   /// \param enabled true to collect; false leaves every mark inert.
+   void beginUpdateSectionTiming(bool enabled);
 #endif
 
    /// \brief advances active room and camera behavior, including room locks, transitions, and zoom.
@@ -463,8 +476,19 @@ protected:
    /// \param name label the elapsed time is recorded under.
    void markRenderSection(const char* name);
 
+   /// \brief opens the first update section of one simulation step.
+   ///
+   /// Unlike the draw sections this is entered once per simulation step rather than once per frame,
+   /// so it restarts the clock without dropping what earlier steps of the same frame accumulated.
+   void beginUpdateSectionPass();
+
+   /// \brief closes the running update section and opens the next one.
+   /// \param name label the elapsed time is added to.
+   void markUpdateSection(const char* name);
+
 #ifdef DEVELOPMENT_MODE
    bool _mechanism_profiling_enabled{false};
    RenderSectionTimer _render_section_timer;
+   UpdateSectionTimer _update_section_timer;
 #endif
 };

--- a/src/game/mechanisms/imagelayer.cpp
+++ b/src/game/mechanisms/imagelayer.cpp
@@ -56,7 +56,7 @@ void ImageLayer::draw(sf::RenderTarget& target, sf::RenderTarget& normal)
    target.draw(*_sprite, {_blend_mode});
 
 #ifdef DEVELOPMENT_MODE
-   DrawCallCounter::countImageLayerPixels(target, {_blend_mode}, *_sprite);
+   DrawCallCounter::countImageLayerPixels(target, {_blend_mode}, *_sprite, getObjectId());
 #endif
 
    if (_parallax_settings.has_value())
@@ -87,7 +87,7 @@ void ImageLayer::draw(sf::RenderTarget& target, sf::RenderTarget& normal, const 
       const sf::RenderStates parallax_states{.blendMode = _blend_mode, .view = _parallax_view, .texture = texture};
       target.draw(*_sprite, parallax_states);
 #ifdef DEVELOPMENT_MODE
-      DrawCallCounter::countImageLayerPixels(target, parallax_states, *_sprite);
+      DrawCallCounter::countImageLayerPixels(target, parallax_states, *_sprite, getObjectId());
 #endif
    }
    else
@@ -97,7 +97,7 @@ void ImageLayer::draw(sf::RenderTarget& target, sf::RenderTarget& normal, const 
       draw_states.texture = texture;
       target.draw(*_sprite, draw_states);
 #ifdef DEVELOPMENT_MODE
-      DrawCallCounter::countImageLayerPixels(target, draw_states, *_sprite);
+      DrawCallCounter::countImageLayerPixels(target, draw_states, *_sprite, getObjectId());
 #endif
    }
 #else


### PR DESCRIPTION
Prerequisite for the optimisation PRs split out of #465 — it is the instrument the rest are measured with.

On real switch hardware, at 48 fps vsync off: `update avg 10.1 ms | draw avg 10.4 ms`. Update is as big as draw and had never been broken down, because Ryujinx reports it at 2.8 ms.

- `UpdateSectionTimer` accumulates **by name, not by position** — the simulation runs a whole number of fixed 1/60 s steps per frame, so a phase is entered once or twice and the sample list changes length between frames.
- 16 phases across `Game::update` and `Level::update`; `level update` is the containing span and excluded from the total.
- **simulation steps per frame** — without it an update figure is unreadable: a doubled number can be a slow phase or just a slow frame.
- mechanism timings as **totals + instance count** rather than per-instance averages (an average of 0.061 ms cannot be ranked against anything).
- per-image-layer fill breakdown; mechanism totals now reach the desktop log too.
- fixes the instrument distorting itself: per-mechanism timing built a `std::string` from a literal for every mechanism every frame purely to key a map.

Tooling: `probe_update_sections.py` (runs **vsync on** on purpose, which pins the frame to exactly one step so each phase reads as its true per-step cost) and `compare_captures.py` (frame % plus worst 64 px cell, because a missing layer barely moves a frame-wide mean).

No behaviour change; everything is behind `DEVELOPMENT_MODE`.