### PR TITLE
levelscript: check the player rect in isPlayerIntersectingSensorRect

### DIFF
--- a/data/level-catacombs/level.lua
+++ b/data/level-catacombs/level.lua
@@ -519,12 +519,13 @@ function playerUsedItem(item)
 
    -- when sensor rect flag set and key is used on locker, then change
    if (item == "locker_key") then
-      local player_in_front_of_locker = isPlayerIntersectingSensorRect("locker_sensor")
-      log(player_in_front_of_locker and "true" or "false")
-      if (player_in_front_of_locker) then
-         openLocker()
-         inventoryRemove("locker_key")
+      -- the key only does something at the locker, so it stays unused everywhere else
+      if (not isPlayerIntersectingSensorRect("locker_sensor")) then
+         return false
       end
+
+      openLocker()
+      inventoryRemove("locker_key")
       return true
    end
 

--- a/src/game/level/levelscript.cpp
+++ b/src/game/level/levelscript.cpp
@@ -597,16 +597,29 @@ bool LevelScript::isPlayerIntersectingSensorRect(const std::string& mechanism_id
 {
    auto mechanisms = _search_mechanism_callback(mechanism_id, "sensor_rects");
 
-   auto mechanism_it = std::ranges::find_if(
+   const auto& player_rect_px = PlayerRegistry::getFirst()->getPixelRectFloat();
+
+   // the search is regex based, so more than one sensor rect can come back; only the one that
+   // actually carries the requested object id is asked whether the player is inside it
+   return std::ranges::any_of(
       mechanisms,
-      [&mechanism_id](const auto& mechanism)
+      [&mechanism_id, &player_rect_px](const auto& mechanism)
       {
          auto* game_node = dynamic_cast<GameNode*>(mechanism.get());
-         return (game_node && game_node->getObjectId() == mechanism_id);
+         if (!game_node || game_node->getObjectId() != mechanism_id)
+         {
+            return false;
+         }
+
+         const auto& rect_px = mechanism->getBoundingBoxPx();
+         if (!rect_px.has_value())
+         {
+            return false;
+         }
+
+         return sfcompat::findIntersection(player_rect_px, rect_px.value()).has_value();
       }
    );
-
-   return mechanism_it != mechanisms.end();
 }
 
 void LevelScript::toggle(const std::string& search_pattern, const std::optional<std::string>& group)


### PR DESCRIPTION
## Problem

`LevelScript::isPlayerIntersectingSensorRect` never checked intersection. It searched the `sensor_rects` group for a mechanism with the requested object id and returned whether it **exists** — always true for any sensor rect that is in the level.

So the guard in the catacombs script was a no-op:

```lua
if (item == "locker_key") then
   local player_in_front_of_locker = isPlayerIntersectingSensorRect("locker_sensor")
   ...
```

The locker key could be used anywhere in the level: it opened the locker from across the map and was removed from the inventory.

## Fix

The query now intersects the player rect with the bounding box of the sensor rect that carries the requested object id. The regex-based mechanism search can return more than one match, so the object id is still compared exactly.

The live intersection test is used rather than `SensorRect::playerIntersects()`, because that cached flag only refreshes while the sensor's chunk is being updated — it can go stale if the player leaves the area without a nearby update. This also matches how `Lever` and `InteractionHelp` do their player checks.

## Also

`playerUsedItem` in the catacombs script returned `true` for `locker_key` even when the guard failed. `Inventory::use` reads that as "the item was used" and removes the item if it has a `consumed_after_use` property. `locker_key` has no such property today, so this was latent, but the handler now returns `false` unless the player is actually at the locker.

## Testing

- `cmake --build build_rel --target deceptus` — compiles and links clean.
- Other caller of this binding in catacombs is the sword ring (`sword_ring_sensor`), which was also receiving an unconditional true; worth a play-through check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)