### PR TITLE
Tiled templates and custom types for every mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ logs/
 
 # written by imgui in the working directory whenever a debug editor is opened
 imgui.ini
+
+# tiled writes one of these next to the project file, it holds per user editor state
+deceptus.tiled-session

--- a/data/templates/check_point.tx
+++ b/data/templates/check_point.tx
@@ -3,9 +3,9 @@
  <object type="CheckPoint" width="72" height="120">
   <properties>
    <property name="index" type="int" value="0"/>
-   <property name="z" type="int" value="20"/>
    <property name="sprite_pos_x_px" type="int" value="0"/>
    <property name="sprite_pos_y_px" type="int" value="0"/>
+   <property name="z" type="int" value="20"/>
   </properties>
  </object>
 </template>

--- a/data/templates/controller_help.tx
+++ b/data/templates/controller_help.tx
@@ -2,7 +2,7 @@
 <template>
  <object type="ControllerHelp" width="96" height="48">
   <properties>
-   <property name="keys" type="string" value="bt_a"/>
+   <property name="keys" value="bt_a"/>
   </properties>
  </object>
 </template>

--- a/data/templates/conveyor_belt.tx
+++ b/data/templates/conveyor_belt.tx
@@ -2,7 +2,7 @@
 <template>
  <object type="ConveyorBelt" width="96" height="24">
   <properties>
-   <property name="velocity" type="float" value="1.0"/>
+   <property name="velocity" type="float" value="1"/>
   </properties>
  </object>
 </template>

--- a/data/templates/crusher.tx
+++ b/data/templates/crusher.tx
@@ -2,7 +2,7 @@
 <template>
  <object type="Crusher" width="120" height="24">
   <properties>
-   <property name="alignment" type="string" value="down"/>
+   <property name="alignment" propertytype="CrusherAlignment" value="down"/>
    <property name="z" type="int" value="20"/>
   </properties>
  </object>

--- a/data/templates/death_block.tx
+++ b/data/templates/death_block.tx
@@ -2,6 +2,12 @@
 <template>
  <object type="DeathBlock" width="24" height="24">
   <properties>
+   <property name="damage" type="int" value="100"/>
+   <property name="mode" propertytype="DeathBlockMode" value="always_on"/>
+   <property name="time_off" type="float" value="2"/>
+   <property name="time_offset" type="float" value="0"/>
+   <property name="time_on" type="float" value="0.2"/>
+   <property name="velocity" type="float" value="50"/>
    <property name="z" type="int" value="20"/>
   </properties>
  </object>

--- a/data/templates/dialogue.tx
+++ b/data/templates/dialogue.tx
@@ -2,11 +2,11 @@
 <template>
  <object type="Dialogue" width="96" height="48">
   <properties>
-   <property name="00" type="string" value=""/>
+   <property name="00" value=""/>
+   <property name="00_background_color" value="#000000ff"/>
+   <property name="00_text_color" value="#ffffffff"/>
    <property name="00_x_px" type="int" value="0"/>
    <property name="00_y_px" type="int" value="0"/>
-   <property name="00_text_color" type="string" value="#ffffffff"/>
-   <property name="00_background_color" type="string" value="#000000ff"/>
   </properties>
  </object>
 </template>

--- a/data/templates/door.tx
+++ b/data/templates/door.tx
@@ -2,15 +2,15 @@
 <template>
  <object type="Door" width="24" height="96">
   <properties>
-   <property name="open" type="bool" value="false"/>
-   <property name="z" type="int" value="20"/>
+   <property name="animation_close" value=""/>
+   <property name="animation_open" value=""/>
+   <property name="key" value=""/>
+   <property name="key_animation" value=""/>
    <property name="observed" type="bool" value="false"/>
-   <property name="key" type="string" value=""/>
-   <property name="sample_open" type="string" value=""/>
-   <property name="sample_close" type="string" value=""/>
-   <property name="animation_open" type="string" value=""/>
-   <property name="animation_close" type="string" value=""/>
-   <property name="key_animation" type="string" value=""/>
+   <property name="open" type="bool" value="false"/>
+   <property name="sample_close" value=""/>
+   <property name="sample_open" value=""/>
+   <property name="z" type="int" value="20"/>
   </properties>
  </object>
 </template>

--- a/data/templates/fan.tx
+++ b/data/templates/fan.tx
@@ -2,8 +2,8 @@
 <template>
  <object type="Fan" width="48" height="96">
   <properties>
-   <property name="direction" type="string" value="up"/>
-   <property name="speed" type="float" value="1.0"/>
+   <property name="direction" propertytype="FanDirection" value="up"/>
+   <property name="speed" type="float" value="1"/>
   </properties>
  </object>
 </template>

--- a/data/templates/gateway.tx
+++ b/data/templates/gateway.tx
@@ -3,10 +3,10 @@
  <object type="Gateway" width="96" height="96">
   <properties>
    <property name="enabled" type="bool" value="true"/>
-   <property name="target_id" type="string" value=""/>
+   <property name="flowfield_reference_id" value=""/>
+   <property name="flowfield_texture" value=""/>
+   <property name="target_id" value=""/>
    <property name="z" type="int" value="20"/>
-   <property name="flowfield_reference_id" type="string" value=""/>
-   <property name="flowfield_texture" type="string" value=""/>
   </properties>
  </object>
 </template>

--- a/data/templates/grab_rope.tx
+++ b/data/templates/grab_rope.tx
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <template>
- <object type="ButtonRect" width="48" height="24">
+ <object type="GrabRope" width="24" height="96">
   <properties>
-   <property name="button" propertytype="ButtonRectButton" value="b"/>
    <property name="z" type="int" value="20"/>
   </properties>
  </object>

--- a/data/templates/interaction_help.tx
+++ b/data/templates/interaction_help.tx
@@ -2,12 +2,12 @@
 <template>
  <object type="InteractionHelp" width="96" height="48">
   <properties>
-   <property name="z" type="int" value="50"/>
-   <property name="animation" type="string" value=""/>
+   <property name="animation" value=""/>
+   <property name="button_0" value="key_cursor_u"/>
    <property name="offset_x_px" type="int" value="0"/>
    <property name="offset_y_px" type="int" value="0"/>
-   <property name="button_0" type="string" value="key_cursor_u"/>
-   <property name="text_0" type="string" value=""/>
+   <property name="text_0" value=""/>
+   <property name="z" type="int" value="50"/>
   </properties>
  </object>
 </template>

--- a/data/templates/laser.tx
+++ b/data/templates/laser.tx
@@ -2,6 +2,14 @@
 <template>
  <object type="Laser" width="24" height="24">
   <properties>
+   <property name="easing_function" propertytype="LaserEasingFunction" value="ease_none"/>
+   <property name="easing_subdivision_count" type="int" value="10"/>
+   <property name="enabled" type="bool" value="true"/>
+   <property name="move_offset_s" type="float" value="0"/>
+   <property name="movement_speed" type="float" value="1"/>
+   <property name="off_time" type="int" value="3000"/>
+   <property name="on_time" type="int" value="3000"/>
+   <property name="reference_id" value=""/>
    <property name="z" type="int" value="20"/>
   </properties>
  </object>

--- a/data/templates/level_transition.tx
+++ b/data/templates/level_transition.tx
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<template>
+ <object type="LevelTransition" width="48" height="96">
+  <properties>
+   <property name="level" value=""/>
+   <property name="spawn_position_x_px" type="int" value="0"/>
+   <property name="spawn_position_y_px" type="int" value="0"/>
+  </properties>
+ </object>
+</template>

--- a/data/templates/lever.tx
+++ b/data/templates/lever.tx
@@ -3,9 +3,9 @@
  <object type="Lever" width="72" height="72">
   <properties>
    <property name="enabled" type="bool" value="false"/>
-   <property name="serialized" type="bool" value="false"/>
    <property name="handle_available" type="bool" value="true"/>
-   <property name="target_ids" type="string" value=""/>
+   <property name="serialized" type="bool" value="false"/>
+   <property name="target_ids" value=""/>
    <property name="z" type="int" value="20"/>
   </properties>
  </object>

--- a/data/templates/moveable_object.tx
+++ b/data/templates/moveable_object.tx
@@ -2,6 +2,7 @@
 <template>
  <object type="MoveableObject" width="24" height="24">
   <properties>
+   <property name="serialized" type="bool" value="true"/>
    <property name="z" type="int" value="20"/>
   </properties>
  </object>

--- a/data/templates/moving_platform.tx
+++ b/data/templates/moving_platform.tx
@@ -2,9 +2,9 @@
 <template>
  <object type="MovingPlatform" width="0" height="0">
   <properties>
+   <property name="interpolation_time" type="float" value="0"/>
    <property name="platform_width_tl" type="int" value="4"/>
    <property name="z" type="int" value="20"/>
-   <property name="interpolation_time" type="float" value="0"/>
   </properties>
   <polyline points="0,0 96,0"/>
  </object>

--- a/data/templates/post_processing.tx
+++ b/data/templates/post_processing.tx
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<template>
+ <object type="PostProcessing" width="480" height="270">
+  <properties>
+   <property name="fragment_shader" value=""/>
+   <property name="scope" propertytype="PostProcessingScope" value="all"/>
+   <property name="vertex_shader" value=""/>
+   <property name="z" type="int" value="0"/>
+  </properties>
+ </object>
+</template>

--- a/data/templates/rotating_blade.tx
+++ b/data/templates/rotating_blade.tx
@@ -2,11 +2,11 @@
 <template>
  <object type="RotatingBlade" width="0" height="0">
   <properties>
-   <property name="enabled" type="bool" value="true"/>
-   <property name="blade_acceleration" type="float" value="1.0"/>
+   <property name="blade_acceleration" type="float" value="1"/>
    <property name="blade_deceleration" type="float" value="0.5"/>
-   <property name="blade_rotation_speed" type="float" value="5.0"/>
-   <property name="movement_speed" type="float" value="1.0"/>
+   <property name="blade_rotation_speed" type="float" value="5"/>
+   <property name="enabled" type="bool" value="true"/>
+   <property name="movement_speed" type="float" value="1"/>
    <property name="z" type="int" value="30"/>
   </properties>
   <polyline points="0,0 48,0 96,0"/>

--- a/data/templates/sensor_rect.tx
+++ b/data/templates/sensor_rect.tx
@@ -2,10 +2,10 @@
 <template>
  <object type="SensorRect" width="96" height="96">
   <properties>
-   <property name="reference_id" type="string" value=""/>
-   <property name="action" type="string" value="toggle"/>
-   <property name="event" type="string" value="on_enter"/>
+   <property name="action" propertytype="SensorRectAction" value="toggle"/>
+   <property name="event" propertytype="SensorRectEvent" value="on_enter"/>
    <property name="observed" type="bool" value="false"/>
+   <property name="reference_id" value=""/>
   </properties>
  </object>
 </template>

--- a/data/templates/shader_quad.tx
+++ b/data/templates/shader_quad.tx
@@ -2,9 +2,14 @@
 <template>
  <object type="ShaderQuad" width="192" height="192">
   <properties>
-   <property name="fragment_shader" type="string" value=""/>
-   <property name="vertex_shader" type="string" value=""/>
-   <property name="texture" type="string" value=""/>
+   <property name="customization" value=""/>
+   <property name="fragment_shader" value=""/>
+   <property name="smooth_texture" type="bool" value="false"/>
+   <property name="texture" value=""/>
+   <property name="time_offset_s" type="float" value="0"/>
+   <property name="uv_height" type="float" value="1"/>
+   <property name="uv_width" type="float" value="1"/>
+   <property name="vertex_shader" value=""/>
    <property name="z" type="int" value="20"/>
   </properties>
  </object>

--- a/data/templates/skill_gate.tx
+++ b/data/templates/skill_gate.tx
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <template>
- <object type="OnOffBlock" width="24" height="24">
+ <object type="SkillGate" width="48" height="96">
   <properties>
    <property name="enabled" type="bool" value="true"/>
+   <property name="fade_speed" type="float" value="2"/>
    <property name="inverted" type="bool" value="false"/>
-   <property name="mode" propertytype="OnOffBlockMode" value="lever"/>
-   <property name="time_off_ms" type="int" value="1000"/>
-   <property name="time_on_ms" type="int" value="1000"/>
+   <property name="normal" value=""/>
+   <property name="skill" propertytype="SkillGateSkill" value="double_jump"/>
+   <property name="texture" value=""/>
    <property name="z" type="int" value="20"/>
   </properties>
  </object>

--- a/data/templates/smoke.tx
+++ b/data/templates/smoke.tx
@@ -2,6 +2,17 @@
 <template>
  <object type="Smoke" width="96" height="96">
   <properties>
