### PR TITLE
keep the camera's lead behind a decelerating player

### DIFF
--- a/src/game/camera/camerasystem.cpp
+++ b/src/game/camera/camerasystem.cpp
@@ -44,6 +44,14 @@
 
 */
 
+namespace
+{
+//!< how much faster the lead's speed collapses than it builds. A player slows down faster than the
+//!< catch-up can follow at its own rate, and an aim point still carrying the old speed would sit
+//!< ahead of one who has already stopped
+constexpr auto lead_decay_factor = 3.0f;
+}  // namespace
+
 void CameraSystem::update(const sf::Time& dt, float view_width_px, float view_height_px)
 {
    // where the camera stood going into this step, so the frames drawn before the next one can be
@@ -90,14 +98,16 @@ void CameraSystem::updateX(const sf::Time& delta_time)
    // where it belongs - while the player is speeding up or slowing down the lead is still short and the
    // camera eases towards the new speed, and once the speed is steady the lead is the whole distance
    // and the camera sits on the player with nothing left over
-   _lead_velocity_px_per_s += (player_velocity_px_per_s - _lead_velocity_px_per_s) * delta_time.asSeconds() * velocity_factor;
+   //
+   // The catch-up runs at that rate only while the player is speeding up. Slowing down, the lead
+   // collapses faster, so the aim point stays behind a player who has stopped rather than hanging on
+   // ahead of them and having to come back. Collapsing it faster rather than snapping it to their
+   // current speed is what keeps the follow's ease out: the camera still glides to a halt instead of
+   // running out of distance to cover all at once
+   const auto catch_up_rate =
+      (fabs(player_velocity_px_per_s) >= fabs(_lead_velocity_px_per_s)) ? velocity_factor : (velocity_factor * lead_decay_factor);
 
-   // the catch-up is only allowed to lag behind a player who is speeding up. Slowing down, the lead
-   // is held to the speed the player actually has, so it never aims past one who has already stopped
-   if (fabs(_lead_velocity_px_per_s) > fabs(player_velocity_px_per_s))
-   {
-      _lead_velocity_px_per_s = player_velocity_px_per_s;
-   }
+   _lead_velocity_px_per_s += (player_velocity_px_per_s - _lead_velocity_px_per_s) * delta_time.asSeconds() * catch_up_rate;
 
    const auto lead_px =
       (velocity_factor > 0.0f) ? (_lead_velocity_px_per_s * camera_config.getCameraLeadFactorX() / velocity_factor) : 0.0f;

--- a/src/game/camera/camerasystem.cpp
+++ b/src/game/camera/camerasystem.cpp
@@ -92,6 +92,13 @@ void CameraSystem::updateX(const sf::Time& delta_time)
    // and the camera sits on the player with nothing left over
    _lead_velocity_px_per_s += (player_velocity_px_per_s - _lead_velocity_px_per_s) * delta_time.asSeconds() * velocity_factor;
 
+   // the catch-up is only allowed to lag behind a player who is speeding up. Slowing down, the lead
+   // is held to the speed the player actually has, so it never aims past one who has already stopped
+   if (fabs(_lead_velocity_px_per_s) > fabs(player_velocity_px_per_s))
+   {
+      _lead_velocity_px_per_s = player_velocity_px_per_s;
+   }
+
    const auto lead_px =
       (velocity_factor > 0.0f) ? (_lead_velocity_px_per_s * camera_config.getCameraLeadFactorX() / velocity_factor) : 0.0f;
 


### PR DESCRIPTION
The camera drifts slowly a few pixels backwards a moment after the walk key is released.

## Cause

The lead added in a05503a6 is built from a velocity that takes `1 / velocity_factor_x` to catch up — a quarter of a second at the shipped factor of 4. That lag is deliberate on the way up, since it is where the camera's acceleration comes from, but it applied on the way down as well, and the player stops in roughly a tenth of a second. For a quarter of a second after the key came up, the aim point still sat a full lead ahead of a player who had already stopped.

The camera chased it there and overshot the player. The focus zone gate then froze it, because the aim point was now inside the zone and there was nothing left to move towards. Once the lead finished decaying, the aim point had travelled back past the far edge of the zone, the gate re-triggered, and the camera crawled back the other way.

That last part is what is visible: a slow drift of a couple of pixels, starting the better part of a second after the key was released rather than immediately.

## Why it is easy to miss

The overshoot scales with speed, and the focus zone hides it below a threshold. Stepping the loop at the shipped constants (`dt` 1/60, `velocity_factor_x` 4.0, `lead_factor_x` 0.8, zone `640 / 100` = 6.4 px):

| | offset while moving | overshoot | parks at | drifts back |
|---|---|---|---|---|
| walk, 120 px/s | −4.1 px | +5.7 px at +0.20 s | +5.7 px | 0.0 px |
| run, 154 px/s | −5.2 px | +7.8 px at +0.22 s | +6.0 px | **1.7 px** |
| run, zone disabled | −5.2 px | +9.3 px at +0.33 s | 0.0 px | 9.3 px |

Walking lands just inside the zone and freezes there, so the return never happens. Running clears the zone and the gate re-fires. The third row is the same run with the gate taken out, showing the full unwind the zone is masking.

## Change

The lead's speed now catches up at the configured rate while the player is speeding up, and at three times that rate while they are slowing down. Outrunning their deceleration is what keeps the aim point from passing a player who has stopped.

The first commit did this by holding the lead to the player's current speed outright. That removed the overshoot but cost the follow its ease out — snapping the aim point onto a decelerating player takes all the remaining distance away at once, so the camera brakes instead of gliding to a halt. Collapsing the lead faster keeps a low pass on it and keeps most of the glide:

| after release, run speed | glide-out to under 4 px/s | reverses | overshoot |
|---|---|---|---|
| before | 0.25 s | **25.8 px/s, 1.7 px of travel** | +8.1 px |
| holding to current speed | 0.10 s | no | −5.9 px |
| **collapsing at ×3** | **0.17 s** | **no** | **+0.6 px** |

The build rate is untouched, so acceleration, cruising and the steady-state offsets are exactly as before — still 4.1 px behind a walking player and 5.2 px behind a running one. The multiplier is a file-local constant, `lead_decay_factor`; it can move to `CameraSystemConfiguration` and the camera ui if it turns out to want tuning live.

## Not addressed

The resting offset. A stopped player still sits up to one focus zone off centre, `view_width / focus_zone_divider`, which is ±6.4 px at the shipped divider of 100. That is a separate dial.

## Checks

Compiles and links clean in a Release Ninja build. The numbers above come from stepping the update loop at the shipped constants rather than from the running game, so the feel is worth confirming on hardware — a model can get this directionally right and still be wrong about how it reads.
