### PR TITLE
offer time_offset_s on the ring too

### DIFF
--- a/data/templates/ring_shader_quad.tx
+++ b/data/templates/ring_shader_quad.tx
@@ -17,6 +17,7 @@
    <property name="ring_scale" type="float" value="0.052083"/>
    <property name="smooth_texture" type="bool" value="true"/>
    <property name="texture" value="data/effects/grainy.png"/>
+   <property name="time_offset_s" type="float" value="0"/>
    <property name="touch_depth" type="float" value="0.22"/>
    <property name="touch_release_s" type="float" value="0.35"/>
    <property name="touch_width" type="float" value="0.55"/>

--- a/deceptus.tiled-project
+++ b/deceptus.tiled-project
@@ -1059,6 +1059,11 @@
                     "value": "data/effects/grainy.png"
                 },
                 {
+                    "name": "time_offset_s",
+                    "type": "float",
+                    "value": 0.0
+                },
+                {
                     "name": "touch_depth",
                     "type": "float",
                     "value": 0.2199999988079071

--- a/doc/level_design/mechanisms.md
+++ b/doc/level_design/mechanisms.md
@@ -1222,7 +1222,11 @@ does not cost a large amount of fill.
 |power_down_s|float|Seconds the ring takes to expand away and fade once the mechanism is disabled.|
 
 The usual shader quad properties apply as well: `fragment_shader`, `vertex_shader`, `texture`,
-`smooth_texture` and `z`.
+`smooth_texture`, `time_offset_s` and `z`.
+
+`uv_width` and `uv_height` are deliberately not offered here. A ring reads its texture coordinate
+as a normalised screen position rather than as a lookup into a texture, so scaling it moves and
+stretches the ring instead of doing anything useful.
 
 ### Contact
 

--- a/src/game/mechanisms/ringshaderlayer.cpp
+++ b/src/game/mechanisms/ringshaderlayer.cpp
@@ -59,6 +59,7 @@ static constexpr std::array ring_shader_quad_properties{
       .template_value = std::string_view{"data/effects/grainy.png"}
    },
    PropertyInfo{.name = "smooth_texture", .type = "bool", .default_value = false, .template_value = true},
+   PropertyInfo{.name = "time_offset_s", .type = "float", .default_value = 0.0f},
    PropertyInfo{.name = "z", .type = "int", .default_value = int32_t{20}},
 
    // the band sits at 14/12 in ring space, so its radius on screen is


### PR DESCRIPTION
Follow-up to #482, from auditing the ring's schema in the other direction.

All twenty declared properties **are** read by the code, so nothing in the schema is decoration. But three properties that do work on a shader quad were missing from the ring's list.

- **`time_offset_s`** belongs there — it shifts the shader clock, so two rings in one level don't have to beat in lockstep. Added to the schema, the generated template and the docs.
- **`uv_width` / `uv_height`** stay out deliberately. A ring reads its texture coordinate as a normalised screen position rather than as a lookup into a texture, so scaling it moves and stretches the ring instead of doing anything useful. The doc now says so rather than leaving the next person to discover it.

`deceptus.tiled-project` and `ring_shader_quad.tx` are regenerated output, not hand-edited.