### PR TITLE
let the player take the owl's eyes and wake the thunderstorm

### DIFF
--- a/data/level-graveyard/graveyard.tmx
+++ b/data/level-graveyard/graveyard.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.10.2" orientation="orthogonal" renderorder="right-down" width="768" height="100" tilewidth="24" tileheight="24" infinite="0" nextlayerid="51" nextobjectid="68">
+<map version="1.10" tiledversion="1.10.2" orientation="orthogonal" renderorder="right-down" width="768" height="100" tilewidth="24" tileheight="24" infinite="0" nextlayerid="52" nextobjectid="71">
  <tileset firstgid="1" source="graveyard-background-diffuse.tsx"/>
  <tileset firstgid="4097" source="graveyard-level-diffuse.tsx"/>
  <imagelayer id="25" name="gv-bg-sky" offsetx="576" offsety="1320">
@@ -1903,7 +1903,18 @@
   </object>
  </objectgroup>
  <objectgroup id="50" name="interaction_help">
-  <object id="66" x="5489.33" y="1436.5" width="85.6667" height="75.5">
+  <object id="66" name="shrine_help_take" x="5489.33" y="1436.5" width="85.6667" height="75.5">
+   <properties>
+    <property name="animation" value="read"/>
+    <property name="button_1" value="key_return"/>
+    <property name="offset_x_px" type="int" value="44"/>
+    <property name="offset_y_px" type="int" value="-10"/>
+    <property name="text" value="Examine"/>
+    <property name="text_1" value="Take"/>
+    <property name="z" type="int" value="50"/>
+   </properties>
+  </object>
+  <object id="68" name="shrine_help_examine" x="5489.33" y="1436.5" width="85.6667" height="75.5">
    <properties>
     <property name="animation" value="read"/>
     <property name="offset_x_px" type="int" value="44"/>
@@ -1915,7 +1926,7 @@
  </objectgroup>
  <objectgroup id="15" name="fireflies" visible="0"/>
  <objectgroup id="14" name="dialogues">
-  <object id="67" x="5489.33" y="1436.46" width="86" height="76.0769">
+  <object id="67" name="shrine_dialogue" x="5489.33" y="1436.46" width="86" height="76.0769">
    <properties>
     <property name="01" value="A stone shrine with an owl. "/>
     <property name="01_background_color" type="color" value="#ff101ad4"/>
@@ -1930,10 +1941,25 @@
     <property name="pause_game" type="bool" value="false"/>
    </properties>
   </object>
+  <object id="69" name="rubies_acquired" x="5520" y="1464" width="24" height="24">
+   <properties>
+    <property name="01" value="You have acquired the [color:#FEBA00FF] Rubies [/color]"/>
+    <property name="01_background_color" type="color" value="#ff8826ff"/>
+    <property name="01_text_color" type="color" value="#ffffffff"/>
+    <property name="01_x_px" type="int" value="0"/>
+    <property name="01_y_px" type="int" value="-70"/>
+    <property name="open_on_intersect" type="bool" value="false"/>
+    <property name="pause_game" type="bool" value="false"/>
+   </properties>
+  </object>
+ </objectgroup>
+ <objectgroup id="51" name="button_rects">
+  <object id="70" name="shrine_rect" x="5472" y="1440" width="96" height="48"/>
  </objectgroup>
  <objectgroup id="13" name="weather" visible="0">
   <object id="31" name="thunderstorm" x="696" y="696" width="14376" height="1080">
    <properties>
+    <property name="enabled" type="bool" value="false"/>
     <property name="sound_volume" type="float" value="0.8"/>
     <property name="sounds" value="weather_thunder_01.ogg;weather_thunder_02.ogg;weather_thunder_03.ogg;weather_thunder_04.ogg;weather_thunder_05.ogg"/>
     <property name="z" type="int" value="2"/>

--- a/data/level-graveyard/level.lua
+++ b/data/level-graveyard/level.lua
@@ -1,11 +1,75 @@
 ------------------------------------------------------------------------------------------------------------------------
+
+_initialized = false
+
+-- the owl statue carries two cut rubies as eyes, and the inventory item that holds them is called "gems"
+_owl_eye_item = "gems"
+
+
+------------------------------------------------------------------------------------------------------------------------
 function initialize()
    setInfoLayerVisible(true)
 end
 
 
 ------------------------------------------------------------------------------------------------------------------------
