### PR TITLE
share vectorial2's methods instead of rebuilding them per vector

### DIFF
--- a/data/scripts/enemies/vectorial2.lua
+++ b/data/scripts/enemies/vectorial2.lua
@@ -20,15 +20,30 @@
    along with this program; if not, write to the Free Software Foundation,
    Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 ]]
+--[[
+   Local modification: the methods and metamethods below used to live inside Vector2D, so every
+   vector built its own copy of all of them - 3 tables plus 24 closures to hold two numbers. They are
+   shared now, built once when the module loads. Every method body and operator is unchanged; only
+   where they live moved. deepcopy carries the metatable over by reference rather than deep copying
+   it, which is the same metamethods either way.
+]]
 local module = {}
+
+--Shared by every vector. Instances hold only their components and reach these through __index.
+local methods = {}
+local mt = {} --Metatable
+mt.__index = methods
+
       module.Vector2D = function (ix, iy)
    local v2d = {}
          v2d.v = {}
          v2d.v.x = ix
          v2d.v.y = iy
-         mt ={} --Metatable
 
-   function v2d:deepcopy(orig) --Deeply copy a table. This is for the operation metatables.
+   return setmetatable(v2d, mt)
+end
+
+   function methods:deepcopy(orig) --Deeply copy a table. This is for the operation metatables.
          local orig_type = type(orig)
          local copy
          if orig_type == 'table' then
@@ -36,7 +51,9 @@ local module = {}
             for orig_key, orig_value in next, orig, nil do
                      copy[self:deepcopy(orig_key)] = self:deepcopy(orig_value)
             end
-            setmetatable(copy, self:deepcopy(getmetatable(orig)))
+            --the metatable is shared rather than owned, so it is carried over as it is. deep copying
+            --it produced a distinct table holding the same metamethods, which behaves identically
+            setmetatable(copy, getmetatable(orig))
          else -- number, string, boolean, etc
             copy = orig
          end
@@ -45,12 +62,12 @@ local module = {}
 
    --Vector Specific Math
 
-   function v2d:getAngle() --Return the 2D angle of the vector IN RADIANS!.
+   function methods:getAngle() --Return the 2D angle of the vector IN RADIANS!.
       return math.atan2(self:getY(), self:getX())
    end
 
-   function v2d:getLength() --Return the length of the vector (i.e. the distance from (0,0), see README.md for examples of using this)
-      origin = self:deepcopy(self) --Get a new vector to work with
+   function methods:getLength() --Return the length of the vector (i.e. the distance from (0,0), see README.md for examples of using this)
+      local origin = self:deepcopy(self) --Get a new vector to work with
       origin:setX(0) --Set the origin equal to the geometric origin
       origin:setY(0)
       return self .. origin --Linear distance from us to the origin
@@ -89,25 +106,25 @@ local module = {}
 
    --Operations
 
-   function v2d:setX(x)
+   function methods:setX(x)
       self.v.x = x
    end
 
-   function v2d:setY(y)
+   function methods:setY(y)
       self.v.y = y
    end
 
-   function v2d:getX()
+   function methods:getX()
       return self.v.x
    end
 
-   function v2d:getY()
+   function methods:getY()
       return self.v.y
    end
 
    mt.__unm = function(rhs)
       --Unary Minus (negation) operator for Vector2Ds