+   <property name="blend_mode" propertytype="SmokeBlendMode" value="add"/>
+   <property name="center_offset_x_px" type="int" value="0"/>
+   <property name="center_offset_y_px" type="int" value="0"/>
+   <property name="layer_color" value="#ffffffff"/>
+   <property name="mode" propertytype="SmokeMode" value="smoke"/>
+   <property name="particle_color" value="#ffffff19"/>
+   <property name="particle_count" type="int" value="50"/>
+   <property name="pixel_ratio" type="float" value="1"/>
+   <property name="spread_factor" type="float" value="0.666667"/>
+   <property name="sprite_scale" type="float" value="1"/>
+   <property name="velocity" type="float" value="1"/>
    <property name="z" type="int" value="20"/>
   </properties>
  </object>

--- a/data/templates/sound_emitter.tx
+++ b/data/templates/sound_emitter.tx
@@ -2,12 +2,12 @@
 <template>
  <object type="SoundEmitter" width="192" height="192">
   <properties>
-   <property name="filename" type="string" value=""/>
+   <property name="filename" value=""/>
    <property name="looped" type="bool" value="true"/>
-   <property name="radius_near_px" type="float" value="200"/>
-   <property name="volume_near" type="float" value="1.0"/>
    <property name="radius_far_px" type="float" value="600"/>
-   <property name="volume_far" type="float" value="0.0"/>
+   <property name="radius_near_px" type="float" value="200"/>
+   <property name="volume_far" type="float" value="0"/>
+   <property name="volume_near" type="float" value="1"/>
   </properties>
  </object>
 </template>

--- a/data/templates/spike_ball.tx
+++ b/data/templates/spike_ball.tx
@@ -2,7 +2,7 @@
 <template>
  <object type="SpikeBall" width="96" height="96">
   <properties>
-   <property name="push_factor" type="float" value="1.0"/>
+   <property name="push_factor" type="float" value="1"/>
    <property name="spline_point_count" type="int" value="8"/>
    <property name="z" type="int" value="16"/>
   </properties>

--- a/data/templates/spikes.tx
+++ b/data/templates/spikes.tx
@@ -2,6 +2,15 @@
 <template>
  <object type="Spikes" width="24" height="24">
   <properties>
+   <property name="down_time_ms" type="int" value="2000"/>
+   <property name="mode" propertytype="SpikesMode" value="trap"/>
+   <property name="orientation" propertytype="SpikesOrientation" value="up"/>
+   <property name="speed_down" type="float" value="35"/>
+   <property name="speed_up" type="float" value="35"/>
+   <property name="time_offset_ms" type="int" value="0"/>
+   <property name="trap_time_ms" type="int" value="250"/>
+   <property name="under_water" type="bool" value="false"/>
+   <property name="up_time_ms" type="int" value="2000"/>
    <property name="z" type="int" value="20"/>
   </properties>
  </object>

--- a/data/templates/static_light.tx
+++ b/data/templates/static_light.tx
@@ -2,11 +2,11 @@
 <template>
  <object type="StaticLight" width="96" height="96">
   <properties>
-   <property name="color" type="string" value="#ffffffff"/>
-   <property name="texture" type="string" value="smooth.png"/>
-   <property name="flicker_intensity" type="float" value="0.0"/>
-   <property name="flicker_speed" type="float" value="0.0"/>
-   <property name="flicker_alpha_amount" type="float" value="1.0"/>
+   <property name="color" value="#ffffffff"/>
+   <property name="flicker_alpha_amount" type="float" value="1"/>
+   <property name="flicker_intensity" type="float" value="0"/>
+   <property name="flicker_speed" type="float" value="0"/>
+   <property name="texture" value="smooth.png"/>
    <property name="z" type="int" value="20"/>
   </properties>
  </object>

--- a/data/templates/text_layer.tx
+++ b/data/templates/text_layer.tx
@@ -2,6 +2,12 @@
 <template>
  <object type="TextLayer" width="192" height="48">
   <properties>
+   <property name="bitmap_font_map" value=""/>
+   <property name="bitmap_font_texture" value=""/>
+   <property name="text" value="undefined"/>
+   <property name="truetype_font" value=""/>
+   <property name="truetype_font_color" value="#ffffffff"/>
+   <property name="truetype_font_size" type="int" value="12"/>
    <property name="z" type="int" value="20"/>
   </properties>
  </object>

--- a/data/templates/treasure_chest.tx
+++ b/data/templates/treasure_chest.tx
@@ -2,6 +2,18 @@
 <template>
  <object type="TreasureChest" width="48" height="48">
   <properties>
+   <property name="animation_idle_closed" value="idle"/>
+   <property name="animation_idle_open" value="open"/>
+   <property name="animation_opening" value="opening"/>
+   <property name="item_required" value=""/>
+   <property name="item_required_consumed" type="bool" value="true"/>
+   <property name="observed" type="bool" value="false"/>
+   <property name="sample_locked" value=""/>
+   <property name="sample_open" value="treasure_chest_open.ogg"/>
+   <property name="spawn_extra" value=""/>
+   <property name="spawn_offset_x" type="float" value="0"/>
+   <property name="spawn_offset_y" type="float" value="0"/>
+   <property name="texture" value="data/sprites/treasure_chest.png"/>
    <property name="z" type="int" value="20"/>
   </properties>
  </object>

--- a/data/templates/water_surface.tx
+++ b/data/templates/water_surface.tx
@@ -2,12 +2,12 @@
 <template>
  <object type="WaterSurface" width="240" height="24">
   <properties>
-   <property name="z" type="int" value="20"/>
-   <property name="splash_factor" type="float" value="1.0"/>
-   <property name="spread" type="float" value="1.2"/>
-   <property name="opacity" type="int" value="255"/>
    <property name="clamp_segment_count" type="int" value="0"/>
-   <property name="pixel_ratio" type="float" value="0.0"/>
+   <property name="opacity" type="int" value="255"/>
+   <property name="pixel_ratio" type="float" value="0"/>
+   <property name="splash_factor" type="float" value="1"/>
+   <property name="spread" type="float" value="1.2"/>
+   <property name="z" type="int" value="20"/>
   </properties>
  </object>
 </template>

--- a/data/templates/water_surface_emitter.tx
+++ b/data/templates/water_surface_emitter.tx
@@ -2,14 +2,14 @@
 <template>
  <object type="WaterSurfaceEmitter" width="96" height="24">
   <properties>
-   <property name="reference" type="string" value=""/>
-   <property name="velocity" type="float" value="2.0"/>
-   <property name="interval_min_s" type="float" value="0.3"/>
-   <property name="interval_max_s" type="float" value="0.6"/>
    <property name="count" type="int" value="1"/>
-   <property name="x_from_px" type="float" value="0.0"/>
-   <property name="x_to_px" type="float" value="96.0"/>
-   <property name="width_px" type="float" value="96.0"/>
+   <property name="interval_max_s" type="float" value="0.6"/>
+   <property name="interval_min_s" type="float" value="0.3"/>
+   <property name="reference" value=""/>
+   <property name="velocity" type="float" value="2"/>
+   <property name="width_px" type="float" value="96"/>
+   <property name="x_from_px" type="float" value="0"/>
+   <property name="x_to_px" type="float" value="96"/>
   </properties>
  </object>
 </template>

--- a/data/templates/weather.tx
+++ b/data/templates/weather.tx
@@ -2,6 +2,10 @@
 <template>
  <object type="Weather" width="192" height="192">
   <properties>
+   <property name="effect_start_delay_s" type="float" value="0"/>
+   <property name="enabled" type="bool" value="true"/>
+   <property name="limit_effect_to_room" type="bool" value="false"/>
+   <property name="sound_volume" type="float" value="1"/>
    <property name="z" type="int" value="20"/>
   </properties>
  </object>

--- a/data/templates/wind.tx
+++ b/data/templates/wind.tx
@@ -2,12 +2,26 @@
 <template>
  <object type="Wind" width="192" height="192">
   <properties>
-   <property name="direction_x" type="float" value="0.0"/>
-   <property name="direction_y" type="float" value="-1.0"/>
-   <property name="strength" type="float" value="1.0"/>
-   <property name="z" type="int" value="20"/>
+   <property name="direction_x" type="float" value="0"/>
+   <property name="direction_y" type="float" value="-1"/>
+   <property name="leaf_alpha" type="float" value="1"/>
+   <property name="leaf_animation_speed" type="float" value="8"/>
    <property name="leaf_count" type="int" value="0"/>
-   <property name="sounds" type="string" value=""/>
+   <property name="leaf_frame_size_px" type="int" value="16"/>
+   <property name="leaf_jitter_amount" type="float" value="0.35"/>
+   <property name="leaf_jitter_frequency_hz" type="float" value="0.8"/>
+   <property name="leaf_scale_max" type="float" value="1"/>
+   <property name="leaf_scale_min" type="float" value="1"/>
+   <property name="leaf_sound_influence" type="float" value="0"/>
+   <property name="leaf_texture" value="data/sprites/leaves_fall.png"/>
+   <property name="leaf_velocity_px_s" type="float" value="60"/>
+   <property name="sound_radius_far_px" type="float" value="800"/>
+   <property name="sound_radius_near_px" type="float" value="200"/>
+   <property name="sound_strength_influence" type="float" value="0"/>
+   <property name="sound_volume" type="float" value="1"/>
+   <property name="sounds" value=""/>
+   <property name="strength" type="float" value="1"/>
+   <property name="z" type="int" value="20"/>
   </properties>
  </object>
 </template>

--- a/data/templates/zoom_rect.tx
+++ b/data/templates/zoom_rect.tx
@@ -2,7 +2,7 @@
 <template>
  <object type="ZoomRect" width="192" height="192">
   <properties>
-   <property name="values" type="string" value="0.0:1.5;1.0:1.0"/>
+   <property name="values" value="0.0:1.5;1.0:1.0"/>
   </properties>
  </object>
 </template>

