### PR TITLE
skip image layers that share no area with the view

### DIFF
--- a/src/game/mechanisms/imagelayer.cpp
+++ b/src/game/mechanisms/imagelayer.cpp
@@ -4,12 +4,35 @@
 #include "framework/tmxparser/tmximagelayer.h"
 #include "framework/tmxparser/tmxproperties.h"
 #include "framework/tmxparser/tmxproperty.h"
+#include "framework/tools/sfmlcompat.h"
 #include "game/io/texturepool.h"
 #include "game/player/playerregistry.h"
 
 #ifdef DEVELOPMENT_MODE
 #include "game/debug/drawcallcounter.h"
 #endif
+
+namespace
+{
+///
+/// \brief Tells whether a sprite reaches into the region a view shows.
+/// \param view the view the sprite would be drawn through.
+/// \param sprite the sprite in question.
+/// \return true when the two rectangles overlap.
+///
+bool reachesView(const sf::View& view, const sf::Sprite& sprite)
+{
+   const auto view_center = sfcompat::getViewCenter(view);
+   const auto view_size = sfcompat::getViewSize(view);
+   const auto bounds = sprite.getGlobalBounds();
+
+   const auto view_left = view_center.x - view_size.x * 0.5f;
+   const auto view_top = view_center.y - view_size.y * 0.5f;
+
+   return bounds.position.x < view_left + view_size.x && view_left < bounds.position.x + bounds.size.x &&
+          bounds.position.y < view_top + view_size.y && view_top < bounds.position.y + bounds.size.y;
+}
+}  // namespace
 
 ImageLayer::ImageLayer(GameNode* parent) : GameNode(parent)
 {
@@ -48,6 +71,12 @@ void ImageLayer::draw(sf::RenderTarget& target, sf::RenderTarget& normal)
    // level view is copied here on purpose
    const auto level_view = target.getView();
 
+   // a layer sharing no area with the view rasterises nothing, so it is skipped
+   if (!reachesView(_parallax_settings.has_value() ? _parallax_view : level_view, *_sprite))
+   {
+      return;
+   }
+
    if (_parallax_settings.has_value())
    {
       target.setView(_parallax_view);
@@ -81,6 +110,12 @@ void ImageLayer::draw(sf::RenderTarget& target, sf::RenderTarget& normal, const 
 
    // the texture has to travel in the render states, vrsfml sprites do not own one
    const auto* texture = _texture->getTexture().get();
+
+   // a layer sharing no area with the view rasterises nothing, so it is skipped
+   if (!reachesView(_parallax_settings.has_value() ? _parallax_view : states.view, *_sprite))
+   {
+      return;
+   }
 
    if (_parallax_settings.has_value())
    {


### PR DESCRIPTION
Split out of #465. **Independent of the other PRs** (touches only `imagelayer.cpp`; #466 touches the same file, so whichever lands second may need a trivial rebase).

Image layers are only unloaded **by chunk**: `LazyTexture` keeps a texture while any of its chunks is within one 512 px chunk of the player's — a very loose fence around a 640×360 view. So room overlays a room or two away stay resident and draw.

Measured at catacombs checkpoint 3: **24 image layers drawn per frame, exactly two of them putting a pixel on screen** (`es-the-widow-maker` and `fp-the-widow-maker`, 1.00x each). The other 22 cost a draw call each, and the parallax ones a view change on top, which flushes the batch under VRSFML.

## Why it's exact, and the proof

A sprite sharing no area with the view rasterises nothing, whatever its blend mode. The views here are built from a rectangle and never rotated, so comparing world-space rectangles is the whole test.

The self-check is the point — after this change:

| | before | after |
|---|---:|---:|
| image layers drawn / frame | 24 | **3** |
| overdraw tiles | 5.46x | 5.46x |
| overdraw normal pass | 2.07x | 2.07x |
| overdraw ao | 0.52x | 0.52x |
| overdraw image layers | 2.01x | 2.01x |
| overdraw total | 8.00x | 8.00x |

**21 draw calls and their view changes gone, zero pixels changed.**

Verified to build standalone on master.