+-- the tile layers already draw the owl with hollow sockets, the "owl-eyes" image layer is what paints the two
+-- rubies into them. taking the eyes therefore only has to hide that image layer.
+--
+--   owl-eyes image layer   ->  glowing rubies in the sockets
+--   decoration-b tiles     ->  the same shrine with empty sockets
+--
+function setOwlEyesPresent(present)
+   setMechanismVisible("owl-eyes", present, "imagelayers")
+   setMechanismEnabled("shrine_rect", present, "button_rects")
+   setMechanismEnabled("shrine_help_take", present, "interaction_help")
+   setMechanismEnabled("shrine_help_examine", not present, "interaction_help")
+end
+
+
+------------------------------------------------------------------------------------------------------------------------
+-- the rubies go into the inventory, and the inventory is part of the save game. that makes "the player carries the
+-- owl's eyes" the persisted flag which decides whether the thunderstorm is already awake when the level is entered.
+function initShrine()
+   local owl_eyes_taken = inventoryHas(_owl_eye_item)
+   setOwlEyesPresent(not owl_eyes_taken)
+   setMechanismEnabled("thunderstorm", owl_eyes_taken, "weather")
+end
+
+
+------------------------------------------------------------------------------------------------------------------------
+function takeOwlEyes()
+   if (inventoryHas(_owl_eye_item)) then
+      return
+   end
+
+   setOwlEyesPresent(false)
+   inventoryAdd(_owl_eye_item)
+   showDialogue("rubies_acquired")
+end
+
+
+------------------------------------------------------------------------------------------------------------------------
 function update(dt)
+   -- the mechanism lookup is not wired up yet while initialize() runs, so the shrine is set up on the first frame
+   if (not _initialized) then
+      _initialized = true
+      initShrine()
+   end
+end
+
+
+------------------------------------------------------------------------------------------------------------------------
+function mechanismEvent(object_id, group_id, event_name, value)
+   -- player pressed the action button in front of the shrine
+   if (object_id == "shrine_rect" and event_name == "pressed" and value == "true") then
+      takeOwlEyes()
+   end
+
+   -- the storm the owl was keeping asleep breaks loose once the player has read that he owns the rubies
+   if (object_id == "rubies_acquired" and event_name == "dismissed") then
+      setMechanismEnabled("thunderstorm", true, "weather")
+   end
 end
 
 

--- a/data/locale/en.json
+++ b/data/locale/en.json
@@ -208,6 +208,7 @@
   "You have acquired the [color:#FEBA00FF] Head Torch [/color]": "",
   "You have acquired the [color:#FEBA00FF] Iron Lever [/color]": "",
   "You have acquired the [color:#FEBA00FF] Locker Key [/color]": "",
+  "You have acquired the [color:#FEBA00FF] Rubies [/color]": "",
   "You see, I can only connect to active engines.[br]No destination, no teleportation!": "",
   "Yuck!": "",
   "mrghm... hungryyyy...": "",


### PR DESCRIPTION
The graveyard thunderstorm now starts out disabled. The owl statue at the shrine can be looted with the action button, which hands the player the two rubies, and acknowledging the acquired message is what breaks the storm loose.

## How it works

**No new art was needed.** The `decoration-b` tiles already draw the shrine with hollow sockets, and `owl-eyes.png` is a 72x48 repaint of the same shrine top with the glowing rubies in them. Taking the eyes is therefore only a matter of hiding that image layer.

**The serialized state is the inventory.** The rubies are the existing (until now unused) `gems` item, whose title already reads "Rubies" and whose description already reads "Two cut stones". `PlayerInfo::_inventory` is part of the save game, so `inventoryHas("gems")` *is* the persisted flag which decides whether the storm is already awake on level entry - the same way the catacombs derive the open library drawer from the solar seal.

## Changes

Three data files, no engine code.

`data/level-graveyard/graveyard.tmx`
- `thunderstorm` gets `enabled=false`. The property is already part of the `Weather` schema; setting it here rather than from Lua avoids a single frame of lightning before the script's first update runs.
- New `button_rects` group holding `shrine_rect`, a 96x48 rect over the shrine steps. That is the same mechanism the catacombs drawer uses, so the keyboard Return key and the controller B button both work without further wiring.
- The shrine dialogue and its interaction help are now named (`shrine_dialogue`, `shrine_help_take`) so the script can address them. `shrine_help_take` gained the `Take` / `key_return` row, and `shrine_help_examine` is the Examine-only variant that takes over once the eyes are gone.
- New `rubies_acquired` message box.

`data/level-graveyard/level.lua`
- `initShrine`, `setOwlEyesPresent`, `takeOwlEyes` and the two `mechanismEvent` branches. The setup runs on the first `update` rather than in `initialize`, because `LevelScript::setup` calls `luaInitialize` before `setSearchMechanismCallback` is installed, so no mechanism lookup works that early.

`data/locale/en.json`
- One new key for the acquired message.

## Testing

Driven headed against `build_rel` with screenshots plus frame-brightness sampling, since the lightning is what the storm looks like from the outside.

Fresh entry, walking up to the shrine:
- eyes glowing, HUD shows Take and Examine
- frame brightness spread 0.13 over 8s, so no lightning at all

Pressing the action button:
- eyes gone, rubies in the HUD slot, "You have acquired the Rubies"
- the Take hint drops away, Examine stays

After the box is acknowledged:
- brightness spread 6.81, storm running

Separate run with `gems` pre-seeded into `savestate.json` and no pickup at all:
- sockets already empty, no Take hint, storm already flashing (spread 13.33)

No mechanism lookup errors in the log in either run.

## Known follow-up

The Examine dialogue still says "Its eyes are made of gems..." after they have been taken. No second text was written for this, and the inscription below it is a puzzle clue, so the wording is left to a follow-up - `shrine_dialogue` is named now, so swapping in a post-pickup variant is a two-line change.
