### PR TITLE
stop updating smoke effects the camera cannot see

### DIFF
--- a/src/game/camera/cameraroomlock.cpp
+++ b/src/game/camera/cameraroomlock.cpp
@@ -166,3 +166,8 @@ void CameraRoomLock::setViewRect(const sf::FloatRect& rect)
 {
    _view_rect = rect;
 }
+
+const sf::FloatRect& CameraRoomLock::getViewRect()
+{
+   return _view_rect;
+}

--- a/src/game/camera/cameraroomlock.h
+++ b/src/game/camera/cameraroomlock.h
@@ -31,4 +31,12 @@ void setRoom(const std::shared_ptr<Room>& room);
 /// \brief updates the current camera view rectangle used by boundary probing.
 /// \param rect current view rectangle in world pixel coordinates.
 void setViewRect(const sf::FloatRect& rect);
+
+/// \brief returns the view rectangle the level last computed, in world pixel coordinates.
+///
+/// Level::updateViews publishes it here at the top of every simulation step, so anything updating
+/// later in the same step can ask what the camera is about to show. That is not the same as the
+/// rectangle the frame is drawn through - draw uses the interpolated camera - so a caller deciding
+/// whether to skip work needs a margin rather than treating this as the exact visible region.
+const sf::FloatRect& getViewRect();
 }  // namespace CameraRoomLock

--- a/src/game/mechanisms/smokeeffect.cpp
+++ b/src/game/mechanisms/smokeeffect.cpp
@@ -8,6 +8,7 @@
 #include "framework/tmxparser/tmxtools.h"
 #include "framework/tools/log.h"
 #include "framework/tools/sfmlcompat.h"
+#include "game/camera/cameraroomlock.h"
 #include "game/io/texturepool.h"
 
 #include <array>
@@ -159,9 +160,62 @@ void SmokeEffect::update(const sf::Time& dt)
    _elapsed += dt;
    const auto dt_scaled = dt.asSeconds() * _velocity;
 
+   // the rotation is the one piece of particle state that integrates; everything else below is a
+   // pure function of _elapsed. So it has to keep advancing even when the rest is skipped, or the
+   // smoke would jump the moment it comes back into view
    for (auto& particle : _particles)
    {
       particle._rot += dt_scaled * 10.0f * particle._rot_dir;
+   }
+
+   // draw already drops this effect when its bounding box misses the view, so recomputing 80-100
+   // particles' transforms and rebuilding their vertices for it is work with no result. Six effects
+   // pass the chunk filter in the catacombs against a 640 x 360 view, and they were the whole of the
+   // frame's mechanism update cost.
+   //
+   // The three regions, and why the middle one has to exist:
+   //
+   //     +-------------------------------------------------------+
+   //     |  chunk range: what checkUpdateMechanism admits,       |
+   //     |  ~1024 px around the player. Six smoke effects.       |
+   //     |                                                       |
+   //     |      +---------------------------------------+        |
+   //     |      |  update_rect: view + 25% margin.      |        |
+   //     |      |  THIS is what gates the work below.   |        |
+   //     |      |                                       |        |
+   //     |      |      +-------------------------+      |        |
+   //     |      |      |  view: what draw()      |      |        |
+   //     |      |      |  already culls against  |      |        |
+   //     |      |      +-------------------------+      |        |
+   //     |      |                                       |        |
+   //     |      +---------------------------------------+        |
+   //     |                                                       |
+   //     +-------------------------------------------------------+
+   //
+   // The margin is not slop, it is the correctness argument. Two reasons the update cull must sit
+   // strictly outside the draw cull:
+   //
+   //   - update runs against the view the simulation just computed; draw runs against the
+   //     interpolated camera a moment later, so the two rectangles never match exactly.
+   //   - consumeSteps() can return ZERO on a fast frame, so mechanisms do not update every frame.
+   //     An effect entering the view on a zero-step frame would draw with whatever vertices it last
+   //     had. With 25% of the view (160 px) of margin and a camera moving a few px per frame, an
+   //     effect gets dozens of steps of updating before it is ever drawn, so that cannot bite.
+   //     Shrink the margin and this stops holding.
+   const auto& view_rect = CameraRoomLock::getViewRect();
+   const auto margin_px = sf::Vector2f{view_rect.size.x * 0.25f, view_rect.size.y * 0.25f};
+   const auto update_rect = sf::FloatRect{
+      {view_rect.position.x - margin_px.x, view_rect.position.y - margin_px.y},
+      {view_rect.size.x + margin_px.x * 2.0f, view_rect.size.y + margin_px.y * 2.0f}
+   };
+
+   if (view_rect.size.x > 0.0f && !sfcompat::findIntersection(update_rect, _bounding_box_px).has_value())
+   {
+      return;
+   }
+
+   for (auto& particle : _particles)
+   {
       sfcompat::setRotation(*particle._sprite, sf::degrees(particle._rot));
 
       // fake z rotation


### PR DESCRIPTION
Split out of #465. **Independent of the other PRs.** Update-side only, so it cannot affect draw cost.

`SmokeEffect::draw` already dropped the effect when its bounding box missed the view. Its **update** did not — and update is where the cost is: 80–100 particles, each getting its transform recomputed and its vertices rebuilt. Six effects pass the chunk filter in the catacombs against a 640×360 view, and they were **the whole of the frame's mechanism update cost**.

```
SmokeEffect update   0.168 -> 0.046 ms     (so four or five of six were off screen)
mechanisms phase     0.190 -> 0.143 ms
```

## Why it's safe

The rotation is the only piece of particle state that *integrates*, so it keeps advancing outside the gate; everything else is a pure function of `_elapsed` and is recomputed from scratch when the effect returns.

The gate uses the view **plus a 25% margin**, and that margin is the correctness argument, not slop:

```
chunk range  ⊃  update_rect (view + 25%)  ⊃  view (what draw() culls against)
```

- update runs against the view the simulation just computed; draw runs against the interpolated camera a moment later, so the two rectangles never match exactly.
- `consumeSteps()` can return **zero** on a fast frame, so mechanisms don't update every frame. An effect entering the view on a zero-step frame would draw with stale vertices. With 160 px of margin and a camera moving a few px per frame, it gets dozens of steps of updating before it is ever drawn. Shrink the margin and this stops holding.

Also verified rather than assumed: the render texture is `object size / _pixel_ratio` drawn at `_offset_px` scaled by `_pixel_ratio`, so the drawn extent is exactly `_bounding_box_px` — the pre-existing draw cull was already tight, which is what lets this one sit outside it.

Needs a getter for the view rectangle `Level::updateViews` already publishes to `CameraRoomLock`.

Instrumented check at the start room: the smoke overlapping the view reported `UPDATED`, and `getViewRect()` returned exactly the real view (`866,2400 640x360`).