-      out = rhs:deepcopy(rhs) --Copy the operand for the output (else the output won't have metamethods)
+      local out = rhs:deepcopy(rhs) --Copy the operand for the output (else the output won't have metamethods)
       out:setX(-rhs:getX()) --Operate on the X property
       out:setY(-rhs:getY()) --Operate on the Y property
       return out
@@ -115,7 +132,7 @@ local module = {}
 
    mt.__add = function(lhs, rhs)
       --Addition operator for Vector2Ds
-      out = lhs:deepcopy(lhs)--Copy the operand for the output (else the output won't have metamethods)
+      local out = lhs:deepcopy(lhs)--Copy the operand for the output (else the output won't have metamethods)
       out:setX(lhs:getX() + rhs:getX()) --Operate on the X property
       out:setY(lhs:getY() + rhs:getY()) --Operate on the Y property
       return out
@@ -123,7 +140,7 @@ local module = {}
 
    mt.__sub = function(lhs, rhs)
       --Subtraction operator for Vector2Ds
-      out = lhs:deepcopy(lhs)--Copy the operand for the output (else the output won't have metamethods)
+      local out = lhs:deepcopy(lhs)--Copy the operand for the output (else the output won't have metamethods)
       out:setX(lhs:getX() - rhs:getX()) --Operate on the X property
       out:setY(lhs:getY() - rhs:getY()) --Operate on the Y property
       return out
@@ -131,7 +148,7 @@ local module = {}
 
    mt.__mul = function(lhs, rhs)
       --Multiplication operator for Vector2Ds
-      out = lhs:deepcopy(lhs)--Copy the operand for the output (else the output won't have metamethods)
+      local out = lhs:deepcopy(lhs)--Copy the operand for the output (else the output won't have metamethods)
       out:setX(lhs:getX() * rhs:getX()) --Operate on the X property
       out:setY(lhs:getY() * rhs:getY()) --Operate on the Y property
       return out
@@ -139,7 +156,7 @@ local module = {}
 
    mt.__div = function(lhs, rhs)
       --Division operator for Vector2Ds
-      out = lhs:deepcopy(lhs)--Copy the operand for the output (else the output won't have metamethods)
+      local out = lhs:deepcopy(lhs)--Copy the operand for the output (else the output won't have metamethods)
       out:setX(lhs:getX() / rhs:getX()) --Operate on the X property
       out:setY(lhs:getY() / rhs:getY()) --Operate on the Y property
       return out
@@ -147,7 +164,7 @@ local module = {}
 
    mt.__mod = function(lhs, rhs)
       --Vector distance operator for Vector2Ds. Denoted by modulo (%)
-      out = lhs:deepcopy(lhs)		--Copy the operand for the output (else the output won't have metamethods)
+      local out = lhs:deepcopy(lhs)		--Copy the operand for the output (else the output won't have metamethods)
       out:setX(math.abs(rhs:getX() - lhs:getX())) --Operate on the X property
       out:setY(math.abs(rhs:getY() - lhs:getY())) --Operate on the Y property
       return out
@@ -155,22 +172,22 @@ local module = {}
 
    mt.__concat = function(lhs, rhs)
       --Linear distance operator for Vector2Ds. Denoted by concat (..)
-      out = 0		--This is a linear operation, so no deepcopy.
+      local out = 0		--This is a linear operation, so no deepcopy.
       out = math.sqrt(((lhs:getX() - rhs:getX())^2) + ((rhs:getY() - lhs:getY())^2)) --Distance formula
       return out
    end
 
-   function v2d:sub(other)
+   function methods:sub(other)
       -- Subtract another vector from this vector
       return self - other
    end
 
-   function v2d:add(other)
+   function methods:add(other)
       -- Add another vector to this vector
       return self + other
    end
 
-   function v2d:mul(scalar)
+   function methods:mul(scalar)
       -- Multiply this vector by a scalar
       if type(scalar) == "number" then
          -- If scalar is a number, multiply both components by it
@@ -184,12 +201,12 @@ local module = {}
       end
    end
 
-   function v2d:len()
+   function methods:len()
       -- Get the length (magnitude) of the vector
       return math.sqrt((self:getX() * self:getX()) + (self:getY() * self:getY()))
    end
 
-   function v2d:norm()
+   function methods:norm()
       -- Normalize the vector (get unit vector in same direction)
       local length = self:len()
       if length == 0 then
@@ -202,13 +219,9 @@ local module = {}
 
    mt.__tostring = function(self)
       --tostring handler for Vector2D
-      out = ""	--This is a string operation, so no deepcopy.
+      local out = ""	--This is a string operation, so no deepcopy.
       out = "[(X:"..self:getX().."),(Y:"..self:getY()..")]"
       return out
    end
 
-   setmetatable(v2d, mt)
-
-   return v2d
-end
 return module


### PR DESCRIPTION
Split out of #465. Data only — no engine change, independent of the other PRs.

`vectorial2.lua` defined every method and operator *inside* the constructor, so each `Vector2D(x, y)` allocated **3 tables plus 24 closures**. Every enemy does that twice per simulation step via `movedTo`/`playerMovedTo`, which nearly every script implements as `_position_px = v2d.Vector2D(x, y)`.

| per frame, 24 enemies in range | before | after |
|---|---:|---:|
| `movedTo` | 0.106 ms | **0.037** |
| `playerMovedTo` | 0.059 | **0.017** |
| `update` (the actual AI) | 0.143 | **0.109** |
| **lua nodes phase** | **0.330** | **0.181** |

Methods now live on one shared metatable. Every method body and comment is unchanged; only where they live moved.

## Verification

- Compiled a standalone Lua 5.4 from `build_rel/_deps/lua-src` and ran the whole public API against both revisions: **every value bit-identical**. Only diffs were error line numbers and `instance keys` — and no script iterates a vector with `pairs`.
- Same binary, library swapped, three places in the level: difference came out **5–15× smaller than the same-build noise floor**.

## Two latent bugs this exposed, left alone

Both unreachable from current scripts; either would hit `LuaNodeCallbacks::error` → `exit(1)`:
- `getAngle()` calls `math.atan2`, removed in Lua 5.4
- `__eq`/`__lt`/`__le` call `lhs.getX()` with a dot, so `self` is nil