### PR TITLE
scope the camera config rows so their widget ids stop colliding

### DIFF
--- a/src/game/camera/camerasystemconfigurationui.cpp
+++ b/src/game/camera/camerasystemconfigurationui.cpp
@@ -79,8 +79,10 @@ void CameraSystemConfigurationUi::draw()
 
    SettingsUi::beginSettings();
 
+   // scopes the widget ids per section, so rows sharing a label stay distinct
    if (ImGui::CollapsingHeader("horizontal", header_flags))
    {
+      ImGui::PushID("horizontal");
       SettingsUi::drawFloat(
          "camera velocity factor",
          &config._camera_velocity_factor_x,
@@ -139,10 +141,12 @@ void CameraSystemConfigurationUi::draw()
          "view rather than leaving the player centred.",
          "Turning it on is what gives the target shift factor above something to do."
       );
+      ImGui::PopID();
    }
 
    if (ImGui::CollapsingHeader("vertical", header_flags))
    {
+      ImGui::PushID("vertical");
       SettingsUi::drawFloat(
          "camera velocity factor",
          &config._camera_velocity_factor_y,
@@ -201,6 +205,7 @@ void CameraSystemConfigurationUi::draw()
          "Multiplies the vertical velocity factor, and replaces the gentle ease-in the normal follow "
          "uses, so it takes hold immediately."
       );
+      ImGui::PopID();
    }
 
    if (ImGui::CollapsingHeader("various", header_flags))


### PR DESCRIPTION
Unrelated to the perf work — split out on request.

The camera configuration window pops `Programmer error: 2 visible items with conflicting ID`, and the affected rows lose their `-`/`+` stepper buttons.

Cause: `drawFloatElement`/`drawIntElement` derive the widget id from the row label (`"##" + name + "_input"`), and **two labels appear in both sections**:

| label | horizontal | vertical |
|---|---|---|
| camera velocity factor | `_camera_velocity_factor_x` | `_camera_velocity_factor_y` |
| back in bounds tolerance | `_back_in_bounds_tolerance_x` | `_back_in_bounds_tolerance_y` |

Same label → same id → imgui keeps one and complains about the other.

Fix is `PushID`/`PopID` around each section, which separates the x row from the y row without renaming anything the user reads.