### PR TITLE
Include vector in the logging headers

### DIFF
--- a/src/framework/tools/log.cpp
+++ b/src/framework/tools/log.cpp
@@ -6,6 +6,7 @@
 #include <iomanip>
 #include <iostream>
 #include <source_location>
+#include <vector>
 
 #ifdef _WIN32
 #include <windows.h>

--- a/src/framework/tools/logthread.h
+++ b/src/framework/tools/logthread.h
@@ -8,6 +8,7 @@
 #include <source_location>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include "log.h"
 

--- a/src/game/mechanisms/gamemechanismobserver.h
+++ b/src/game/mechanisms/gamemechanismobserver.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <string>
 #include <variant>
+#include <vector>
 
 #include "framework/tools/log.h"
 

--- a/src/game/mechanisms/portal.h
+++ b/src/game/mechanisms/portal.h
@@ -11,6 +11,7 @@
 #include "box2d/box2d.h"
 
 // std
+#include <atomic>
 #include <filesystem>
 
 struct TmxLayer;


### PR DESCRIPTION
Master is red on macOS. The merge commit of #487 (`078e895a`) fails:

```
log.cpp:24:36: error: implicit instantiation of undefined template
  'std::vector<std::function<void (..., Log::Level, ...)>>'
log.cpp:25:33: error: implicit instantiation of undefined template 'std::vector<std::function<void ()>>'
```

`log.cpp` declares two `std::vector` callback lists and `logthread.h` a `std::vector<LogItem>` member; neither includes `<vector>`. Both relied on some other header leaking it. The runner is `macos-latest`, an auto-updating image whose libc++ stopped doing that — `callbackmap.h` went the same way yesterday and was fixed in #487.

`logthread.h` is not what the build tripped over yet, but it is the same subsystem with the same omission and would have been next.

## This is a wider latent problem

A scan of `src/` finds **119 places** that name a container without including its header — 97 `<vector>`, 12 `<array>`, 10 `<map>` — spread across the tmxparser, the mechanisms, the player and the menus. Most compile today only because SFML or a project header happens to pull the container in, which is exactly what just stopped being true on one platform.

I have deliberately **not** touched those here: this PR fixes what is breaking the build, nothing more. Worth deciding separately whether to run include-what-you-use over the tree, because the next libc++ or SFML bump will surface more of them one CI round at a time.