### PR TITLE
Disable smoothing on the truetype text layer font on VRSFML too

### DIFF
--- a/src/game/mechanisms/textlayer.cpp
+++ b/src/game/mechanisms/textlayer.cpp
@@ -123,6 +123,10 @@ std::shared_ptr<TextLayer> TextLayer::deserialize(GameNode* parent, const GameDe
          const auto rgba = TmxTools::color(color);
 
 #ifdef DECEPTUS_VRSFML
+         // vrsfml creates its glyph atlas smoothed and has no Font::setSmooth to clear it with, so
+         // the texture is cleared directly. it holds one atlas of a fixed size that is never
+         // reallocated, so the filter set here is the one it keeps
+         instance->_truetype_font->getTexture().setSmooth(false);
          instance->_truetype_text = std::make_unique<sf::Text>(*instance->_truetype_font, sf::Text::Data{});
          instance->_truetype_text->position = {data._tmx_object->_x_px, data._tmx_object->_y_px};
          instance->_truetype_text->setString(instance->_text.c_str());


### PR DESCRIPTION
Follow-up to #487, found while checking whether `textlayer.cpp` had the same problem as `getFont()` did.

`TextLayer` clears smoothing on its truetype font only in the vanilla branch:

```cpp
#ifdef DECEPTUS_VRSFML
   instance->_truetype_text = std::make_unique<sf::Text>(*instance->_truetype_font, sf::Text::Data{});
#else
   instance->_truetype_font.setSmooth(false);   // vanilla only
```

vrsfml creates its glyph atlas with `smooth = true` and has no `Font::setSmooth` to clear it with, so the same text layer would have rendered soft on the switch and in the browser and crisp on the desktop. The texture is cleared directly instead, which is enough there: vrsfml holds one atlas of a fixed size that is never reallocated.

Worth saying plainly: **nothing shows this today.** No level sets a `truetype_font` property, so the branch is unreached in shipped content. This lands now so the two paths do not drift further apart before something does reach it.

Also of note, the vanilla branch here was already using the font level `setSmooth` — the correct one, and the very call `getFont()` was missing in #487. So the desktop path never had the blur bug.