### PR TITLE
Include vector in gamestate.h

### DIFF
--- a/src/game/state/gamestate.h
+++ b/src/game/state/gamestate.h
@@ -4,6 +4,7 @@
 
 #include <functional>
 #include <mutex>
+#include <vector>
 
 /// \brief tracks current and queued game execution modes and notifies listeners on changes.
 class GameState


### PR DESCRIPTION
Master is still red on macOS after #489:

```
src/game/state/gamestate.h:64:9: error: no template named 'vector' in namespace 'std'
```

Same omission as `log.cpp`, `logthread.h`, `gamemechanismobserver.h` and `portal.h` before it. One line.

**This will keep happening.** The updated `macos-latest` libc++ no longer leaks `<vector>` through other headers, and a scan of `src/` finds ~97 more files that name `std::vector` without including it. They surface one per CI round because compilation stops at the first bad translation unit. Worth doing a single deliberate pass rather than this drip — see the note on #489.