### PR TITLE
flash the screen when the player picks up the sword

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,8 @@ set(GAME_FILES
     src/game/effects/fadetransitioneffect.h
     src/game/effects/lightsystem.cpp
     src/game/effects/lightsystem.h
+    src/game/effects/screenflash.cpp
+    src/game/effects/screenflash.h
     src/game/effects/screentransition.cpp
     src/game/effects/screentransition.h
     src/game/effects/screentransitioneffect.cpp

--- a/data/level-catacombs/level.lua
+++ b/data/level-catacombs/level.lua
@@ -23,7 +23,9 @@ _delay_to_show_dive_dialogue = 1.0
 _player_intersected_with_water_block_sensor = false
 _player_wont_dive_dialogue_shown = false
 
-_sword_ring_flash_color = {r = 1.0, g = 0.6, b = 0.2}
+_sword_pickup_flash_color = {r = 255, g = 244, b = 214}
+_sword_pickup_flash_intensity = 0.55
+_sword_pickup_flash_duration_s = 0.45
 
 _pixels_per_tile = 24
 _lever_spike_camera_x_offset_tiles = 11
@@ -417,6 +419,13 @@ function playerReceivedExtra(extra)
    -- enable all blocking rects once player picked up diving suit
    if (extra == "sword") then
       giveWeaponSword()
+      flashScreen(
+         _sword_pickup_flash_color.r,
+         _sword_pickup_flash_color.g,
+         _sword_pickup_flash_color.b,
+         _sword_pickup_flash_intensity,
+         _sword_pickup_flash_duration_s
+      )
    end
    
    if (extra == "handle") then
@@ -463,8 +472,6 @@ function playerCollidesWithSensorRect(rect_id)
       _player_intersected_with_monk_rect = true
    elseif (rect_id == "water_block_sensor_01") then
       _player_intersected_with_water_block_sensor = true
-   elseif (rect_id == "sword_ring_sensor") then
-      flashMechanism("sword_ring", _sword_ring_flash_color.r, _sword_ring_flash_color.g, _sword_ring_flash_color.b, 0.4)
    end
 end
 

--- a/src/game/effects/screenflash.cpp
+++ b/src/game/effects/screenflash.cpp
@@ -1,0 +1,76 @@
+#include "screenflash.h"
+
+#include "framework/easings/easings.h"
+#include "game/config/gameconfiguration.h"
+
+#ifdef DECEPTUS_VRSFML
+#include <span>
+#endif
+
+ScreenFlash& ScreenFlash::getInstance()
+{
+   static ScreenFlash instance;
+   return instance;
+}
+
+void ScreenFlash::flash(const sf::Color& color, float peak_intensity, float duration_s)
+{
+   _color = color;
+   _peak_intensity = peak_intensity;
+   _duration_s = duration_s;
+   _elapsed_s = 0.0f;
+   _intensity = peak_intensity;
+}
+
+void ScreenFlash::update(const sf::Time& dt)
+{
+   if (_duration_s <= 0.0f)
+   {
+      return;
+   }
+
+   _elapsed_s += dt.asSeconds();
+
+   if (_elapsed_s >= _duration_s)
+   {
+      _duration_s = 0.0f;
+      _intensity = 0.0f;
+      return;
+   }
+
+   // an impact flash is at full strength on the frame it is triggered and then drops away quickly,
+   // so the fade-out eases out rather than running down linearly
+   _intensity = _peak_intensity * (1.0f - Easings::easeOutCubic<float>(_elapsed_s / _duration_s));
+}
+
+void ScreenFlash::draw(const std::shared_ptr<sf::RenderTexture>& target)
+{
+   if (_intensity <= 0.0f)
+   {
+      return;
+   }
+
+   const auto width = static_cast<float>(GameConfiguration::getInstance()._view_width);
+   const auto height = static_cast<float>(GameConfiguration::getInstance()._view_height);
+
+   auto color = _color;
+   color.a = static_cast<uint8_t>(_intensity * 255.0f);
+
+   const std::array<sf::Vertex, 4> vertices{
+      sf::Vertex{{0.0f, 0.0f}, color},
+      sf::Vertex{{0.0f, height}, color},
+      sf::Vertex{{width, 0.0f}, color},
+      sf::Vertex{{width, height}, color}
+   };
+
+#ifdef DECEPTUS_VRSFML
+   const sf::View view = sf::View::fromRect(sf::FloatRect{{0.0f, 0.0f}, {width, height}});
+   target->draw(
+      std::span<const sf::Vertex>{vertices.data(), vertices.size()}, sf::PrimitiveType::TriangleStrip, sf::RenderStates{.view = view}
+   );
+#else
+   const sf::View view(sf::FloatRect({0.0f, 0.0f}, {width, height}));
+   target->setView(view);
+   target->draw(vertices.data(), vertices.size(), sf::PrimitiveType::TriangleStrip);
+#endif
+}

--- a/src/game/effects/screenflash.h
+++ b/src/game/effects/screenflash.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <SFML/Graphics.hpp>
+
+#include <array>
+#include <memory>
+
+/// \brief draws a short full-screen colour flash over the level.
+/// \details deliberately not a ScreenTransitionEffect: those set Display::ScreenTransition, which
+///          forces the player into an idle animation for as long as they run.
+class ScreenFlash
+{
+public:
+   /// \brief returns the global screen flash instance.
+   static ScreenFlash& getInstance();
+
+   /// \brief starts a flash, replacing whatever was running.
+   /// \param color flash color.
+   /// \param peak_intensity opacity the flash starts at, 0-1.
+   /// \param duration_s time the flash needs to fade out completely.
+   void flash(const sf::Color& color, float peak_intensity, float duration_s);
+
+   /// \brief advances the fade-out.
+   /// \param dt elapsed frame time.
+   void update(const sf::Time& dt);
+
+   /// \brief draws the full-screen quad if a flash is running.
+   /// \param target render texture that receives the overlay.
+   void draw(const std::shared_ptr<sf::RenderTexture>& target);
+
+private:
+   ScreenFlash() = default;
+
+   sf::Color _color{sf::Color::White};  //!< color the screen is flashed with
+   float _peak_intensity{0.0f};         //!< opacity at the start of the flash, 0-1
+   float _duration_s{0.0f};             //!< total fade-out duration; 0 means no flash is running
+   float _elapsed_s{0.0f};              //!< time since the flash was triggered
+   float _intensity{0.0f};              //!< current opacity, 0-1
+};

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -18,6 +18,7 @@
 #include "game/debug/debugdrawstates.h"
 #include "game/debug/mechanismschemawriter.h"
 #include "game/effects/fadetransitioneffect.h"
+#include "game/effects/screenflash.h"
 #include "game/effects/screentransition.h"
 #include "game/event/eventdistributor.h"
 #include "game/level/level.h"
@@ -807,6 +808,7 @@ void Game::draw()
    _screenshot = false;
 
    ScreenTransitionHandler::getInstance().draw(_window_render_texture);
+   ScreenFlash::getInstance().draw(_window_render_texture);
 
 #ifdef DEVELOPMENT_MODE
    _draw_section_timer.mark("post processing resolve");
@@ -1134,6 +1136,7 @@ void Game::update()
 
    // update screen transitions here
    ScreenTransitionHandler::getInstance().update(dt);
+   ScreenFlash::getInstance().update(dt);
 
    // reload the level when the save state has been invalidated, that means when a state is selected from the menu
    if (SaveState::getCurrent()._load_level_requested)

--- a/src/game/level/levelscript.cpp
+++ b/src/game/level/levelscript.cpp
@@ -12,6 +12,7 @@
 #include "game/constants.h"
 #include "game/effects/fadetransitioneffect.h"
 #include "game/effects/lightsystem.h"
+#include "game/effects/screenflash.h"
 #include "game/effects/screentransition.h"
 #include "game/effects/screentransitioneffect.h"
 #include "game/io/eventserializer.h"
@@ -176,6 +177,7 @@ void LevelScript::setup(const std::filesystem::path& path)
    lua_register(_lua_state, "setMechanismEnabled", LevelScriptCallbacks::setMechanismEnabled);
    lua_register(_lua_state, "setMechanismVisible", LevelScriptCallbacks::setMechanismVisible);
    lua_register(_lua_state, "flashMechanism", LevelScriptCallbacks::flashMechanism);
+   lua_register(_lua_state, "flashScreen", LevelScriptCallbacks::flashScreen);
    lua_register(_lua_state, "setAmbient", LevelScriptCallbacks::setAmbient);
    lua_register(_lua_state, "setZoomFactor", LevelScriptCallbacks::setZoomFactor);
    lua_register(_lua_state, "showDialogue", LevelScriptCallbacks::showDialogue);
@@ -638,6 +640,11 @@ void LevelScript::addPlayerHealthMax(int32_t health_points_to_add)
 void LevelScript::setZoomFactor(float zoom_factor)
 {
    CameraZoom::getInstance().setZoomFactor(zoom_factor);
+}
+
+void LevelScript::flashScreen(uint8_t red, uint8_t green, uint8_t blue, float peak_intensity, float duration_s)
+{
+   ScreenFlash::getInstance().flash(sf::Color{red, green, blue}, peak_intensity, duration_s);
 }
 
 void LevelScript::setAmbient(sf::Color color)

--- a/src/game/level/levelscript.h
+++ b/src/game/level/levelscript.h
@@ -158,6 +158,14 @@ public:
    /// \param zoom_factor absolute zoom multiplier.
    void setZoomFactor(float zoom_factor);
 
+   /// \brief flashes the whole screen in a given color.
+   /// \param red red component 0-255.
+   /// \param green green component 0-255.
+   /// \param blue blue component 0-255.
+   /// \param peak_intensity opacity the flash starts at, 0-1.
+   /// \param duration_s time the flash needs to fade out completely.
+   void flashScreen(uint8_t red, uint8_t green, uint8_t blue, float peak_intensity, float duration_s);
+
    /// \brief sets the ambient light color for the current level.
    /// \param color rgba color (0–255 per channel).
    void setAmbient(sf::Color color);

--- a/src/game/level/levelscriptcallbacks.cpp
+++ b/src/game/level/levelscriptcallbacks.cpp
@@ -611,6 +611,23 @@ int32_t fadeIn(lua_State* state)
    return 0;
 }
 