--- a/deceptus.tiled-project
+++ b/deceptus.tiled-project
@@ -1,0 +1,1972 @@
+{
+    "automappingRulesFile": "",
+    "commands": [],
+    "extensionsPath": "extensions",
+    "folders": [
+        "data"
+    ],
+    "properties": [],
+    "propertyTypes": [
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 1,
+            "members": [
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "BlockingRect",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 2,
+            "members": [
+                {
+                    "name": "force",
+                    "type": "float",
+                    "value": 0.6000000238418579
+                }
+            ],
+            "name": "Bouncer",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 3,
+            "members": [
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "BoxCollider",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 4,
+            "members": [
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "BubbleCube",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 5,
+            "members": [
+                {
+                    "name": "button",
+                    "propertyType": "ButtonRectButton",
+                    "type": "string",
+                    "value": "b"
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "ButtonRect",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "id": 6,
+            "name": "ButtonRectButton",
+            "storageType": "string",
+            "type": "enum",
+            "values": [
+                "a",
+                "b",
+                "x",
+                "y"
+            ],
+            "valuesAsFlags": false
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 7,
+            "members": [
+                {
+                    "name": "index",
+                    "type": "int",
+                    "value": 0
+                },
+                {
+                    "name": "sprite_pos_x_px",
+                    "type": "int",
+                    "value": 0
+                },
+                {
+                    "name": "sprite_pos_y_px",
+                    "type": "int",
+                    "value": 0
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "CheckPoint",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 8,
+            "members": [
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "CollapsingPlatform",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 9,
+            "members": [
+                {
+                    "name": "keys",
+                    "type": "string",
+                    "value": "bt_a"
+                }
+            ],
+            "name": "ControllerHelp",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 10,
+            "members": [
+                {
+                    "name": "velocity",
+                    "type": "float",
+                    "value": 1.0
+                }
+            ],
+            "name": "ConveyorBelt",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 11,
+            "members": [
+                {
+                    "name": "alignment",
+                    "propertyType": "CrusherAlignment",
+                    "type": "string",
+                    "value": "down"
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "Crusher",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "id": 12,
+            "name": "CrusherAlignment",
+            "storageType": "string",
+            "type": "enum",
+            "values": [
+                "up",
+                "down",
+                "left",
+                "right"
+            ],
+            "valuesAsFlags": false
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 13,
+            "members": [
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "DamageRect",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 14,
+            "members": [
+                {
+                    "name": "damage",
+                    "type": "int",
+                    "value": 100
+                },
+                {
+                    "name": "mode",
+                    "propertyType": "DeathBlockMode",
+                    "type": "string",
+                    "value": "always_on"
+                },
+                {
+                    "name": "time_off",
+                    "type": "float",
+                    "value": 2.0
+                },
+                {
+                    "name": "time_offset",
+                    "type": "float",
+                    "value": 0.0
+                },
+                {
+                    "name": "time_on",
+                    "type": "float",
+                    "value": 0.20000000298023224
+                },
+                {
+                    "name": "velocity",
+                    "type": "float",
+                    "value": 50.0
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "DeathBlock",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "id": 15,
+            "name": "DeathBlockMode",
+            "storageType": "string",
+            "type": "enum",
+            "values": [
+                "always_on",
+                "interval",
+                "rotate"
+            ],
+            "valuesAsFlags": false
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 16,
+            "members": [
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "DestructibleBlockingRect",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 17,
+            "members": [
+                {
+                    "name": "00",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "00_background_color",
+                    "type": "string",
+                    "value": "#000000ff"
+                },
+                {
+                    "name": "00_text_color",
+                    "type": "string",
+                    "value": "#ffffffff"
+                },
+                {
+                    "name": "00_x_px",
+                    "type": "int",
+                    "value": 0
+                },
+                {
+                    "name": "00_y_px",
+                    "type": "int",
+                    "value": 0
+                }
+            ],
+            "name": "Dialogue",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 18,
+            "members": [
+                {
+                    "name": "animation_close",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "animation_open",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "key",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "key_animation",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "observed",
+                    "type": "bool",
+                    "value": false
+                },
+                {
+                    "name": "open",
+                    "type": "bool",
+                    "value": false
+                },
+                {
+                    "name": "sample_close",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "sample_open",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "Door",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 19,
+            "members": [
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "Dust",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 20,
+            "members": [
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "EnemyWall",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 21,
+            "members": [
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "Extra",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 22,
+            "members": [
+                {
+                    "name": "direction",
+                    "propertyType": "FanDirection",
+                    "type": "string",
+                    "value": "up"
+                },
+                {
+                    "name": "speed",
+                    "type": "float",
+                    "value": 1.0
+                }
+            ],
+            "name": "Fan",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "id": 23,
+            "name": "FanDirection",
+            "storageType": "string",
+            "type": "enum",
+            "values": [
+                "up",
+                "down",
+                "left",
+                "right"
+            ],
+            "valuesAsFlags": false
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 24,
+            "members": [
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "Fireflies",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 25,
+            "members": [
+                {
+                    "name": "enabled",
+                    "type": "bool",
+                    "value": true
+                },
+                {
+                    "name": "flowfield_reference_id",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "flowfield_texture",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "target_id",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "Gateway",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 26,
+            "members": [
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "GrabRope",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 27,
+            "members": [
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "InfoOverlay",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 28,
+            "members": [
+                {
+                    "name": "animation",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "button_0",
+                    "type": "string",
+                    "value": "key_cursor_u"
+                },
+                {
+                    "name": "offset_x_px",
+                    "type": "int",
+                    "value": 0
+                },
+                {
+                    "name": "offset_y_px",
+                    "type": "int",
+                    "value": 0
+                },
+                {
+                    "name": "text_0",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 50
+                }
+            ],
+            "name": "InteractionHelp",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 29,
+            "members": [
+                {
+                    "name": "easing_function",
+                    "propertyType": "LaserEasingFunction",
+                    "type": "string",
+                    "value": "ease_none"
+                },
+                {
+                    "name": "easing_subdivision_count",
+                    "type": "int",
+                    "value": 10
+                },
+                {
+                    "name": "enabled",
+                    "type": "bool",
+                    "value": true
+                },
+                {
+                    "name": "move_offset_s",
+                    "type": "float",
+                    "value": 0.0
+                },
+                {
+                    "name": "movement_speed",
+                    "type": "float",
+                    "value": 1.0
+                },
+                {
+                    "name": "off_time",
+                    "type": "int",
+                    "value": 3000
+                },
+                {
+                    "name": "on_time",
+                    "type": "int",
+                    "value": 3000
+                },
+                {
+                    "name": "reference_id",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "Laser",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "id": 30,
+            "name": "LaserEasingFunction",
+            "storageType": "string",
+            "type": "enum",
+            "values": [
+                "ease_in_sine",
+                "ease_in_cubic",
+                "ease_in_quint",
+                "ease_in_circ",
+                "ease_in_elastic",
+                "ease_out_sine",
+                "ease_out_cubic",
+                "ease_out_quint",
+                "ease_out_circ",
+                "ease_out_elastic",
+                "ease_in_out_sine",
+                "ease_in_out_cubic",
+                "ease_in_out_quint",
+                "ease_in_out_circ",
+                "ease_in_out_elastic",
+                "ease_none"
+            ],
+            "valuesAsFlags": false
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 31,
+            "members": [
+                {
+                    "name": "level",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "spawn_position_x_px",
+                    "type": "int",
+                    "value": 0
+                },
+                {
+                    "name": "spawn_position_y_px",
+                    "type": "int",
+                    "value": 0
+                }
+            ],
+            "name": "LevelTransition",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 32,
+            "members": [
+                {
+                    "name": "enabled",
+                    "type": "bool",
+                    "value": false
+                },
+                {
+                    "name": "handle_available",
+                    "type": "bool",
+                    "value": true
+                },
+                {
+                    "name": "serialized",
+                    "type": "bool",
+                    "value": false
+                },
+                {
+                    "name": "target_ids",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "Lever",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 33,
+            "members": [
+                {
+                    "name": "serialized",
+                    "type": "bool",
+                    "value": true
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "MoveableObject",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 34,
+            "members": [
+                {
+                    "name": "interpolation_time",
+                    "type": "float",
+                    "value": 0.0
+                },
+                {
+                    "name": "platform_width_tl",
+                    "type": "int",
+                    "value": 4
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "MovingPlatform",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 35,
+            "members": [
+                {
+                    "name": "enabled",
+                    "type": "bool",
+                    "value": true
+                },
+                {
+                    "name": "inverted",
+                    "type": "bool",
+                    "value": false
+                },
+                {
+                    "name": "mode",
+                    "propertyType": "OnOffBlockMode",
+                    "type": "string",
+                    "value": "lever"
+                },
+                {
+                    "name": "time_off_ms",
+                    "type": "int",
+                    "value": 1000
+                },
+                {
+                    "name": "time_on_ms",
+                    "type": "int",
+                    "value": 1000
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "OnOffBlock",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "id": 36,
+            "name": "OnOffBlockMode",
+            "storageType": "string",
+            "type": "enum",
+            "values": [
+                "lever",
+                "interval"
+            ],
+            "valuesAsFlags": false
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 37,
+            "members": [
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "Portal",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 38,
+            "members": [
+                {
+                    "name": "fragment_shader",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "scope",
+                    "propertyType": "PostProcessingScope",
+                    "type": "string",
+                    "value": "all"
+                },
+                {
+                    "name": "vertex_shader",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 0
+                }
+            ],
+            "name": "PostProcessing",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "id": 39,
+            "name": "PostProcessingScope",
+            "storageType": "string",
+            "type": "enum",
+            "values": [
+                "all",
+                "level"
+            ],
+            "valuesAsFlags": false
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 40,
+            "members": [
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "Rope",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 41,
+            "members": [
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "RopeWithLight",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 42,
+            "members": [
+                {
+                    "name": "blade_acceleration",
+                    "type": "float",
+                    "value": 1.0
+                },
+                {
+                    "name": "blade_deceleration",
+                    "type": "float",
+                    "value": 0.5
+                },
+                {
+                    "name": "blade_rotation_speed",
+                    "type": "float",
+                    "value": 5.0
+                },
+                {
+                    "name": "enabled",
+                    "type": "bool",
+                    "value": true
+                },
+                {
+                    "name": "movement_speed",
+                    "type": "float",
+                    "value": 1.0
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 30
+                }
+            ],
+            "name": "RotatingBlade",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 43,
+            "members": [
+                {
+                    "name": "action",
+                    "propertyType": "SensorRectAction",
+                    "type": "string",
+                    "value": "toggle"
+                },
+                {
+                    "name": "event",
+                    "propertyType": "SensorRectEvent",
+                    "type": "string",
+                    "value": "on_enter"
+                },
+                {
+                    "name": "observed",
+                    "type": "bool",
+                    "value": false
+                },
+                {
+                    "name": "reference_id",
+                    "type": "string",
+                    "value": ""
+                }
+            ],
+            "name": "SensorRect",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "id": 44,
+            "name": "SensorRectAction",
+            "storageType": "string",
+            "type": "enum",
+            "values": [
+                "enable",
+                "disable",
+                "toggle"
+            ],
+            "valuesAsFlags": false
+        },
+        {
+            "id": 45,
+            "name": "SensorRectEvent",
+            "storageType": "string",
+            "type": "enum",
+            "values": [
+                "on_enter",
+                "on_leave"
+            ],
+            "valuesAsFlags": false
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 46,
+            "members": [
+                {
+                    "name": "customization",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "fragment_shader",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "smooth_texture",
+                    "type": "bool",
+                    "value": false
+                },
+                {
+                    "name": "texture",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "time_offset_s",
+                    "type": "float",
+                    "value": 0.0
+                },
+                {
+                    "name": "uv_height",
+                    "type": "float",
+                    "value": 1.0
+                },
+                {
+                    "name": "uv_width",
+                    "type": "float",
+                    "value": 1.0
+                },
+                {
+                    "name": "vertex_shader",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "ShaderQuad",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 47,
+            "members": [
+                {
+                    "name": "enabled",
+                    "type": "bool",
+                    "value": true
+                },
+                {
+                    "name": "fade_speed",
+                    "type": "float",
+                    "value": 2.0
+                },
+                {
+                    "name": "inverted",
+                    "type": "bool",
+                    "value": false
+                },
+                {
+                    "name": "normal",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "skill",
+                    "propertyType": "SkillGateSkill",
+                    "type": "string",
+                    "value": "double_jump"
+                },
+                {
+                    "name": "texture",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "SkillGate",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "id": 48,
+            "name": "SkillGateSkill",
+            "storageType": "string",
+            "type": "enum",
+            "values": [
+                "wall_climb",
+                "dash",
+                "invulnerable",
+                "wall_slide",
+                "wall_jump",
+                "double_jump",
+                "crouch",
+                "swim"
+            ],
+            "valuesAsFlags": false
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 49,
+            "members": [
+                {
+                    "name": "blend_mode",
+                    "propertyType": "SmokeBlendMode",
+                    "type": "string",
+                    "value": "add"
+                },
+                {
+                    "name": "center_offset_x_px",
+                    "type": "int",
+                    "value": 0
+                },
+                {
+                    "name": "center_offset_y_px",
+                    "type": "int",
+                    "value": 0
+                },
+                {
+                    "name": "layer_color",
+                    "type": "string",
+                    "value": "#ffffffff"
+                },
+                {
+                    "name": "mode",
+                    "propertyType": "SmokeMode",
+                    "type": "string",
+                    "value": "smoke"
+                },
+                {
+                    "name": "particle_color",
+                    "type": "string",
+                    "value": "#ffffff19"
+                },
+                {
+                    "name": "particle_count",
+                    "type": "int",
+                    "value": 50
+                },
+                {
+                    "name": "pixel_ratio",
+                    "type": "float",
+                    "value": 1.0
+                },
+                {
+                    "name": "spread_factor",
+                    "type": "float",
+                    "value": 0.6666666865348816
+                },
+                {
+                    "name": "sprite_scale",
+                    "type": "float",
+                    "value": 1.0
+                },
+                {
+                    "name": "velocity",
+                    "type": "float",
+                    "value": 1.0
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "Smoke",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "id": 50,
+            "name": "SmokeBlendMode",
+            "storageType": "string",
+            "type": "enum",
+            "values": [
+                "alpha",
+                "add",
+                "multiply"
+            ],
+            "valuesAsFlags": false
+        },
+        {
+            "id": 51,
+            "name": "SmokeMode",
+            "storageType": "string",
+            "type": "enum",
+            "values": [
+                "smoke",
+                "fog"
+            ],
+            "valuesAsFlags": false
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 52,
+            "members": [
+                {
+                    "name": "filename",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "looped",
+                    "type": "bool",
+                    "value": true
+                },
+                {
+                    "name": "radius_far_px",
+                    "type": "float",
+                    "value": 600.0
+                },
+                {
+                    "name": "radius_near_px",
+                    "type": "float",
+                    "value": 200.0
+                },
+                {
+                    "name": "volume_far",
+                    "type": "float",
+                    "value": 0.0
+                },
+                {
+                    "name": "volume_near",
+                    "type": "float",
+                    "value": 1.0
+                }
+            ],
+            "name": "SoundEmitter",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 53,
+            "members": [
+                {
+                    "name": "push_factor",
+                    "type": "float",
+                    "value": 1.0
+                },
+                {
+                    "name": "spline_point_count",
+                    "type": "int",
+                    "value": 8
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 16
+                }
+            ],
+            "name": "SpikeBall",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 54,
+            "members": [
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "SpikeBlock",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 55,
+            "members": [
+                {
+                    "name": "down_time_ms",
+                    "type": "int",
+                    "value": 2000
+                },
+                {
+                    "name": "mode",
+                    "propertyType": "SpikesMode",
+                    "type": "string",
+                    "value": "trap"
+                },
+                {
+                    "name": "orientation",
+                    "propertyType": "SpikesOrientation",
+                    "type": "string",
+                    "value": "up"
+                },
+                {
+                    "name": "speed_down",
+                    "type": "float",
+                    "value": 35.0
+                },
+                {
+                    "name": "speed_up",
+                    "type": "float",
+                    "value": 35.0
+                },
+                {
+                    "name": "time_offset_ms",
+                    "type": "int",
+                    "value": 0
+                },
+                {
+                    "name": "trap_time_ms",
+                    "type": "int",
+                    "value": 250
+                },
+                {
+                    "name": "under_water",
+                    "type": "bool",
+                    "value": false
+                },
+                {
+                    "name": "up_time_ms",
+                    "type": "int",
+                    "value": 2000
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "Spikes",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "id": 56,
+            "name": "SpikesMode",
+            "storageType": "string",
+            "type": "enum",
+            "values": [
+                "trap",
+                "interval",
+                "toggled"
+            ],
+            "valuesAsFlags": false
+        },
+        {
+            "id": 57,
+            "name": "SpikesOrientation",
+            "storageType": "string",
+            "type": "enum",
+            "values": [
+                "up",
+                "down",
+                "left",
+                "right"
+            ],
+            "valuesAsFlags": false
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 58,
+            "members": [
+                {
+                    "name": "color",
+                    "type": "string",
+                    "value": "#ffffffff"
+                },
+                {
+                    "name": "flicker_alpha_amount",
+                    "type": "float",
+                    "value": 1.0
+                },
+                {
+                    "name": "flicker_intensity",
+                    "type": "float",
+                    "value": 0.0
+                },
+                {
+                    "name": "flicker_speed",
+                    "type": "float",
+                    "value": 0.0
+                },
+                {
+                    "name": "texture",
+                    "type": "string",
+                    "value": "smooth.png"
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "StaticLight",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 59,
+            "members": [
+                {
+                    "name": "bitmap_font_map",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "bitmap_font_texture",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "text",
+                    "type": "string",
+                    "value": "undefined"
+                },
+                {
+                    "name": "truetype_font",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "truetype_font_color",
+                    "type": "string",
+                    "value": "#ffffffff"
+                },
+                {
+                    "name": "truetype_font_size",
+                    "type": "int",
+                    "value": 12
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "TextLayer",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 60,
+            "members": [
+                {
+                    "name": "animation_idle_closed",
+                    "type": "string",
+                    "value": "idle"
+                },
+                {
+                    "name": "animation_idle_open",
+                    "type": "string",
+                    "value": "open"
+                },
+                {
+                    "name": "animation_opening",
+                    "type": "string",
+                    "value": "opening"
+                },
+                {
+                    "name": "item_required",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "item_required_consumed",
+                    "type": "bool",
+                    "value": true
+                },
+                {
+                    "name": "observed",
+                    "type": "bool",
+                    "value": false
+                },
+                {
+                    "name": "sample_locked",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "sample_open",
+                    "type": "string",
+                    "value": "treasure_chest_open.ogg"
+                },
+                {
+                    "name": "spawn_extra",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "spawn_offset_x",
+                    "type": "float",
+                    "value": 0.0
+                },
+                {
+                    "name": "spawn_offset_y",
+                    "type": "float",
+                    "value": 0.0
+                },
+                {
+                    "name": "texture",
+                    "type": "string",
+                    "value": "data/sprites/treasure_chest.png"
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "TreasureChest",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 61,
+            "members": [
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "WaterDamage",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 62,
+            "members": [
+                {
+                    "name": "clamp_segment_count",
+                    "type": "int",
+                    "value": 0
+                },
+                {
+                    "name": "opacity",
+                    "type": "int",
+                    "value": 255
+                },
+                {
+                    "name": "pixel_ratio",
+                    "type": "float",
+                    "value": 0.0
+                },
+                {
+                    "name": "splash_factor",
+                    "type": "float",
+                    "value": 1.0
+                },
+                {
+                    "name": "spread",
+                    "type": "float",
+                    "value": 1.2000000476837158
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "WaterSurface",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 63,
+            "members": [
+                {
+                    "name": "count",
+                    "type": "int",
+                    "value": 1
+                },
+                {
+                    "name": "interval_max_s",
+                    "type": "float",
+                    "value": 0.6000000238418579
+                },
+                {
+                    "name": "interval_min_s",
+                    "type": "float",
+                    "value": 0.30000001192092896
+                },
+                {
+                    "name": "reference",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "velocity",
+                    "type": "float",
+                    "value": 2.0
+                },
+                {
+                    "name": "width_px",
+                    "type": "float",
+                    "value": 96.0
+                },
+                {
+                    "name": "x_from_px",
+                    "type": "float",
+                    "value": 0.0
+                },
+                {
+                    "name": "x_to_px",
+                    "type": "float",
+                    "value": 96.0
+                }
+            ],
+            "name": "WaterSurfaceEmitter",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 64,
+            "members": [
+                {
+                    "name": "effect_start_delay_s",
+                    "type": "float",
+                    "value": 0.0
+                },
+                {
+                    "name": "enabled",
+                    "type": "bool",
+                    "value": true
+                },
+                {
+                    "name": "limit_effect_to_room",
+                    "type": "bool",
+                    "value": false
+                },
+                {
+                    "name": "sound_volume",
+                    "type": "float",
+                    "value": 1.0
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "Weather",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 65,
+            "members": [
+                {
+                    "name": "direction_x",
+                    "type": "float",
+                    "value": 0.0
+                },
+                {
+                    "name": "direction_y",
+                    "type": "float",
+                    "value": -1.0
+                },
+                {
+                    "name": "leaf_alpha",
+                    "type": "float",
+                    "value": 1.0
+                },
+                {
+                    "name": "leaf_animation_speed",
+                    "type": "float",
+                    "value": 8.0
+                },
+                {
+                    "name": "leaf_count",
+                    "type": "int",
+                    "value": 0
+                },
+                {
+                    "name": "leaf_frame_size_px",
+                    "type": "int",
+                    "value": 16
+                },
+                {
+                    "name": "leaf_jitter_amount",
+                    "type": "float",
+                    "value": 0.3499999940395355
+                },
+                {
+                    "name": "leaf_jitter_frequency_hz",
+                    "type": "float",
+                    "value": 0.800000011920929
+                },
+                {
+                    "name": "leaf_scale_max",
+                    "type": "float",
+                    "value": 1.0
+                },
+                {
+                    "name": "leaf_scale_min",
+                    "type": "float",
+                    "value": 1.0
+                },
+                {
+                    "name": "leaf_sound_influence",
+                    "type": "float",
+                    "value": 0.0
+                },
+                {
+                    "name": "leaf_texture",
+                    "type": "string",
+                    "value": "data/sprites/leaves_fall.png"
+                },
+                {
+                    "name": "leaf_velocity_px_s",
+                    "type": "float",
+                    "value": 60.0
+                },
+                {
+                    "name": "sound_radius_far_px",
+                    "type": "float",
+                    "value": 800.0
+                },
+                {
+                    "name": "sound_radius_near_px",
+                    "type": "float",
+                    "value": 200.0
+                },
+                {
+                    "name": "sound_strength_influence",
+                    "type": "float",
+                    "value": 0.0
+                },
+                {
+                    "name": "sound_volume",
+                    "type": "float",
+                    "value": 1.0
+                },
+                {
+                    "name": "sounds",
+                    "type": "string",
+                    "value": ""
+                },
+                {
+                    "name": "strength",
+                    "type": "float",
+                    "value": 1.0
+                },
+                {
+                    "name": "z",
+                    "type": "int",
+                    "value": 20
+                }
+            ],
+            "name": "Wind",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 66,
+            "members": [
+                {
+                    "name": "values",
+                    "type": "string",
+                    "value": "0.0:1.5;1.0:1.0"
+                }
+            ],
+            "name": "ZoomRect",
+            "type": "class",
+            "useAs": [
+                "property",
+                "object"
+            ]
+        }
+    ]
+}

--- a/src/framework/tmxparser/tmxobject.cpp
+++ b/src/framework/tmxparser/tmxobject.cpp
@@ -1,12 +1,37 @@
 #include "tmxobject.h"
 
 #include "framework/tools/log.h"
+#include "tmxparsedata.h"
 #include "tmxpolygon.h"
 #include "tmxpolyline.h"
 #include "tmxproperties.h"
 #include "tmxtemplate.h"
 
 #include <iostream>
+
+namespace
+{
+
+///
+/// \brief Loads the object stored in a tmx template, reusing the one already parsed for this map.
+/// \param template_name Template path as written in the map.
+/// \param parse_data Shared TMX parse context that holds the template cache.
+/// \return Template object, or nullptr when the template could not be loaded.
+///
+std::shared_ptr<TmxObject> loadTemplateObject(const std::string& template_name, const std::shared_ptr<TmxParseData>& parse_data)
+{
+   const auto it = parse_data->_template_objects.find(template_name);
+   if (it != parse_data->_template_objects.end())
+   {
+      return it->second;
+   }
+
+   TmxTemplate object_template(template_name, parse_data);
+   parse_data->_template_objects[template_name] = object_template._object;
+   return object_template._object;
+}
+
+}  // namespace
 
 void TmxObject::deserialize(tinyxml2::XMLElement* element, const std::shared_ptr<TmxParseData>& parse_data)
 {
@@ -26,6 +51,9 @@ void TmxObject::deserialize(tinyxml2::XMLElement* element, const std::shared_ptr
 
    _x_px = static_cast<float>(element->IntAttribute("x"));
    _y_px = static_cast<float>(element->IntAttribute("y"));
+
+   auto* width_attribute = element->Attribute("width");
+   auto* height_attribute = element->Attribute("height");
    _width_px = element->FloatAttribute("width");
    _height_px = element->FloatAttribute("height");
 
@@ -35,18 +63,10 @@ void TmxObject::deserialize(tinyxml2::XMLElement* element, const std::shared_ptr
       _template_type = type_attribute;
    }
 
-   // inherit object type from template
    auto* template_name = element->Attribute("template");
    if (template_name)
    {
       _template_name = template_name;
-
-      // if we don't have an object type yet, try to derive it from the template
-      if (!_template_type.has_value())
-      {
-         TmxTemplate t(template_name, parse_data);
-         _template_type = t._object->_template_type;
-      }
    }
 
    auto* node = element->FirstChild();
@@ -89,6 +109,74 @@ void TmxObject::deserialize(tinyxml2::XMLElement* element, const std::shared_ptr
       }
 
       node = node->NextSibling();
+   }
+
+   // tiled stores a template instance as the reference plus whatever the instance changed, so
+   // everything the object did not spell out here is inherited from the template:
+   //
+   //    template (crusher.tx)            instance in the map              merged object
+   //    +------------------------+       +----------------------+       +----------------------+
+   //    | type    = Crusher      |       | template = crusher.tx|       | type   = Crusher     |
+   //    | 120 x 24               |  -->  | x, y                 |  -->  | 120 x 24             |
+   //    | alignment = down       |       | alignment = left     |       | alignment = left     |
+   //    | z         = 20         |       |                      |       | z         = 20       |
+   //    +------------------------+       +----------------------+       +----------------------+
+   //
+   if (_template_name.has_value())
+   {
+      const auto template_object = loadTemplateObject(_template_name.value(), parse_data);
+      if (template_object)
+      {
+         // inherit object type from template
+         // if we don't have an object type yet, try to derive it from the template
+         if (!_template_type.has_value())
+         {
+            _template_type = template_object->_template_type;
+         }
+
+         if (!_gid.has_value())
+         {
+            _gid = template_object->_gid;
+         }
+
+         if (_name.empty())
+         {
+            _name = template_object->_name;
+         }
+
+         if (width_attribute == nullptr)
+         {
+            _width_px = template_object->_width_px;
+         }
+
+         if (height_attribute == nullptr)
+         {
+            _height_px = template_object->_height_px;
+         }
+
+         if (!_polyline && template_object->_polyline)
+         {
+            _polyline = std::make_shared<TmxPolyLine>(*template_object->_polyline);
+         }
+
+         if (!_polygon && template_object->_polygon)
+         {
+            _polygon = std::make_shared<TmxPolygon>(*template_object->_polygon);
+         }
+
+         if (template_object->_properties)
+         {
+            if (!_properties)
+            {
+               _properties = std::make_shared<TmxProperties>();
+            }
+
+            for (const auto& [property_name, property] : template_object->_properties->_map)
+            {
+               _properties->_map.try_emplace(property_name, property);
+            }
+         }
+      }
    }
 }
 

--- a/src/framework/tmxparser/tmxparsedata.h
+++ b/src/framework/tmxparser/tmxparsedata.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <map>
+#include <memory>
 #include <string>
+
+struct TmxObject;
 
 ///
 /// \brief Carries shared parse context for TMX element deserialization.
@@ -8,4 +12,7 @@
 struct TmxParseData
 {
    std::string _filename;
+
+   //! objects loaded from tmx templates, keyed by the template path as written in the map
+   std::map<std::string, std::shared_ptr<TmxObject>> _template_objects;
 };

--- a/src/game/debug/mechanismschemawriter.cpp
+++ b/src/game/debug/mechanismschemawriter.cpp
@@ -1,45 +1,227 @@
 #include "mechanismschemawriter.h"
 
-#ifdef DEVELOPMENT_MODE
+#ifdef MECHANISM_SCHEMA_WRITER_ENABLED
 
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdio>
 #include <filesystem>
 #include <fstream>
+#include <map>
+#include <sstream>
 #include <string>
 #include <variant>
+#include <vector>
 
 #include "game/mechanisms/gamemechanismdeserializerregistry.h"
 #include "json/json.hpp"
 
-void writeMechanismSchemas()
+namespace
 {
-   const auto& all_schemas = GameMechanismDeserializerRegistry::instance().schemas();
+
+//! \brief tiled's default color for a custom class
+constexpr std::string_view tiled_class_color{"#ffa0a0a4"};
+
+//! \brief path of the tiled project file that carries the generated custom types
+constexpr std::string_view tiled_project_path{"deceptus.tiled-project"};
+
+/// \brief converts a pascal case mechanism type name to the snake case template file name.
+/// \param type_name mechanism type name such as "OnOffBlock".
+/// \return snake case file stem such as "on_off_block".
+std::string toSnakeCase(std::string_view type_name)
+{
+   std::string result;
+   for (auto index = 0u; index < type_name.size(); index++)
+   {
+      const auto character = type_name[index];
+      if (std::isupper(static_cast<unsigned char>(character)) && index > 0)
+      {
+         result.push_back('_');
+      }
+      result.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(character))));
+   }
+   return result;
+}
+
+/// \brief converts a snake case property name to pascal case so it can be appended to an enum type name.
+/// \param property_name property name such as "blend_mode".
+/// \return pascal case name such as "BlendMode".
+std::string toPascalCase(std::string_view property_name)
+{
+   std::string result;
+   auto capitalize_next = true;
+   for (const auto character : property_name)
+   {
+      if (character == '_')
+      {
+         capitalize_next = true;
+         continue;
+      }
+      result.push_back(capitalize_next ? static_cast<char>(std::toupper(static_cast<unsigned char>(character))) : character);
+      capitalize_next = false;
+   }
+   return result;
+}
+
+/// \brief builds the tiled enum type name for a property that has a fixed set of accepted values.
+/// \param type_name mechanism type name.
+/// \param property_name property name.
+/// \return enum type name such as "SmokeBlendMode".
+std::string toEnumTypeName(std::string_view type_name, std::string_view property_name)
+{
+   return std::string{type_name} + toPascalCase(property_name);
+}
+
+/// \brief formats a float the way tiled does, so that regenerating a file does not churn its contents.
+/// \param value value to format.
+/// \return shortest representation using six significant digits.
+std::string toTiledFloat(float value)
+{
+   std::array<char, 32> buffer{};
+   std::snprintf(buffer.data(), buffer.size(), "%g", static_cast<double>(value));
+   return std::string{buffer.data()};
+}
+
+/// \brief returns the value a newly inserted object should start with.
+/// \param property_info property to read.
+/// \return the property's template value when it has one, its engine default otherwise.
+PropertyValue effectiveValue(const PropertyInfo& property_info)
+{
+   return property_info.template_value.value_or(property_info.default_value);
+}
+
+/// \brief renders a property value as the string that goes into a tmx value attribute.
+/// \param value_variant value to render.
+/// \return value as text.
+std::string toValueString(const PropertyValue& value_variant)
+{
+   return std::visit(
+      [](const auto& value) -> std::string
+      {
+         using ValueType = std::decay_t<decltype(value)>;
+         if constexpr (std::is_same_v<ValueType, std::string_view>)
+         {
+            return std::string{value};
+         }
+         else if constexpr (std::is_same_v<ValueType, bool>)
+         {
+            return value ? "true" : "false";
+         }
+         else if constexpr (std::is_same_v<ValueType, float>)
+         {
+            return toTiledFloat(value);
+         }
+         else
+         {
+            return std::to_string(value);
+         }
+      },
+      value_variant
+   );
+}
+
+/// \brief renders a property value as the json value that goes into a tiled class member.
+/// \param value_variant value to render.
+/// \return value as json.
+nlohmann::json toValueJson(const PropertyValue& value_variant)
+{
+   return std::visit(
+      [](const auto& value) -> nlohmann::json
+      {
+         if constexpr (std::is_same_v<std::decay_t<decltype(value)>, std::string_view>)
+         {
+            return std::string{value};
+         }
+         else
+         {
+            return value;
+         }
+      },
+      value_variant
+   );
+}
+
+/// \brief escapes the characters that must not appear literally inside an xml attribute.
+/// \param value text to escape.
+/// \return escaped text.
+std::string escapeXmlAttribute(std::string_view value)
+{
+   std::string result;
+   for (const auto character : value)
+   {
+      switch (character)
+      {
+         case '&':
+            result += "&amp;";
+            break;
+         case '<':
+            result += "&lt;";
+            break;
+         case '>':
+            result += "&gt;";
+            break;
+         case '"':
+            result += "&quot;";
+            break;
+         default:
+            result.push_back(character);
+            break;
+      }
+   }
+   return result;
+}
+
+/// \brief returns the mechanism's properties sorted by name, matching the order tiled writes them in.
+/// \param schema schema to read the properties from.
+/// \return pointers to the schema's properties, sorted by name.
+std::vector<const PropertyInfo*> sortedProperties(const MechanismSchema& schema)
+{
+   std::vector<const PropertyInfo*> properties;
+   properties.reserve(schema.properties.size());
+   for (const auto& property_info : schema.properties)
+   {
+      properties.push_back(&property_info);
+   }
+   std::ranges::sort(properties, [](const auto* left, const auto* right) { return left->name < right->name; });
+   return properties;
+}
+
+/// \brief writes data/schemas/mechanisms.json, the machine readable dump of all registered schemas.
+/// \param all_schemas schemas to write.
+void writeSchemaJson(const std::vector<MechanismSchema>& all_schemas)
+{
    auto json_array = nlohmann::json::array();
    for (const auto& schema : all_schemas)
    {
       auto json_properties = nlohmann::json::array();
       for (const auto& property_info : schema.properties)
       {
-         const auto default_json = std::visit(
-            [](const auto& value) -> nlohmann::json
+         auto json_property = nlohmann::json{
+            {"name", std::string(property_info.name)},
+            {"type", std::string(property_info.type)},
+            {"default", toValueJson(property_info.default_value)},
+            {"required", property_info.required}
+         };
+
+         if (property_info.template_value.has_value())
+         {
+            json_property["template_default"] = toValueJson(property_info.template_value.value());
+         }
+
+         if (!property_info.allowed_values.empty())
+         {
+            auto json_allowed_values = nlohmann::json::array();
+            for (const auto& allowed_value : property_info.allowed_values)
             {
-               if constexpr (std::is_same_v<std::decay_t<decltype(value)>, std::string_view>)
-               {
-                  return std::string(value);
-               }
-               else
-               {
-                  return value;
-               }
-            },
-            property_info.default_value
-         );
-         json_properties.push_back(
-            {{"name", std::string(property_info.name)},
-             {"type", std::string(property_info.type)},
-             {"default", default_json},
-             {"required", property_info.required}}
-         );
+               json_allowed_values.push_back(std::string(allowed_value));
+            }
+            json_property["allowed_values"] = json_allowed_values;
+         }
+
+         json_properties.push_back(json_property);
       }
+
       json_array.push_back(
          {{"type", std::string(schema.type_name)},
           {"layer", std::string(schema.layer_name)},
@@ -48,9 +230,177 @@ void writeMechanismSchemas()
           {"properties", json_properties}}
       );
    }
+
    std::filesystem::create_directories("data/schemas");
    std::ofstream schemas_file("data/schemas/mechanisms.json");
    schemas_file << json_array.dump(3);
 }
 
-#endif  // DEVELOPMENT_MODE
+/// \brief writes one tiled template per mechanism into data/templates.
+/// \param all_schemas schemas to write templates for.
+void writeTemplates(const std::vector<MechanismSchema>& all_schemas)
+{
+   std::filesystem::create_directories("data/templates");
+
+   for (const auto& schema : all_schemas)
+   {
+      std::ostringstream stream;
+      stream << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+      stream << "<template>\n";
+      stream << " <object type=\"" << escapeXmlAttribute(schema.type_name) << "\" width=\"" << schema.default_width << "\" height=\""
+             << schema.default_height << "\">\n";
+
+      if (!schema.properties.empty())
+      {
+         stream << "  <properties>\n";
+         for (const auto* property_info : sortedProperties(schema))
+         {
+            stream << "   <property name=\"" << escapeXmlAttribute(property_info->name) << "\"";
+
+            // tiled omits the type attribute for strings, which is also the tmx parser's fallback
+            if (property_info->type != "string")
+            {
+               stream << " type=\"" << escapeXmlAttribute(property_info->type) << "\"";
+            }
+
+            if (!property_info->allowed_values.empty())
+            {
+               stream << " propertytype=\"" << escapeXmlAttribute(toEnumTypeName(schema.type_name, property_info->name)) << "\"";
+            }
+
+            stream << " value=\"" << escapeXmlAttribute(toValueString(effectiveValue(*property_info))) << "\"/>\n";
+         }
+         stream << "  </properties>\n";
+      }
+
+      if (!schema.default_polyline.empty())
+      {
+         stream << "  <polyline points=\"" << escapeXmlAttribute(schema.default_polyline) << "\"/>\n";
+      }
+
+      stream << " </object>\n";
+      stream << "</template>\n";
+
+      std::ofstream template_file("data/templates/" + toSnakeCase(schema.type_name) + ".tx");
+      template_file << stream.str();
+   }
+}
+
+/// \brief builds the tiled custom types for all mechanisms: one class per mechanism plus one enum per constrained property.
+/// \param all_schemas schemas to derive the custom types from.
+/// \return custom types keyed by name so that they end up sorted and can be merged with hand made ones.
+std::map<std::string, nlohmann::json> buildPropertyTypes(const std::vector<MechanismSchema>& all_schemas)
+{
+   std::map<std::string, nlohmann::json> property_types;
+
+   for (const auto& schema : all_schemas)
+   {
+      auto json_members = nlohmann::json::array();
+
+      for (const auto* property_info : sortedProperties(schema))
+      {
+         auto json_member = nlohmann::json{
+            {"name", std::string(property_info->name)},
+            {"type", std::string(property_info->type)},
+            {"value", toValueJson(effectiveValue(*property_info))}
+         };
+
+         if (!property_info->allowed_values.empty())
+         {
+            const auto enum_type_name = toEnumTypeName(schema.type_name, property_info->name);
+            json_member["propertyType"] = enum_type_name;
+
+            auto json_values = nlohmann::json::array();
+            for (const auto& allowed_value : property_info->allowed_values)
+            {
+               json_values.push_back(std::string(allowed_value));
+            }
+
+            property_types[enum_type_name] = nlohmann::json{
+               {"name", enum_type_name}, {"type", "enum"}, {"storageType", "string"}, {"values", json_values}, {"valuesAsFlags", false}
+            };
+         }
+
+         json_members.push_back(json_member);
+      }
+
+      property_types[std::string(schema.type_name)] = nlohmann::json{
+         {"name", std::string(schema.type_name)},
+         {"type", "class"},
+         {"color", std::string(tiled_class_color)},
+         {"drawFill", true},
+         {"members", json_members},
+         {"useAs", nlohmann::json::array({"property", "object"})}
+      };
+   }
+
+   return property_types;
+}
+
+/// \brief writes the tiled project file, replacing the generated custom types and keeping everything else untouched.
+/// \param all_schemas schemas to derive the custom types from.
+void writeTiledProject(const std::vector<MechanismSchema>& all_schemas)
+{
+   auto project = nlohmann::json{
+      {"automappingRulesFile", ""},
+      {"commands", nlohmann::json::array()},
+      {"extensionsPath", "extensions"},
+      {"folders", nlohmann::json::array({"data"})},
+      {"properties", nlohmann::json::array()},
+      {"propertyTypes", nlohmann::json::array()}
+   };
+
+   auto property_types = buildPropertyTypes(all_schemas);
+
+   // keep custom types that were added by hand in tiled and that no mechanism owns
+   std::ifstream existing_project_file{std::string{tiled_project_path}};
+   if (existing_project_file.is_open())
+   {
+      const auto existing_project = nlohmann::json::parse(existing_project_file, nullptr, false);
+      if (!existing_project.is_discarded() && existing_project.is_object())
+      {
+         for (const auto& [key, value] : existing_project.items())
+         {
+            if (key != "propertyTypes")
+            {
+               project[key] = value;
+            }
+         }
+
+         for (const auto& existing_property_type : existing_project.value("propertyTypes", nlohmann::json::array()))
+         {
+            const auto name = existing_property_type.value("name", std::string{});
+            if (!name.empty() && !property_types.contains(name))
+            {
+               property_types[name] = existing_property_type;
+            }
+         }
+      }
+   }
+   existing_project_file.close();
+
+   auto next_id = 1;
+   auto json_property_types = nlohmann::json::array();
+   for (auto& [name, property_type] : property_types)
+   {
+      property_type["id"] = next_id++;
+      json_property_types.push_back(property_type);
+   }
+   project["propertyTypes"] = json_property_types;
+
+   std::ofstream project_file{std::string{tiled_project_path}};
+   project_file << project.dump(4) << "\n";
+}
+
+}  // namespace
+
+void writeMechanismSchemas()
+{
+   const auto& all_schemas = GameMechanismDeserializerRegistry::instance().schemas();
+
+   writeSchemaJson(all_schemas);
+   writeTemplates(all_schemas);
+   writeTiledProject(all_schemas);
+}
+
+#endif  // MECHANISM_SCHEMA_WRITER_ENABLED

--- a/src/game/debug/mechanismschemawriter.h
+++ b/src/game/debug/mechanismschemawriter.h
@@ -1,7 +1,15 @@
 #pragma once
 
-#ifdef DEVELOPMENT_MODE
+// the writer authors files into the working directory next to the source tree, which neither the
+// console nor the web build has, and the console's romfs is read only on top of that. both are
+// excluded explicitly because they can still be built with the development instrumentation for a
+// profiling run.
+#if defined(DEVELOPMENT_MODE) && !defined(__SWITCH__) && !defined(__EMSCRIPTEN__)
+#define MECHANISM_SCHEMA_WRITER_ENABLED
+#endif
+
+#ifdef MECHANISM_SCHEMA_WRITER_ENABLED
 
 void writeMechanismSchemas();
 
-#endif  // DEVELOPMENT_MODE
+#endif  // MECHANISM_SCHEMA_WRITER_ENABLED

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -713,7 +713,7 @@ void Game::initialize()
    GameAudio::getInstance().initialize();
    _audio_callback = [](GameAudio::SoundEffect effect) { GameAudio::getInstance().play(effect); };
 
-#ifdef DEVELOPMENT_MODE
+#ifdef MECHANISM_SCHEMA_WRITER_ENABLED
    writeMechanismSchemas();
 #endif
 

--- a/src/game/mechanisms/buttonrect.cpp
+++ b/src/game/mechanisms/buttonrect.cpp
@@ -11,9 +11,15 @@
 namespace
 {
 static constexpr std::string_view default_button_rect_button = "b";
+static constexpr std::array button_rect_buttons{
+   std::string_view{"a"},
+   std::string_view{"b"},
+   std::string_view{"x"},
+   std::string_view{"y"},
+};
 static constexpr std::array button_rect_properties{
    PropertyInfo{.name = "z", .type = "int", .default_value = int32_t{20}},
-   PropertyInfo{.name = "button", .type = "string", .default_value = default_button_rect_button},
+   PropertyInfo{.name = "button", .type = "string", .default_value = default_button_rect_button, .allowed_values = button_rect_buttons},
 };
 static constexpr MechanismSchema button_rect_schema{
    .type_name = "ButtonRect",

--- a/src/game/mechanisms/collapsingplatform.cpp
+++ b/src/game/mechanisms/collapsingplatform.cpp
@@ -20,7 +20,7 @@ namespace
 {
 static constexpr int32_t default_collapsing_platform_z = 0;
 static constexpr std::array collapsing_platform_properties{
-   PropertyInfo{.name = "z", .type = "int", .default_value = default_collapsing_platform_z},
+   PropertyInfo{.name = "z", .type = "int", .default_value = default_collapsing_platform_z, .template_value = int32_t{20}},
 };
 static constexpr MechanismSchema collapsing_platform_schema{
    .type_name = "CollapsingPlatform",

--- a/src/game/mechanisms/crusher.cpp
+++ b/src/game/mechanisms/crusher.cpp
@@ -20,8 +20,14 @@ int32_t Crusher::__instance_counter = 0;
 namespace
 {
 static constexpr std::string_view default_crusher_alignment = "down";
+static constexpr std::array crusher_alignments{
+   std::string_view{"up"},
+   std::string_view{"down"},
+   std::string_view{"left"},
+   std::string_view{"right"},
+};
 static constexpr std::array crusher_properties{
-   PropertyInfo{.name = "alignment", .type = "string", .default_value = default_crusher_alignment},
+   PropertyInfo{.name = "alignment", .type = "string", .default_value = default_crusher_alignment, .allowed_values = crusher_alignments},
    PropertyInfo{.name = "z", .type = "int", .default_value = int32_t{20}},
 };
 static constexpr MechanismSchema crusher_schema{

--- a/src/game/mechanisms/deathblock.cpp
+++ b/src/game/mechanisms/deathblock.cpp
@@ -32,13 +32,19 @@ static constexpr int32_t default_death_block_damage = 100;
 static constexpr std::string_view default_death_block_mode = "always_on";
 static constexpr float default_death_block_velocity = 50.0f;
 
+static constexpr std::array death_block_modes{
+   std::string_view{"always_on"},
+   std::string_view{"interval"},
+   std::string_view{"rotate"},
+};
+
 static constexpr std::array death_block_properties{
    PropertyInfo{.name = "z", .type = "int", .default_value = int32_t{20}},
    PropertyInfo{.name = "time_off", .type = "float", .default_value = default_death_block_time_off},
    PropertyInfo{.name = "time_on", .type = "float", .default_value = default_death_block_time_on},
    PropertyInfo{.name = "time_offset", .type = "float", .default_value = default_death_block_time_offset},
    PropertyInfo{.name = "damage", .type = "int", .default_value = default_death_block_damage},
-   PropertyInfo{.name = "mode", .type = "string", .default_value = default_death_block_mode},
+   PropertyInfo{.name = "mode", .type = "string", .default_value = default_death_block_mode, .allowed_values = death_block_modes},
    PropertyInfo{.name = "velocity", .type = "float", .default_value = default_death_block_velocity},
 };
 static constexpr MechanismSchema death_block_schema{

--- a/src/game/mechanisms/fan.cpp
+++ b/src/game/mechanisms/fan.cpp
@@ -18,8 +18,15 @@ namespace
 static constexpr std::string_view default_fan_direction = "up";
 static constexpr float default_fan_speed = 1.0f;
 
+static constexpr std::array fan_directions{
+   std::string_view{"up"},
+   std::string_view{"down"},
+   std::string_view{"left"},
+   std::string_view{"right"},
+};
+
 static constexpr std::array fan_properties{
-   PropertyInfo{.name = "direction", .type = "string", .default_value = default_fan_direction},
+   PropertyInfo{.name = "direction", .type = "string", .default_value = default_fan_direction, .allowed_values = fan_directions},
    PropertyInfo{.name = "speed", .type = "float", .default_value = default_fan_speed},
 };
 static constexpr MechanismSchema fan_schema{

--- a/src/game/mechanisms/gamemechanismschema.h
+++ b/src/game/mechanisms/gamemechanismschema.h
@@ -2,16 +2,22 @@
 #define GAMEMECHANISMSCHEMA_H
 
 #include <cstdint>
+#include <optional>
 #include <span>
 #include <string_view>
 #include <variant>
+
+using PropertyValue = std::variant<std::string_view, int32_t, float, bool>;
 
 struct PropertyInfo
 {
    std::string_view name;
    std::string_view type;
-   std::variant<std::string_view, int32_t, float, bool> default_value;
+   PropertyValue default_value;  //!< value the engine falls back to when the property is absent
    bool required = false;
+   std::span<const std::string_view> allowed_values;  //!< fixed set of accepted values, exported as a tiled enum
+   std::optional<PropertyValue>
+      template_value;  //!< value a newly inserted tiled object starts with, where the engine default would be inert
 };
 
 struct MechanismSchema
@@ -21,6 +27,7 @@ struct MechanismSchema
    int32_t default_width = 48;
    int32_t default_height = 48;
    std::span<const PropertyInfo> properties;
+   std::string_view default_polyline;  //!< tiled polyline points, set for mechanisms placed as a path instead of a rectangle
 };
 
 #endif  // GAMEMECHANISMSCHEMA_H

--- a/src/game/mechanisms/laser.cpp
+++ b/src/game/mechanisms/laser.cpp
@@ -15,6 +15,9 @@
 #include "game/constants.h"
 #include "game/io/texturepool.h"
 #include "game/level/fixturenode.h"
+#include "game/mechanisms/gamemechanismdeserializerregistry.h"
+
+#include <array>
 #include "game/player/playerregistry.h"
 
 #include <iostream>
@@ -655,3 +658,53 @@ void Laser::merge()
       }
    }
 }
+
+namespace
+{
+static constexpr std::array laser_easing_functions{
+   std::string_view{"ease_in_sine"},
+   std::string_view{"ease_in_cubic"},
+   std::string_view{"ease_in_quint"},
+   std::string_view{"ease_in_circ"},
+   std::string_view{"ease_in_elastic"},
+   std::string_view{"ease_out_sine"},
+   std::string_view{"ease_out_cubic"},
+   std::string_view{"ease_out_quint"},
+   std::string_view{"ease_out_circ"},
+   std::string_view{"ease_out_elastic"},
+   std::string_view{"ease_in_out_sine"},
+   std::string_view{"ease_in_out_cubic"},
+   std::string_view{"ease_in_out_quint"},
+   std::string_view{"ease_in_out_circ"},
+   std::string_view{"ease_in_out_elastic"},
+   std::string_view{"ease_none"},
+};
+static constexpr std::array laser_properties{
+   PropertyInfo{.name = "z", .type = "int", .default_value = int32_t{20}},
+   PropertyInfo{.name = "enabled", .type = "bool", .default_value = true},
+   PropertyInfo{.name = "on_time", .type = "int", .default_value = int32_t{3000}},
+   PropertyInfo{.name = "off_time", .type = "int", .default_value = int32_t{3000}},
+   PropertyInfo{.name = "reference_id", .type = "string", .default_value = std::string_view{""}},
+   PropertyInfo{.name = "movement_speed", .type = "float", .default_value = 1.0f},
+   PropertyInfo{.name = "move_offset_s", .type = "float", .default_value = 0.0f},
+   PropertyInfo{
+      .name = "easing_function",
+      .type = "string",
+      .default_value = std::string_view{"ease_none"},
+      .allowed_values = laser_easing_functions
+   },
+   PropertyInfo{.name = "easing_subdivision_count", .type = "int", .default_value = int32_t{10}},
+};
+static constexpr MechanismSchema laser_schema{
+   .type_name = "Laser",
+   .layer_name = "lasers",
+   .default_width = 24,
+   .default_height = 24,
+   .properties = laser_properties,
+};
+const auto registered_laser = []
+{
+   GameMechanismDeserializerRegistry::instance().registerSchema(laser_schema);
+   return true;
+}();
+}  // namespace

--- a/src/game/mechanisms/movingplatform.cpp
+++ b/src/game/mechanisms/movingplatform.cpp
@@ -47,6 +47,7 @@ static constexpr MechanismSchema moving_platform_schema{
    .default_width = 0,
    .default_height = 0,
    .properties = moving_platform_properties,
+   .default_polyline = "0,0 96,0",
 };
 const auto registered_moving_platform = []
 {

--- a/src/game/mechanisms/onoffblock.cpp
+++ b/src/game/mechanisms/onoffblock.cpp
@@ -27,9 +27,14 @@ namespace
 {
 static constexpr bool default_on_off_block_inverted = false;
 
+static constexpr std::array on_off_block_modes{
+   std::string_view{"lever"},
+   std::string_view{"interval"},
+};
+
 static constexpr std::array on_off_block_properties{
    PropertyInfo{.name = "enabled", .type = "bool", .default_value = true},
-   PropertyInfo{.name = "mode", .type = "string", .default_value = std::string_view{"lever"}},
+   PropertyInfo{.name = "mode", .type = "string", .default_value = std::string_view{"lever"}, .allowed_values = on_off_block_modes},
    PropertyInfo{.name = "inverted", .type = "bool", .default_value = default_on_off_block_inverted},
    PropertyInfo{.name = "time_on_ms", .type = "int", .default_value = int32_t{1000}},
    PropertyInfo{.name = "time_off_ms", .type = "int", .default_value = int32_t{1000}},

--- a/src/game/mechanisms/portal.cpp
+++ b/src/game/mechanisms/portal.cpp
@@ -15,6 +15,9 @@
 #include "game/effects/fadetransitioneffect.h"
 #include "game/effects/screentransition.h"
 #include "game/io/texturepool.h"
+#include "game/mechanisms/gamemechanismdeserializerregistry.h"
+
+#include <array>
 #include "game/player/playerregistry.h"
 #include "game/state/displaymode.h"
 
@@ -344,3 +347,23 @@ std::vector<std::shared_ptr<GameMechanism>> Portal::load(GameNode* parent, const
 
    return portals;
 }
+
+namespace
+{
+static constexpr std::array portal_properties{
+   PropertyInfo{.name = "z", .type = "int", .default_value = int32_t{20}},
+};
+static constexpr MechanismSchema portal_schema{
+   .type_name = "Portal",
+   .layer_name = "portals",
+   .default_width = 0,
+   .default_height = 0,
+   .properties = portal_properties,
+   .default_polyline = "0,0 96,0",
+};
+const auto registered_portal = []
+{
+   GameMechanismDeserializerRegistry::instance().registerSchema(portal_schema);
+   return true;
+}();
+}  // namespace

--- a/src/game/mechanisms/postprocessingmechanism.cpp
+++ b/src/game/mechanisms/postprocessingmechanism.cpp
@@ -19,10 +19,15 @@ namespace
 //! \brief prefix marking a tmx property as a shader uniform
 constexpr std::string_view uniform_prefix{"u_"};
 
+static constexpr std::array post_processing_scopes{
+   std::string_view{"all"},
+   std::string_view{"level"},
+};
+
 static constexpr std::array post_processing_properties{
    PropertyInfo{.name = "fragment_shader", .type = "string", .default_value = "", .required = true},
    PropertyInfo{.name = "vertex_shader", .type = "string", .default_value = ""},
-   PropertyInfo{.name = "scope", .type = "string", .default_value = "all"},
+   PropertyInfo{.name = "scope", .type = "string", .default_value = "all", .allowed_values = post_processing_scopes},
    PropertyInfo{.name = "z", .type = "int", .default_value = int32_t{0}},
 };
 

--- a/src/game/mechanisms/rotatingblade.cpp
+++ b/src/game/mechanisms/rotatingblade.cpp
@@ -33,6 +33,7 @@ static constexpr MechanismSchema rotating_blade_schema{
    .default_width = 0,
    .default_height = 0,
    .properties = rotating_blade_properties,
+   .default_polyline = "0,0 48,0 96,0",
 };
 const auto registered_rotatingblade = []
 {

--- a/src/game/mechanisms/sensorrect.cpp
+++ b/src/game/mechanisms/sensorrect.cpp
@@ -17,10 +17,19 @@ static constexpr std::string_view default_sensor_rect_reference_id = "";
 static constexpr std::string_view default_sensor_rect_action = "toggle";
 static constexpr std::string_view default_sensor_rect_event = "on_enter";
 static constexpr bool default_sensor_rect_observed = false;
+static constexpr std::array sensor_rect_actions{
+   std::string_view{"enable"},
+   std::string_view{"disable"},
+   std::string_view{"toggle"},
+};
+static constexpr std::array sensor_rect_events{
+   std::string_view{"on_enter"},
+   std::string_view{"on_leave"},
+};
 static constexpr std::array sensor_rect_properties{
    PropertyInfo{.name = "reference_id", .type = "string", .default_value = default_sensor_rect_reference_id},
-   PropertyInfo{.name = "action", .type = "string", .default_value = default_sensor_rect_action},
-   PropertyInfo{.name = "event", .type = "string", .default_value = default_sensor_rect_event},
+   PropertyInfo{.name = "action", .type = "string", .default_value = default_sensor_rect_action, .allowed_values = sensor_rect_actions},
+   PropertyInfo{.name = "event", .type = "string", .default_value = default_sensor_rect_event, .allowed_values = sensor_rect_events},
    PropertyInfo{.name = "observed", .type = "bool", .default_value = default_sensor_rect_observed},
 };
 static constexpr MechanismSchema sensor_rect_schema{

--- a/src/game/mechanisms/shaderlayer.cpp
+++ b/src/game/mechanisms/shaderlayer.cpp
@@ -6,6 +6,9 @@
 #include "framework/tools/sfmlcompat.h"
 #include "game/io/texturepool.h"
 #include "game/io/valuereader.h"
+#include "game/mechanisms/gamemechanismdeserializerregistry.h"
+
+#include <array>
 
 #include <filesystem>
 #ifdef DECEPTUS_VRSFML
@@ -265,3 +268,30 @@ std::shared_ptr<ShaderLayer> ShaderLayer::deserialize(GameNode* parent, const Ga
 
    return instance;
 }
+
+namespace
+{
+static constexpr std::array shader_quad_properties{
+   PropertyInfo{.name = "fragment_shader", .type = "string", .default_value = std::string_view{""}, .required = true},
+   PropertyInfo{.name = "vertex_shader", .type = "string", .default_value = std::string_view{""}},
+   PropertyInfo{.name = "texture", .type = "string", .default_value = std::string_view{""}},
+   PropertyInfo{.name = "smooth_texture", .type = "bool", .default_value = false},
+   PropertyInfo{.name = "customization", .type = "string", .default_value = std::string_view{""}},
+   PropertyInfo{.name = "uv_width", .type = "float", .default_value = 1.0f},
+   PropertyInfo{.name = "uv_height", .type = "float", .default_value = 1.0f},
+   PropertyInfo{.name = "time_offset_s", .type = "float", .default_value = 0.0f},
+   PropertyInfo{.name = "z", .type = "int", .default_value = int32_t{20}},
+};
+static constexpr MechanismSchema shader_quad_schema{
+   .type_name = "ShaderQuad",
+   .layer_name = "shader_quads",
+   .default_width = 192,
+   .default_height = 192,
+   .properties = shader_quad_properties,
+};
+const auto registered_shader_quad = []
+{
+   GameMechanismDeserializerRegistry::instance().registerSchema(shader_quad_schema);
+   return true;
+}();
+}  // namespace

--- a/src/game/mechanisms/skillgate.cpp
+++ b/src/game/mechanisms/skillgate.cpp
@@ -21,8 +21,25 @@ static constexpr bool default_skill_gate_inverted = false;
 static constexpr float default_skill_gate_fade_speed = 2.0f;
 static constexpr auto default_skill_gate_skill = std::string_view{"double_jump"};
 
+static constexpr std::array skill_gate_skills{
+   std::string_view{"wall_climb"},
+   std::string_view{"dash"},
+   std::string_view{"invulnerable"},
+   std::string_view{"wall_slide"},
+   std::string_view{"wall_jump"},
+   std::string_view{"double_jump"},
+   std::string_view{"crouch"},
+   std::string_view{"swim"},
+};
+
 static constexpr std::array skill_gate_properties{
-   PropertyInfo{.name = "skill", .type = "string", .default_value = default_skill_gate_skill, .required = true},
+   PropertyInfo{
+      .name = "skill",
+      .type = "string",
+      .default_value = default_skill_gate_skill,
+      .required = true,
+      .allowed_values = skill_gate_skills
+   },
    PropertyInfo{.name = "inverted", .type = "bool", .default_value = default_skill_gate_inverted},
    PropertyInfo{.name = "fade_speed", .type = "float", .default_value = default_skill_gate_fade_speed},
    PropertyInfo{.name = "enabled", .type = "bool", .default_value = true},

--- a/src/game/mechanisms/smokeeffect.cpp
+++ b/src/game/mechanisms/smokeeffect.cpp
@@ -10,6 +10,7 @@
 #include "framework/tools/sfmlcompat.h"
 #include "game/camera/cameraroomlock.h"
 #include "game/io/texturepool.h"
+#include "game/mechanisms/gamemechanismdeserializerregistry.h"
 
 #include <array>
 #include <cmath>
@@ -460,3 +461,42 @@ std::shared_ptr<SmokeEffect> SmokeEffect::deserialize(GameNode* parent, const Ga
 
    return smoke_effect;
 }
+
+namespace
+{
+static constexpr std::array smoke_modes{
+   std::string_view{"smoke"},
+   std::string_view{"fog"},
+};
+static constexpr std::array smoke_blend_modes{
+   std::string_view{"alpha"},
+   std::string_view{"add"},
+   std::string_view{"multiply"},
+};
+static constexpr std::array smoke_properties{
+   PropertyInfo{.name = "mode", .type = "string", .default_value = std::string_view{"smoke"}, .allowed_values = smoke_modes},
+   PropertyInfo{.name = "blend_mode", .type = "string", .default_value = std::string_view{"add"}, .allowed_values = smoke_blend_modes},
+   PropertyInfo{.name = "particle_count", .type = "int", .default_value = int32_t{50}},
+   PropertyInfo{.name = "particle_color", .type = "string", .default_value = std::string_view{"#ffffff19"}},
+   PropertyInfo{.name = "layer_color", .type = "string", .default_value = std::string_view{"#ffffffff"}},
+   PropertyInfo{.name = "spread_factor", .type = "float", .default_value = 0.6666667f},
+   PropertyInfo{.name = "velocity", .type = "float", .default_value = 1.0f},
+   PropertyInfo{.name = "sprite_scale", .type = "float", .default_value = 1.0f},
+   PropertyInfo{.name = "pixel_ratio", .type = "float", .default_value = 1.0f},
+   PropertyInfo{.name = "center_offset_x_px", .type = "int", .default_value = int32_t{0}},
+   PropertyInfo{.name = "center_offset_y_px", .type = "int", .default_value = int32_t{0}},
+   PropertyInfo{.name = "z", .type = "int", .default_value = int32_t{20}},
+};
+static constexpr MechanismSchema smoke_schema{
+   .type_name = "Smoke",
+   .layer_name = "smoke",
+   .default_width = 96,
+   .default_height = 96,
+   .properties = smoke_properties,
+};
+const auto registered_smoke = []
+{
+   GameMechanismDeserializerRegistry::instance().registerSchema(smoke_schema);
+   return true;
+}();
+}  // namespace

--- a/src/game/mechanisms/soundemitter.cpp
+++ b/src/game/mechanisms/soundemitter.cpp
@@ -3,6 +3,9 @@
 #include "framework/tmxparser/tmxproperties.h"
 #include "framework/tmxparser/tmxproperty.h"
 #include "game/audio/audio.h"
+#include "game/mechanisms/gamemechanismdeserializerregistry.h"
+
+#include <array>
 
 SoundEmitter::SoundEmitter(GameNode* parent) : GameNode(parent)
 {
@@ -129,3 +132,27 @@ std::optional<sf::FloatRect> SoundEmitter::getBoundingBoxPx()
 {
    return _rect;
 }
+
+namespace
+{
+static constexpr std::array sound_emitter_properties{
+   PropertyInfo{.name = "filename", .type = "string", .default_value = std::string_view{""}, .required = true},
+   PropertyInfo{.name = "looped", .type = "bool", .default_value = true},
+   PropertyInfo{.name = "radius_near_px", .type = "float", .default_value = 200.0f},
+   PropertyInfo{.name = "volume_near", .type = "float", .default_value = 1.0f},
+   PropertyInfo{.name = "radius_far_px", .type = "float", .default_value = 600.0f},
+   PropertyInfo{.name = "volume_far", .type = "float", .default_value = 0.0f},
+};
+static constexpr MechanismSchema sound_emitter_schema{
+   .type_name = "SoundEmitter",
+   .layer_name = "sound_emitters",
+   .default_width = 192,
+   .default_height = 192,
+   .properties = sound_emitter_properties,
+};
+const auto registered_sound_emitter = []
+{
+   GameMechanismDeserializerRegistry::instance().registerSchema(sound_emitter_schema);
+   return true;
+}();
+}  // namespace

--- a/src/game/mechanisms/spikes.cpp
+++ b/src/game/mechanisms/spikes.cpp
@@ -2,6 +2,9 @@
 
 #include "constants.h"
 #include "game/io/texturepool.h"
+#include "game/mechanisms/gamemechanismdeserializerregistry.h"
+
+#include <array>
 #include "game/player/playerregistry.h"
 
 #include "framework/tmxparser/tmxlayer.h"
@@ -569,3 +572,42 @@ std::vector<std::shared_ptr<Spikes>> Spikes::load(GameNode* parent, const GameDe
 
    return all_spikes;
 }
+
+namespace
+{
+static constexpr std::array spikes_modes{
+   std::string_view{"trap"},
+   std::string_view{"interval"},
+   std::string_view{"toggled"},
+};
+static constexpr std::array spikes_orientations{
+   std::string_view{"up"},
+   std::string_view{"down"},
+   std::string_view{"left"},
+   std::string_view{"right"},
+};
+static constexpr std::array spikes_properties{
+   PropertyInfo{.name = "mode", .type = "string", .default_value = std::string_view{"trap"}, .allowed_values = spikes_modes},
+   PropertyInfo{.name = "orientation", .type = "string", .default_value = std::string_view{"up"}, .allowed_values = spikes_orientations},
+   PropertyInfo{.name = "up_time_ms", .type = "int", .default_value = int32_t{2000}},
+   PropertyInfo{.name = "down_time_ms", .type = "int", .default_value = int32_t{2000}},
+   PropertyInfo{.name = "trap_time_ms", .type = "int", .default_value = int32_t{250}},
+   PropertyInfo{.name = "speed_up", .type = "float", .default_value = 35.0f},
+   PropertyInfo{.name = "speed_down", .type = "float", .default_value = 35.0f},
+   PropertyInfo{.name = "time_offset_ms", .type = "int", .default_value = int32_t{0}},
+   PropertyInfo{.name = "under_water", .type = "bool", .default_value = false},
+   PropertyInfo{.name = "z", .type = "int", .default_value = int32_t{20}},
+};
+static constexpr MechanismSchema spikes_schema{
+   .type_name = "Spikes",
+   .layer_name = "interval_spikes",
+   .default_width = 24,
+   .default_height = 24,
+   .properties = spikes_properties,
+};
+const auto registered_spikes = []
+{
+   GameMechanismDeserializerRegistry::instance().registerSchema(spikes_schema);
+   return true;
+}();
+}  // namespace

--- a/src/game/mechanisms/textlayer.cpp
+++ b/src/game/mechanisms/textlayer.cpp
@@ -8,6 +8,9 @@
 #include "game/io/texturepool.h"
 #include "game/io/valuereader.h"
 #include "game/layers/bitmapfont.h"
+#include "game/mechanisms/gamemechanismdeserializerregistry.h"
+
+#include <array>
 
 TextLayer::TextLayer(GameNode* parent) : GameNode(parent)
 {
@@ -136,3 +139,28 @@ std::shared_ptr<TextLayer> TextLayer::deserialize(GameNode* parent, const GameDe
 
    return instance;
 }
+
+namespace
+{
+static constexpr std::array text_layer_properties{
+   PropertyInfo{.name = "text", .type = "string", .default_value = std::string_view{"undefined"}, .required = true},
+   PropertyInfo{.name = "bitmap_font_texture", .type = "string", .default_value = std::string_view{""}},
+   PropertyInfo{.name = "bitmap_font_map", .type = "string", .default_value = std::string_view{""}},
+   PropertyInfo{.name = "truetype_font", .type = "string", .default_value = std::string_view{""}},
+   PropertyInfo{.name = "truetype_font_size", .type = "int", .default_value = int32_t{12}},
+   PropertyInfo{.name = "truetype_font_color", .type = "string", .default_value = std::string_view{"#ffffffff"}},
+   PropertyInfo{.name = "z", .type = "int", .default_value = int32_t{0}, .template_value = int32_t{20}},
+};
+static constexpr MechanismSchema text_layer_schema{
+   .type_name = "TextLayer",
+   .layer_name = "text_layers",
+   .default_width = 192,
+   .default_height = 48,
+   .properties = text_layer_properties,
+};
+const auto registered_text_layer = []
+{
+   GameMechanismDeserializerRegistry::instance().registerSchema(text_layer_schema);
+   return true;
+}();
+}  // namespace

--- a/src/game/mechanisms/treasurechest.cpp
+++ b/src/game/mechanisms/treasurechest.cpp
@@ -20,7 +20,7 @@ namespace
 {
 static constexpr int32_t default_treasure_chest_z = 0;
 static constexpr std::array treasure_chest_properties{
-   PropertyInfo{.name = "z", .type = "int", .default_value = default_treasure_chest_z},
+   PropertyInfo{.name = "z", .type = "int", .default_value = default_treasure_chest_z, .template_value = int32_t{20}},
    PropertyInfo{.name = "texture", .type = "string", .default_value = std::string_view{"data/sprites/treasure_chest.png"}},
    PropertyInfo{.name = "sample_open", .type = "string", .default_value = std::string_view{"treasure_chest_open.ogg"}},
    PropertyInfo{.name = "sample_locked", .type = "string", .default_value = std::string_view{""}},

--- a/src/game/mechanisms/watersurface.cpp
+++ b/src/game/mechanisms/watersurface.cpp
@@ -29,6 +29,23 @@ static constexpr std::array water_surface_properties{
    PropertyInfo{.name = "clamp_segment_count", .type = "int", .default_value = default_water_surface_clamp_segment_count},
    PropertyInfo{.name = "pixel_ratio", .type = "float", .default_value = default_water_surface_pixel_ratio},
 };
+static constexpr std::array water_surface_emitter_properties{
+   PropertyInfo{.name = "reference", .type = "string", .default_value = std::string_view{""}, .required = true},
+   PropertyInfo{.name = "velocity", .type = "float", .default_value = 2.0f},
+   PropertyInfo{.name = "interval_min_s", .type = "float", .default_value = 0.3f},
+   PropertyInfo{.name = "interval_max_s", .type = "float", .default_value = 0.6f},
+   PropertyInfo{.name = "count", .type = "int", .default_value = int32_t{1}},
+   PropertyInfo{.name = "x_from_px", .type = "float", .default_value = 0.0f},
+   PropertyInfo{.name = "x_to_px", .type = "float", .default_value = 96.0f},
+   PropertyInfo{.name = "width_px", .type = "float", .default_value = 96.0f},
+};
+static constexpr MechanismSchema water_surface_emitter_schema{
+   .type_name = "WaterSurfaceEmitter",
+   .layer_name = "water_surface_emitter",
+   .default_width = 96,
+   .default_height = 24,
+   .properties = water_surface_emitter_properties,
+};
 static constexpr MechanismSchema water_surface_schema{
    .type_name = "WaterSurface",
    .layer_name = "water_surface",
@@ -40,6 +57,7 @@ const auto registered_watersurface = []
 {
    auto& registry = GameMechanismDeserializerRegistry::instance();
    registry.registerSchema(water_surface_schema);
+   registry.registerSchema(water_surface_emitter_schema);
    registry.mapGroupToLayer("WaterSurface", "water_surface");
 
    registry.registerLayerName(

--- a/src/game/mechanisms/weather.cpp
+++ b/src/game/mechanisms/weather.cpp
@@ -8,6 +8,9 @@
 #include "game/audio/soundrotation.h"
 #include "game/io/valuereader.h"
 #include "game/level/roomupdater.h"
+#include "game/mechanisms/gamemechanismdeserializerregistry.h"
+
+#include <array>
 #include "game/player/playerregistry.h"
 
 #include <string>
@@ -291,3 +294,26 @@ std::shared_ptr<Weather> Weather::deserialize(GameNode* parent, const GameDeseri
 
    return weather;
 }
+
+namespace
+{
+static constexpr std::array weather_properties{
+   PropertyInfo{.name = "enabled", .type = "bool", .default_value = true},
+   PropertyInfo{.name = "limit_effect_to_room", .type = "bool", .default_value = false},
+   PropertyInfo{.name = "effect_start_delay_s", .type = "float", .default_value = 0.0f},
+   PropertyInfo{.name = "sound_volume", .type = "float", .default_value = 1.0f},
+   PropertyInfo{.name = "z", .type = "int", .default_value = int32_t{20}},
+};
+static constexpr MechanismSchema weather_schema{
+   .type_name = "Weather",
+   .layer_name = "weather",
+   .default_width = 192,
+   .default_height = 192,
+   .properties = weather_properties,
+};
+const auto registered_weather = []
+{
+   GameMechanismDeserializerRegistry::instance().registerSchema(weather_schema);
+   return true;
+}();
+}  // namespace

--- a/src/game/mechanisms/wind.cpp
+++ b/src/game/mechanisms/wind.cpp
@@ -56,8 +56,8 @@ static constexpr auto leaf_jitter_frequency_factor_max = 1.25f;
 
 static constexpr std::array wind_properties{
    PropertyInfo{.name = "direction_x", .type = "float", .default_value = default_wind_direction_x},
-   PropertyInfo{.name = "direction_y", .type = "float", .default_value = default_wind_direction_y},
-   PropertyInfo{.name = "strength", .type = "float", .default_value = default_wind_strength},
+   PropertyInfo{.name = "direction_y", .type = "float", .default_value = default_wind_direction_y, .template_value = -1.0f},
+   PropertyInfo{.name = "strength", .type = "float", .default_value = default_wind_strength, .template_value = 1.0f},
    PropertyInfo{.name = "z", .type = "int", .default_value = default_wind_z},
    PropertyInfo{.name = "sounds", .type = "string", .default_value = std::string_view{}},
    PropertyInfo{.name = "sound_volume", .type = "float", .default_value = default_sound_volume},

--- a/src/game/mechanisms/zoomrect.cpp
+++ b/src/game/mechanisms/zoomrect.cpp
@@ -13,7 +13,12 @@ namespace
 {
 static constexpr std::string_view default_zoom_rect_values = "0.0:1.0;1.0:1.0";
 static constexpr std::array zoom_rect_properties{
-   PropertyInfo{.name = "values", .type = "string", .default_value = default_zoom_rect_values},
+   PropertyInfo{
+      .name = "values",
+      .type = "string",
+      .default_value = default_zoom_rect_values,
+      .template_value = std::string_view{"0.0:1.5;1.0:1.0"}
+   },
 };
 static constexpr MechanismSchema zoom_rect_schema{
    .type_name = "ZoomRect",


### PR DESCRIPTION
## Why

`data/templates` already held 48 `.tx` files, but `grep template= data/level-*/*.tmx` returns nothing — no level ever used one. Placing a template produced a dead object: `TmxObject` inherited only the `type` from the template, and Tiled writes an instance as the reference plus whatever the instance *changed*. Size, properties and shape stay in the template and were dropped on load.

There was also no `.tiled-project`, so the templates never appeared in Tiled's Templates view, and no Custom Types, so every mechanism property was free text in the editor.

## What

**The parser actually merges templates.** `TmxObject::deserialize` now inherits type, gid, name, size, polyline/polygon and properties from the template, with anything the instance spelled out winning. The template is parsed once per map and cached in `TmxParseData`, so a level with thousands of instances does not re-read the same `.tx` per object.

**The generator emits what Tiled needs.** `writeMechanismSchemas()` now also writes:

- `data/templates/*.tx` for all 52 registered mechanisms, in Tiled's own serialization — `type` omitted for strings, properties sorted, floats via `%g` — so re-saving from the editor produces no diff
- `deceptus.tiled-project` with one class per mechanism and an enum per constrained property (14 of them: crusher alignment, fan direction, spikes mode/orientation, smoke mode/blend mode, laser easing, skill gate skill, …), so the editor offers dropdowns. Custom types live inside the project file in Tiled 1.10+; hand-added types and the other project keys are preserved on regeneration.

**Drift is closed.** Schemas are registered for the nine mechanisms still on the legacy deserializer path (Laser, Portal, ShaderQuad, Smoke, SoundEmitter, Spikes, TextLayer, WaterSurfaceEmitter, Weather). Before: 9 templates had no schema, 4 schemas had no template, 5 templates were missing properties the schema declared.

**`PropertyInfo` gains two fields.** `allowed_values` feeds the enums. `template_value` covers the cases where the engine default is inert but a newly inserted object needs a usable seed — wind `strength`/`direction_y`, zoom rect `values`, and the `z` of collapsing platform, text layer and treasure chest. Without it, regenerating would have overwritten the deliberate seeds from 0b16658b with zeros. `mechanisms.json` still reports the engine default, plus `template_default` where they differ.

## Where the writer runs

It authors files into the working directory, so it only makes sense on a development build with the source tree sitting there. `MECHANISM_SCHEMA_WRITER_ENABLED` in `mechanismschemawriter.h` is the single definition the call site shares, so the guard cannot drift:

| build | writer |
|---|---|
| windows dev | on |
| linux dev | on |
| macos dev | on |
| windows release | off |
| switch, dev instrumentation on (profiling run) | off |
| wasm, dev instrumentation on | off |

The console and web build are excluded explicitly rather than by omission, because `CMakeLists.txt:1215` documents that both can be built with `-DDECEPTUS_DEVELOPMENT_MODE=ON` for a profiling run — and on the console `create_directories` against the read-only romfs throws an uncaught `filesystem_error` — the same failure mode as the read-only-romfs level-load crash we chased earlier.

## Verification

- Desktop build clean (`build_rel`, DEVELOPMENT_MODE). Regenerating twice produces byte-identical output.
- The guard was checked per target by running the preprocessor over the header with each target's defines — that is where the table above comes from, not from reasoning about it.
- Tiled 1.11.2 opens `deceptus.tiled-project` without error; `--export-map` resolves a template instance to width 120, height 24, `alignment=down`, `z=20`.
- The `propertyTypes` / project shapes were taken from Tiled 1.11.2's own `PropertyType::toJson` and `Project::save`, not guessed. Objects keep being written with `type=` rather than `class=` at the default compatibility version, which is what the parser reads.
- A focused test against the built parser objects covers: a bare instance inheriting everything; instance values overriding the template; polyline inheritance; and a non-template object staying untouched. All pass.
- Regenerated templates diffed against `HEAD` property by property — no template loses a value or a property.

## Note

`data/schemas/` is gitignored, so `mechanisms.json` stays a local artifact; `deceptus.tiled-project` is committed since it is shared editor config. `deceptus.tiled-session` is per-user and now ignored.


