### PR TITLE
cull lights by what reaches the view, not by distance to the player

### DIFF
--- a/src/game/effects/lightsystem.cpp
+++ b/src/game/effects/lightsystem.cpp
@@ -453,17 +453,22 @@ void LightSystem::updateActiveLights()
    _active_lights.clear();
 
    auto* player_body = PlayerRegistry::getFirst()->getBody();
+   const auto& level_view = *LevelRegistry::getCurrent()->getLevelView();
 
    for (const auto& light : _lights)
    {
-      if (!light->_enabled)
+      if (!light->_enabled || !light->_sprite)
       {
          continue;
       }
 
-      // don't draw lights that are too far away
-      auto distanceToPlayer = (player_body->GetWorldCenter() - light->_pos_m).LengthSquared();
-      if (distanceToPlayer > max_distance_m2)
+      // a light can only change a pixel where its own sprite lands, so whether that sprite reaches
+      // the view is what decides if it is live. clipViewToLight is the same test draw runs per
+      // light, which is the point of reusing it: anything that fails here would have been skipped
+      // there anyway, except there it has already taken one of the six channels and drawn nothing.
+      // distance to the player is not a substitute - the camera leads the player and clamps to
+      // rooms, so a light behind the camera can sit closer than one that is actually on screen
+      if (!clipViewToLight(level_view, light->_sprite->getGlobalBounds()).has_value())
       {
          continue;
       }

--- a/src/game/effects/lightsystem.h
+++ b/src/game/effects/lightsystem.h
@@ -97,7 +97,8 @@ public:
    /// \return newly created light instance with default smooth texture overridden by json values.
    static std::shared_ptr<LightSystem::LightInstance> createLightInstance(GameNode* parent, const nlohmann::json& node);
 
-   /// \brief picks the lights that will be drawn this frame, closest to the player first.
+   /// \brief picks the lights that will be drawn this frame: those whose sprite reaches the view,
+   ///        closest to the player first.
    ///
    /// Split out of draw so the rest of the frame can ask which lights are live before the light map
    /// is rendered: the light map pass runs after the level layers, but the layers already need to


### PR DESCRIPTION
## Rule

Every light that reaches the screen should be rendered. Nothing else should take a channel.

## Problem

`LightSystem::updateActiveLights` picked the frame's lights by distance to the player:

```cpp
auto distanceToPlayer = (player_body->GetWorldCenter() - light->_pos_m).LengthSquared();
if (distanceToPlayer > max_distance_m2)
```

That is not the same question. The camera leads the player and clamps to rooms, so a light behind the camera can sit closer to the player than one that is actually on screen. The survivors were sorted by that distance and truncated to the six channels the two light maps provide.

`draw` then applied the real test, too late:

```cpp
const auto clipped_view = clipViewToLight(full_view, light->_sprite->getGlobalBounds());
if (!clipped_view.has_value())
{
   channel_index++;
   continue;
}
```

An off-screen light that won a channel consumed it and rendered nothing. Four lights could be visible with only two of them lit.

Off-screen winners also entered `_active_light_bounds_px`, which clips the normal pass at `level.cpp:1258`, so that pass covered area no light would read.

## Change

Cull on the predicate `draw` already uses, so the two cannot disagree:

```cpp
if (!clipViewToLight(level_view, light->_sprite->getGlobalBounds()).has_value())
{
   continue;
}
```

`clipViewToLight` already lived in the anonymous namespace directly above `updateActiveLights`; this is reuse, not new geometry code.

The closest-to-player sort is unchanged - it now only orders lights that are genuinely on screen. `max_distance_m2` is unchanged too, still culling shadow casters at lines 163/225/259.

Ordering is safe: `updateSpritePositions` runs once per frame before draw and calls `updateViewsForDraw()` first, so sprite bounds and `_level_view` are both the interpolated draw-frame values when this runs.

## Effect

The six channels now always go to lights that reach the screen, so a level renders the lights that were placed in it. Lights are no longer dropped for being far from the player when the camera is elsewhere - cutscenes, panning, the player dead and sinking - or for being large enough that their glow reaches the screen from further out.

This does not raise the cap. Past six lights on screen the sort still decides and the rest go dark.

## Testing

Desktop Release builds clean, no new warnings. Not yet run on hardware.