+int32_t flashScreen(lua_State* state)
+{
+   if (lua_gettop(state) != 5)
+   {
+      return 0;
+   }
+
+   const auto red = static_cast<uint8_t>(lua_tointeger(state, 1));
+   const auto green = static_cast<uint8_t>(lua_tointeger(state, 2));
+   const auto blue = static_cast<uint8_t>(lua_tointeger(state, 3));
+   const auto peak_intensity = static_cast<float>(lua_tonumber(state, 4));
+   const auto duration_s = static_cast<float>(lua_tonumber(state, 5));
+
+   LevelScript::getCurrent()->flashScreen(red, green, blue, peak_intensity, duration_s);
+   return 0;
+}
+
 int32_t setAmbient(lua_State* state)
 {
    if (lua_gettop(state) != 4)

--- a/src/game/level/levelscriptcallbacks.h
+++ b/src/game/level/levelscriptcallbacks.h
@@ -21,6 +21,7 @@ int32_t isMechanismVisible(lua_State* state);
 int32_t setMechanismEnabled(lua_State* state);
 int32_t setMechanismVisible(lua_State* state);
 int32_t flashMechanism(lua_State* state);
+int32_t flashScreen(lua_State* state);
 int32_t toggle(lua_State* state);
 int32_t showDialogue(lua_State* state);
 


### PR DESCRIPTION
Adds `ScreenFlash`, a full-screen colour quad with an eased fade-out, and a `flashScreen(r, g, b, peak, duration_s)` Lua binding to trigger it.

## Why it is not a ScreenTransitionEffect

`FadeTransitionEffect` already draws full-screen colour quads, but `ScreenTransition::startEffect1` sets `Display::ScreenTransition` — and `PlayerAnimation::processScreenTransitionIdleAnimation` forces the player into an idle pose for as long as that flag is set. A short flash would snap him out of a run mid-stride.

`ScreenFlash` is standalone, drawn straight after the transition handler in `Game::draw` (so it covers the level but sits under the HUD) and touches no display state.

## First user

The catacombs sword pickup. The ring's old proximity flash on `sword_ring_sensor` goes away with it — `RingShaderLayer::flash()` itself is untouched and stays available.

## Testing

Builds and links clean (MSVC, C++23, `/W4`). Not yet seen running.