### PR TITLE
re-equip items on the drawing thread, not in the level loader

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -437,6 +437,19 @@ void Game::loadLevel(LoadingMode loading_mode)
 
 void Game::processPendingLevelLoad()
 {
+   // Re-equip items now that level and player are both live; items deserialized before the level was
+   // ready (e.g. head torch) had their onEquipped() silently no-op at that point.
+   //
+   // Equipping an item creates and destroys GL objects of its own, and unlike a mechanism's those
+   // belong to the item rather than to the level, so they outlive it. That puts them under the same
+   // rule as the teardown below: the thread that owns the drawing context does that work, never the
+   // loader thread with its own context.
+   if (_level_loading_finished && _equipped_items_reinit_pending)
+   {
+      _equipped_items_reinit_pending = false;
+      SaveState::getPlayerInfo()._items.reinitializeEquippedItems();
+   }
+
    if (!_pending_level_load.has_value())
    {
       return;
@@ -508,9 +521,8 @@ void Game::processPendingLevelLoad()
          _player->setWorld(_level->getWorld());
          _player->initializeLevel();
 
-         // re-equip items now that level and player are both live; items deserialized before the
-         // level was ready (e.g. head torch) had their onEquipped() silently no-op at that point
-         SaveState::getPlayerInfo()._items.reinitializeEquippedItems();
+         // the re-equip itself runs on the drawing thread, see processPendingLevelLoad
+         _equipped_items_reinit_pending = true;
 
          // jump back to stored position, that's only for debugging purposes, not for checkpoints
          if (_restore_previous_position)

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -228,6 +228,7 @@ private:
    std::atomic<bool> _level_loading_finished = false;
    std::atomic<bool> _level_loading_finished_previous = false;  // keep track of level loading in an async manner
    std::future<void> _level_loading_thread;
+   std::atomic<bool> _equipped_items_reinit_pending = false;  //!< set by the loader, consumed on the drawing thread
    std::vector<std::function<void()>> _level_loaded_callbacks;
    bool _restore_previous_position = false;
    sf::Vector2f _stored_position;


### PR DESCRIPTION
## the crash

A hard crash when walking through a level transition with the head torch equipped. It always lands on the first frame after the new level reports `level loading finished`, in the second transition of a session:

```
nvoglv64+0x58fa60                      <- reads freed heap (0xfeeefeee)
sf::Shader::getUniformLocation          Shader.cpp:982
sf::Shader::setUniform                  Shader.cpp:660
sfcompat::Shader::setUniform            sfmlshader.h:103
LightSystem::draw                       lightsystem.cpp:676
Level::drawLightMap -> Level::draw
```

`lightsystem.cpp:676` is `light->_shader->setUniform("u_texture", *light->_texture)`, and `itemheadtorch.cpp` is the only place in the engine that ever sets `LightInstance::_shader`.

## why

The rule is already written down, in the comment above the teardown in `processPendingLevelLoad`: GL objects have to be created and destroyed on the thread that owns the drawing context, because the loader's own `sf::Context` frees handles that the drawing context still resolves to the old objects, and "the first draw after a reload then walks freed driver memory and dies inside `glGetUniformLocation`".

Every mechanism obeys that for free - its shaders belong to the level, and the level is torn down on the drawing thread. `ItemHeadTorch` is the one GL owner that is not part of a level: `ItemFactory::create` hands out process-lifetime statics, so the item and its `_noise_shader` outlive every level. `reinitializeEquippedItems()` sat inside the loader lambda, so `onEquipped()` deleted the shader compiled in loader context N and compiled a new one in loader context N+1.

## the change

The loader raises `_equipped_items_reinit_pending`; `processPendingLevelLoad` consumes it at the top of the next frame, on the drawing thread, still before anything draws the new level. Anything added to `ItemFactory` later that touches GL is covered by the same hook.

## verification

Six laps of graveyard <-> catacombs, driven through the debug console under `cdb`, head torch equipped:

| build | transitions survived | result |
|---|---|---|
| master | 2 | crash above |
| master, `dust.enabled=false` | 12 | clean - isolates it to the light shader |
| this branch | 12 | clean, beam still lit on the last one |

Gems in the inventory turned out to be a red herring; it reproduces with and without them, and never without the head torch.