### PR TITLE
check the view before drawing dust and shader layers

### DIFF
--- a/src/game/mechanisms/dust.cpp
+++ b/src/game/mechanisms/dust.cpp
@@ -4,6 +4,7 @@
 #include "framework/tmxparser/tmxproperties.h"
 #include "framework/tmxparser/tmxproperty.h"
 #include "framework/tmxparser/tmxtools.h"
+#include "framework/tools/sfmlcompat.h"
 #include "game/event/eventdistributor.h"
 #include "game/io/texturepool.h"
 #include "game/io/valuereader.h"
@@ -14,6 +15,21 @@
 
 namespace
 {
+// the same test SmokeEffect and WaterSurface make before drawing, kept local to match them
+bool isOnScreen(const sf::View& view, const sf::FloatRect& bounding_box)
+{
+   const auto view_center = sfcompat::getViewCenter(view);
+   const auto view_size = sfcompat::getViewSize(view);
+   if (view_size.x <= 0.0f || view_size.y <= 0.0f)
+   {
+      return true;
+   }
+
+   const sf::FloatRect view_rect{{view_center.x - view_size.x * 0.5f, view_center.y - view_size.y * 0.5f}, {view_size.x, view_size.y}};
+
+   return sfcompat::findIntersection(view_rect, bounding_box).has_value();
+}
+
 static constexpr std::array dust_properties{
    PropertyInfo{.name = "z", .type = "int", .default_value = int32_t{20}},
 };
@@ -168,6 +184,42 @@ void Dust::draw(sf::RenderTarget& target, sf::RenderTarget& /*normal*/, const sf
 
    sf::RenderStates states = incoming_states;
    states.blendMode = sf::BlendAlpha;
+
+   // an effect whose particles cannot reach the view contributes nothing, and building its quads is
+   // the most expensive mechanism draw in the frame. mechanisms are only culled by chunk distance to
+   // the player, which admits six of these against a 640 x 360 view (SmokeEffect and WaterSurface
+   // already check the view for the same reason).
+   //
+   // The clip rect is grown rather than used as it is, because a particle can be drawn outside it:
+   //
+   //     _clip_rect
+   //     +---------------------------+
+   //     |                           |
+   //     |                        o--|-->  update() moves the particle first and only respawns it
+   //     |                           | \    on the NEXT step, once it is already outside. So it
+   //     +---------------------------+  \   spends one step out here...
+   //                                  [##]  ...and is drawn as a _particle_size_px quad reaching
+   //     |<-- reachable_rect adds ----->|    further still from its position.
+   //          _particle_size_px + 16
+   //
+   // Without the slack there is a sliver a few pixels wide - where the clip rect is just off screen
+   // but a drifted particle is just on it - in which one particle would be dropped. Two pixels of
+   // alpha-50 dust, so imperceptible either way; with the slack the cull is exact instead of merely
+   // unnoticeable, which is a better thing to be able to say about it
+   const auto slack_px = static_cast<float>(_particle_size_px) + 16.0f;
+   const auto reachable_rect = sf::FloatRect{
+      {_clip_rect.position.x - slack_px, _clip_rect.position.y - slack_px},
+      {_clip_rect.size.x + slack_px * 2.0f, _clip_rect.size.y + slack_px * 2.0f}
+   };
+
+#ifdef DECEPTUS_VRSFML
+   if (!isOnScreen(states.view, reachable_rect))
+#else
+   if (!isOnScreen(target.getView(), reachable_rect))
+#endif
+   {
+      return;
+   }
 
    std::size_t vertex_index = 0;
 

--- a/src/game/mechanisms/shaderlayer.cpp
+++ b/src/game/mechanisms/shaderlayer.cpp
@@ -3,6 +3,7 @@
 #include "framework/tmxparser/tmxobject.h"
 #include "framework/tmxparser/tmxproperties.h"
 #include "framework/tmxparser/tmxproperty.h"
+#include "framework/tools/sfmlcompat.h"
 #include "game/io/texturepool.h"
 #include "game/io/valuereader.h"
 
@@ -16,6 +17,23 @@
 
 namespace
 {
+// the same test SmokeEffect, WaterSurface and Dust make before drawing, kept local to match them.
+// worth it here for the state changes rather than the fill: each layer binds its shader and uploads
+// three or four uniforms, and a layer the camera cannot see pays all of that for nothing
+bool isOnScreen(const sf::View& view, const sf::FloatRect& bounding_box)
+{
+   const auto view_center = sfcompat::getViewCenter(view);
+   const auto view_size = sfcompat::getViewSize(view);
+   if (view_size.x <= 0.0f || view_size.y <= 0.0f)
+   {
+      return true;
+   }
+
+   const sf::FloatRect view_rect{{view_center.x - view_size.x * 0.5f, view_center.y - view_size.y * 0.5f}, {view_size.x, view_size.y}};
+
+   return sfcompat::findIntersection(view_rect, bounding_box).has_value();
+}
+
 std::map<std::string, std::function<ShaderLayer::FactoryFunction>>& getCustomizations()
 {
    static std::map<std::string, std::function<ShaderLayer::FactoryFunction>> __customizations;
@@ -69,6 +87,11 @@ void ShaderLayer::draw(sf::RenderTarget& target, sf::RenderTarget& /*normal*/, c
       return;
    }
 
+   if (!isOnScreen(states.view, _rect))
+   {
+      return;
+   }
+
    const auto x = _position.x;
    const auto y = _position.y;
    const auto w = _size.x;
@@ -97,6 +120,11 @@ void ShaderLayer::draw(sf::RenderTarget& target, sf::RenderTarget& /*normal*/, c
 #else
 void ShaderLayer::draw(sf::RenderTarget& target, sf::RenderTarget& /*normal*/)
 {
+   if (!isOnScreen(target.getView(), _rect))
+   {
+      return;
+   }
+
    const auto x = _position.x;
    const auto y = _position.y;
    const auto w = _size.x;


### PR DESCRIPTION
Split out of #465. **Independent of the other PRs.**

Mechanisms are culled by chunk distance to the player, which admits six dust effects against a 640×360 view. `SmokeEffect` and `WaterSurface` already test the view before drawing for exactly this reason; these two did not, despite both owning a rectangle that says where they draw.

| | before | after |
|---|---:|---:|
| Dust draw | 0.057 ms | **0.025** |
| ShaderLayer draw | 0.040 ms | **0.022** |

**Dust** was the most expensive mechanism draw in the frame, building a quad per particle. Its test rect is `_clip_rect` grown by `_particle_size_px + 16`, because `update()` respawns a particle only once it has *already left* the rect — so one can spend a step outside it, and is drawn as a quad reaching further still. Without the slack there's a sliver a few pixels wide where one particle would be dropped; imperceptible either way, but this makes it exact rather than merely unnoticeable.

**ShaderLayer**'s `_rect` is exactly the quad it draws, so the cull is exact by construction. Worth it there for the *state changes* rather than the fill: each layer binds its shader and uploads three or four uniforms per frame. `RingShaderLayer` delegates its geometry to `ShaderLayer::draw`, so it's covered too.

Verified the ring and waterfall still render: 0.04% frame diff against a 0.22% noise floor.

**Dust's update is deliberately left alone** — its positions integrate through a flow field, so skipping would freeze them rather than being recoverable.

## Caveat worth reviewing against

In the Ryujinx A/B of the whole of #465, `draw` measured 7.5% **slower** (6.62 → 7.12 ms, reproducible in both orders). That comparison was confounded — the branch carried draw-side instrumentation master lacked — but these draw-side culls are among the suspects, and I have no mechanism for it. Splitting them out like this is partly so that can be bisected.