### PR TITLE
Break the storm on the pickup with a scripted lightning strike

### DIFF
--- a/data/level-graveyard/graveyard.tmx
+++ b/data/level-graveyard/graveyard.tmx
@@ -1962,6 +1962,7 @@
     <property name="enabled" type="bool" value="false"/>
     <property name="sound_volume" type="float" value="0.8"/>
     <property name="sounds" value="weather_thunder_01.ogg;weather_thunder_02.ogg;weather_thunder_03.ogg;weather_thunder_04.ogg;weather_thunder_05.ogg"/>
+    <property name="thunder_delay_s" type="float" value="0.5"/>
     <property name="z" type="int" value="2"/>
    </properties>
   </object>

--- a/data/level-graveyard/level.lua
+++ b/data/level-graveyard/level.lua
@@ -5,6 +5,12 @@ _initialized = false
 -- the owl statue carries two cut rubies as eyes, and the inventory item that holds them is called "gems"
 _owl_eye_item = "gems"
 
+-- seconds left until the pickup message is shown, or nil when none is pending
+_pickup_message_delay_s = nil
+
+-- long enough for the strike to land and start decaying before the message slides in
+_pickup_message_delay_default_s = 1.5
+
 
 ------------------------------------------------------------------------------------------------------------------------
 function initialize()
@@ -56,7 +62,15 @@ function takeOwlEyes()
 
    setOwlEyesPresent(false)
    inventoryAdd(_owl_eye_item)
-   showDialogue("rubies_acquired")
+
+   -- the storm the owl was keeping asleep breaks the moment its eyes come out, on the same frame the
+   -- sockets go dark. the strike is fired through the weather mechanism rather than as a screen flash
+   -- so it looks and sounds like the storm that follows it
+   setStormActive(true)
+   strikeThunderMechanism("thunderstorm", 1.0, "weather")
+
+   -- the pickup message is the same one every item shows, it just waits for the thunder
+   _pickup_message_delay_s = _pickup_message_delay_default_s
 end
 
 
@@ -66,6 +80,14 @@ function update(dt)
    if (not _initialized) then
       _initialized = true
       initShrine()
+   end
+
+   if (_pickup_message_delay_s ~= nil) then
+      _pickup_message_delay_s = _pickup_message_delay_s - dt
+      if (_pickup_message_delay_s <= 0.0) then
+         _pickup_message_delay_s = nil
+         showDialogue("rubies_acquired")
+      end
    end
 end
 
@@ -77,10 +99,6 @@ function mechanismEvent(object_id, group_id, event_name, value)
       takeOwlEyes()
    end
 
-   -- the storm the owl was keeping asleep breaks loose once the player has read that he owns the rubies
-   if (object_id == "rubies_acquired" and event_name == "dismissed") then
-      setStormActive(true)
-   end
 end
 
 

--- a/data/level-graveyard/level.lua
+++ b/data/level-graveyard/level.lua
@@ -67,7 +67,7 @@ function takeOwlEyes()
    -- sockets go dark. the strike is fired through the weather mechanism rather than as a screen flash
    -- so it looks and sounds like the storm that follows it
    setStormActive(true)
-   strikeThunderMechanism("thunderstorm", 1.0, "weather")
+   strikeThunderMechanism("thunderstorm", "weather_thunder_02.ogg", 1.0, "weather")
 
    -- the pickup message is the same one every item shows, it just waits for the thunder
    _pickup_message_delay_s = _pickup_message_delay_default_s

--- a/data/templates/weather.tx
+++ b/data/templates/weather.tx
@@ -6,7 +6,7 @@
    <property name="enabled" type="bool" value="true"/>
    <property name="limit_effect_to_room" type="bool" value="false"/>
    <property name="sound_volume" type="float" value="1"/>
-   <property name="thunder_delay_s" type="float" value="0.5"/>
+   <property name="thunder_delay_s" type="float" value="0"/>
    <property name="z" type="int" value="20"/>
   </properties>
  </object>

--- a/data/templates/weather.tx
+++ b/data/templates/weather.tx
@@ -6,6 +6,7 @@
    <property name="enabled" type="bool" value="true"/>
    <property name="limit_effect_to_room" type="bool" value="false"/>
    <property name="sound_volume" type="float" value="1"/>
+   <property name="thunder_delay_s" type="float" value="0.5"/>
    <property name="z" type="int" value="20"/>
   </properties>
  </object>

--- a/deceptus.tiled-project
+++ b/deceptus.tiled-project
@@ -1991,6 +1991,11 @@
                     "value": 1.0
                 },
                 {
+                    "name": "thunder_delay_s",
+                    "type": "float",
+                    "value": 0.5
+                },
+                {
                     "name": "z",
                     "type": "int",
                     "value": 20

--- a/deceptus.tiled-project
+++ b/deceptus.tiled-project
@@ -1993,7 +1993,7 @@
                 {
                     "name": "thunder_delay_s",
                     "type": "float",
-                    "value": 0.5
+                    "value": 0.0
                 },
                 {
                     "name": "z",

--- a/doc/level_design/visual_effects.md
+++ b/doc/level_design/visual_effects.md
@@ -373,10 +373,15 @@ Thunderstorms have the custom properties below:
 |-|-|-|
 |thunderstorm_time_s|float|The duration of the lightning phase. The default is `3s`.|
 |silence_time_s|float|The duration for everything to be 'quiet', i.e. from one lightning phase to the other (given in seconds). The default is `5s`.|
-|sounds|string|A list of samples from `data/sounds`, separated by semicolons, such as `weather_thunder_01.ogg;weather_thunder_02.ogg`. Every time a lightning phase starts, one of them is picked at random. When the property is omitted, the thunderstorm stays silent.|
+|sounds|string|A list of samples from `data/sounds`, separated by semicolons, such as `weather_thunder_01.ogg;weather_thunder_02.ogg`. Every time a lightning phase starts, one of them is picked at random, never the same one twice in a row. When the property is omitted, the thunderstorm stays silent.|
 |sound_volume|float|Volume multiplier for the picked thunder sample. The default is `1.0`.|
+|thunder_delay_s|float|How long the thunder trails its flash, in seconds. The default is `0`, which lands them together.|
 
-The thunder is played the moment a lightning phase begins, which is roughly 50-70ms before the flash becomes visible on screen, so both land together. Bear in mind that the samples you pick decide how well this works: a sample whose loudest moment is two seconds in will still be building up while the flash is already over. Pick samples that crack right at the start, or trim the build-up from them.
+By default the thunder is played the moment a lightning phase begins, which is roughly 50-70ms before the flash becomes visible on screen, so both land together. Bear in mind that the samples you pick decide how well this works: a sample whose loudest moment is two seconds in will still be building up while the flash is already over. Pick samples that crack right at the start, or trim the build-up from them.
+
+Set `thunder_delay_s` when you want the storm to feel further away instead. Light outruns sound by roughly 300m for every second of delay, so half a second reads as a strike a few streets over and three seconds as one on the horizon. It applies to every strike in that region, the scripted ones included.
+
+A level script can fire a single strike on demand with `strikeThunderMechanism`, naming the sample and its volume - see `doc/level_scripts/readme.md`. That is how a story beat gets its thunder on cue rather than waiting for the next lightning phase.
 
 ![](images/weather_thunderstorm_1.png) &nbsp;&nbsp; ![](images/weather_thunderstorm_2.png)
 

--- a/doc/level_scripts/readme.md
+++ b/doc/level_scripts/readme.md
@@ -274,6 +274,28 @@ Triggers a colour flash on all matching `RingShaderLayer` mechanisms.
 |5|float|Fade-out duration in seconds|
 
 
+## `strikeThunderMechanism`
+
+Fires one lightning strike on all matching `Weather` mechanisms that are thunderstorms, instead of
+waiting for the storm's own silence phase to elapse. The flash is snapped to full rather than ramped
+in over the fifth of a second the ambient strikes take, so a scripted strike reads as a crack rather
+than a swell.
+
+The strike is only seen on an *enabled* mechanism: `Weather::draw` and `Weather::update` both return
+early while it is disabled, so the flash would neither be drawn nor decay. Enable the storm first.
+
+|Parameter Position|Type|Description|
+|-|-|-|
+|1|string|Mechanism search pattern (regular expression)|
+|2|float|Thunder sample volume (optional, defaults to the object's `sound_volume`)|
+|3|string|Mechanism group (optional)|
+
+```lua
+setMechanismEnabled("thunderstorm", true, "weather")
+strikeThunderMechanism("thunderstorm", 1.0, "weather")
+```
+
+
 ## `getMechanismRect`
 
 Returns the bounding rectangle of the first mechanism matching the search pattern, or `nil` if none is found.

--- a/doc/level_scripts/readme.md
+++ b/doc/level_scripts/readme.md
@@ -304,9 +304,8 @@ strikeThunderMechanism("thunderstorm", "weather_thunder_02.ogg", 1.0, "weather")
 strikeThunderMechanism("thunderstorm", nil, 1.0, "weather")
 ```
 
-The thunder does not play on the same frame as the flash. It follows after the weather object's
-`thunder_delay_s` (0.5s by default), because light outruns sound, and an instant crack reads as a
-sound effect rather than as weather.
+The thunder follows the flash by the weather object's `thunder_delay_s`, which is `0` by default so
+the two land together. Set it on the object when the strike should read as distant.
 
 
 ## `getMechanismRect`

--- a/doc/level_scripts/readme.md
+++ b/doc/level_scripts/readme.md
@@ -295,6 +295,10 @@ setMechanismEnabled("thunderstorm", true, "weather")
 strikeThunderMechanism("thunderstorm", 1.0, "weather")
 ```
 
+The thunder does not play on the same frame as the flash. It follows after the weather object's
+`thunder_delay_s` (0.5s by default), because light outruns sound, and an instant crack reads as a
+sound effect rather than as weather.
+
 
 ## `getMechanismRect`
 

--- a/doc/level_scripts/readme.md
+++ b/doc/level_scripts/readme.md
@@ -287,12 +287,21 @@ early while it is disabled, so the flash would neither be drawn nor decay. Enabl
 |Parameter Position|Type|Description|
 |-|-|-|
 |1|string|Mechanism search pattern (regular expression)|
-|2|float|Thunder sample volume (optional, defaults to the object's `sound_volume`)|
-|3|string|Mechanism group (optional)|
+|2|string|Thunder sample to play (optional, `nil` picks one at random)|
+|3|float|Thunder sample volume (optional, defaults to the object's `sound_volume`)|
+|4|string|Mechanism group (optional)|
+
+The named sample has to be one of the weather object's configured `sounds` — those are the ones that
+were preloaded. Naming anything else logs a warning and falls back to a random pick. Name one when a
+scripted moment has to land a particular way; the samples differ by a lot in loudness, so a random
+pick is not interchangeable with a chosen one.
 
 ```lua
 setMechanismEnabled("thunderstorm", true, "weather")
-strikeThunderMechanism("thunderstorm", 1.0, "weather")
+strikeThunderMechanism("thunderstorm", "weather_thunder_02.ogg", 1.0, "weather")
+
+-- or leave the choice to the storm
+strikeThunderMechanism("thunderstorm", nil, 1.0, "weather")
 ```
 
 The thunder does not play on the same frame as the flash. It follows after the weather object's

--- a/src/game/layers/thunderstormoverlay.cpp
+++ b/src/game/layers/thunderstormoverlay.cpp
@@ -49,6 +49,17 @@ void ThunderstormOverlay::update(const sf::Time& dt)
 {
    _time_s += dt.asSeconds();
 
+   // the flash has already gone off; the sound of it is still on its way
+   if (_pending_thunder_s.has_value())
+   {
+      _pending_thunder_s = _pending_thunder_s.value() - dt.asSeconds();
+      if (_pending_thunder_s.value() <= 0.0f)
+      {
+         _pending_thunder_s.reset();
+         playThunder(_pending_thunder_volume);
+      }
+   }
+
    _value = fbm::fbm({_time_s, 0.0f}) * 3.0f;
 
    if (_state == State::Lightning)
@@ -82,7 +93,7 @@ void ThunderstormOverlay::update(const sf::Time& dt)
          // start lightning
          _thunderstorm_time_elapsed_s = 0.0f;
          _state = State::Lightning;
-         playThunder(std::nullopt);
+         scheduleThunder(std::nullopt);
       }
    }
 }
@@ -93,7 +104,13 @@ void ThunderstormOverlay::strike(const std::optional<float>& volume)
    _state = State::Lightning;
    _factor = 1.0f;
 
-   playThunder(volume);
+   scheduleThunder(volume);
+}
+
+void ThunderstormOverlay::scheduleThunder(const std::optional<float>& volume)
+{
+   _pending_thunder_s = _settings._thunder_delay_s;
+   _pending_thunder_volume = volume;
 }
 
 void ThunderstormOverlay::playThunder(const std::optional<float>& volume)
@@ -103,7 +120,18 @@ void ThunderstormOverlay::playThunder(const std::optional<float>& volume)
       return;
    }
 
-   const auto index = static_cast<size_t>(std::rand()) % _settings._sounds.size();
+   auto index = size_t{0};
+   if (_settings._sounds.size() > 1)
+   {
+      // hearing the same sample twice in a row makes the randomization look broken
+      std::uniform_int_distribution<size_t> distribution{0, _settings._sounds.size() - 1};
+      do
+      {
+         index = distribution(_random_engine);
+      } while (_previous_sound_index.has_value() && index == _previous_sound_index.value());
+   }
+
+   _previous_sound_index = index;
    Audio::getInstance().playSample({_settings._sounds[index], volume.value_or(_settings._sound_volume)});
 }
 

--- a/src/game/layers/thunderstormoverlay.cpp
+++ b/src/game/layers/thunderstormoverlay.cpp
@@ -2,8 +2,10 @@
 
 #include "framework/math/fbm.h"
 #include "framework/tmxparser/tmxobject.h"
+#include "framework/tools/log.h"
 #include "game/audio/audio.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <iostream>
 
@@ -56,7 +58,7 @@ void ThunderstormOverlay::update(const sf::Time& dt)
       if (_pending_thunder_s.value() <= 0.0f)
       {
          _pending_thunder_s.reset();
-         playThunder(_pending_thunder_volume);
+         playThunder(_pending_thunder_sample, _pending_thunder_volume);
       }
    }
 
@@ -93,31 +95,46 @@ void ThunderstormOverlay::update(const sf::Time& dt)
          // start lightning
          _thunderstorm_time_elapsed_s = 0.0f;
          _state = State::Lightning;
-         scheduleThunder(std::nullopt);
+         scheduleThunder(std::nullopt, std::nullopt);
       }
    }
 }
 
-void ThunderstormOverlay::strike(const std::optional<float>& volume)
+void ThunderstormOverlay::strike(const std::optional<std::string>& sample, const std::optional<float>& volume)
 {
    _thunderstorm_time_elapsed_s = 0.0f;
    _state = State::Lightning;
    _factor = 1.0f;
 
-   scheduleThunder(volume);
+   scheduleThunder(sample, volume);
 }
 
-void ThunderstormOverlay::scheduleThunder(const std::optional<float>& volume)
+void ThunderstormOverlay::scheduleThunder(const std::optional<std::string>& sample, const std::optional<float>& volume)
 {
    _pending_thunder_s = _settings._thunder_delay_s;
    _pending_thunder_volume = volume;
+   _pending_thunder_sample = sample;
 }
 
-void ThunderstormOverlay::playThunder(const std::optional<float>& volume)
+void ThunderstormOverlay::playThunder(const std::optional<std::string>& sample, const std::optional<float>& volume)
 {
    if (_settings._sounds.empty())
    {
       return;
+   }
+
+   // a named sample has to be one of the configured ones, those are the ones that were preloaded
+   if (sample.has_value())
+   {
+      const auto named = std::ranges::find(_settings._sounds, sample.value());
+      if (named != _settings._sounds.end())
+      {
+         _previous_sound_index = static_cast<size_t>(std::distance(_settings._sounds.begin(), named));
+         Audio::getInstance().playSample({*named, volume.value_or(_settings._sound_volume)});
+         return;
+      }
+
+      Log::Warning() << "thunder sample '" << sample.value() << "' is not one of this weather object's sounds";
    }
 
    auto index = size_t{0};

--- a/src/game/layers/thunderstormoverlay.cpp
+++ b/src/game/layers/thunderstormoverlay.cpp
@@ -82,12 +82,21 @@ void ThunderstormOverlay::update(const sf::Time& dt)
          // start lightning
          _thunderstorm_time_elapsed_s = 0.0f;
          _state = State::Lightning;
-         playThunder();
+         playThunder(std::nullopt);
       }
    }
 }
 
-void ThunderstormOverlay::playThunder()
+void ThunderstormOverlay::strike(const std::optional<float>& volume)
+{
+   _thunderstorm_time_elapsed_s = 0.0f;
+   _state = State::Lightning;
+   _factor = 1.0f;
+
+   playThunder(volume);
+}
+
+void ThunderstormOverlay::playThunder(const std::optional<float>& volume)
 {
    if (_settings._sounds.empty())
    {
@@ -95,7 +104,7 @@ void ThunderstormOverlay::playThunder()
    }
 
    const auto index = static_cast<size_t>(std::rand()) % _settings._sounds.size();
-   Audio::getInstance().playSample({_settings._sounds[index], _settings._sound_volume});
+   Audio::getInstance().playSample({_settings._sounds[index], volume.value_or(_settings._sound_volume)});
 }
 
 void ThunderstormOverlay::setRect(const sf::FloatRect& rect)

--- a/src/game/layers/thunderstormoverlay.h
+++ b/src/game/layers/thunderstormoverlay.h
@@ -3,6 +3,7 @@
 #include "game/mechanisms/weather.h"
 
 #include <optional>
+#include <random>
 #include <string>
 #include <vector>
 
@@ -17,6 +18,7 @@ public:
    {
       float _thunderstorm_time_s = 3.0;
       float _silence_time_s = 5.0f;
+      float _thunder_delay_s = 0.5f;     //!< gap between the flash and its thunder, light outruns sound
       std::vector<std::string> _sounds;  //!< thunder samples; one is picked at random per lightning phase, empty disables audio
       float _sound_volume = 1.0f;        //!< per-sample volume multiplier applied to the picked thunder sample
    };
@@ -55,6 +57,10 @@ public:
    void strike(const std::optional<float>& volume);
 
 private:
+   /// \brief arms the thunder that belongs to a flash that has just gone off.
+   /// \param volume volume to play at, or std::nullopt for the configured sound volume.
+   void scheduleThunder(const std::optional<float>& volume);
+
    /// \brief plays one randomly picked thunder sample, if any are configured.
    /// \param volume volume to play at, or std::nullopt for the configured sound volume.
    void playThunder(const std::optional<float>& volume);
@@ -72,6 +78,15 @@ private:
    float _thunderstorm_time_elapsed_s = 0.0;
    float _silence_time_elapsed_s = 0.0f;
    State _state = State::Silence;
+
+   std::optional<float> _pending_thunder_s;       //!< time left until the armed thunder is played
+   std::optional<float> _pending_thunder_volume;  //!< volume the armed thunder was requested at
+   std::optional<size_t> _previous_sound_index;   //!< last sample played, so it is not picked twice in a row
+
+   // the global c rng is seeded by whoever ran last - StaticLight seeds it from its own tmx position
+   // during level load, which leaves it on a fixed sequence. an engine of its own keeps the sample
+   // choice actually random
+   std::mt19937 _random_engine{std::random_device{}()};
 
    ThunderstormSettings _settings;
 };

--- a/src/game/layers/thunderstormoverlay.h
+++ b/src/game/layers/thunderstormoverlay.h
@@ -53,17 +53,21 @@ public:
    ///
    /// The flash is snapped to full rather than ramped in over the fifth of a second the ambient
    /// strikes take, which is what makes a scripted strike read as a crack rather than a swell.
+   /// \param sample thunder sample to play, or std::nullopt to pick one at random. The sample has to be
+   ///        one of the object's configured sounds, those are the ones that were preloaded.
    /// \param volume volume to play the thunder sample at, or std::nullopt for the configured one.
-   void strike(const std::optional<float>& volume);
+   void strike(const std::optional<std::string>& sample, const std::optional<float>& volume);
 
 private:
    /// \brief arms the thunder that belongs to a flash that has just gone off.
+   /// \param sample sample to play, or std::nullopt to pick one at random.
    /// \param volume volume to play at, or std::nullopt for the configured sound volume.
-   void scheduleThunder(const std::optional<float>& volume);
+   void scheduleThunder(const std::optional<std::string>& sample, const std::optional<float>& volume);
 
-   /// \brief plays one randomly picked thunder sample, if any are configured.
+   /// \brief plays the named thunder sample, or a randomly picked one, if any are configured.
+   /// \param sample sample to play, or std::nullopt to pick one at random.
    /// \param volume volume to play at, or std::nullopt for the configured sound volume.
-   void playThunder(const std::optional<float>& volume);
+   void playThunder(const std::optional<std::string>& sample, const std::optional<float>& volume);
 
    enum class State
    {
@@ -79,9 +83,10 @@ private:
    float _silence_time_elapsed_s = 0.0f;
    State _state = State::Silence;
 
-   std::optional<float> _pending_thunder_s;       //!< time left until the armed thunder is played
-   std::optional<float> _pending_thunder_volume;  //!< volume the armed thunder was requested at
-   std::optional<size_t> _previous_sound_index;   //!< last sample played, so it is not picked twice in a row
+   std::optional<float> _pending_thunder_s;             //!< time left until the armed thunder is played
+   std::optional<float> _pending_thunder_volume;        //!< volume the armed thunder was requested at
+   std::optional<std::string> _pending_thunder_sample;  //!< sample the armed thunder was requested with
+   std::optional<size_t> _previous_sound_index;         //!< last sample played, so it is not picked twice in a row
 
    // the global c rng is seeded by whoever ran last - StaticLight seeds it from its own tmx position
    // during level load, which leaves it on a fixed sequence. an engine of its own keeps the sample

--- a/src/game/layers/thunderstormoverlay.h
+++ b/src/game/layers/thunderstormoverlay.h
@@ -18,7 +18,7 @@ public:
    {
       float _thunderstorm_time_s = 3.0;
       float _silence_time_s = 5.0f;
-      float _thunder_delay_s = 0.5f;     //!< gap between the flash and its thunder, light outruns sound
+      float _thunder_delay_s = 0.0f;     //!< gap between the flash and its thunder, 0 lands them together
       std::vector<std::string> _sounds;  //!< thunder samples; one is picked at random per lightning phase, empty disables audio
       float _sound_volume = 1.0f;        //!< per-sample volume multiplier applied to the picked thunder sample
    };

--- a/src/game/layers/thunderstormoverlay.h
+++ b/src/game/layers/thunderstormoverlay.h
@@ -2,6 +2,7 @@
 
 #include "game/mechanisms/weather.h"
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -46,9 +47,17 @@ public:
    /// \param newSettings durations for lightning and silence phases.
    void setSettings(const ThunderstormSettings& newSettings);
 
+   /// \brief fires one lightning phase right now instead of waiting the silence phase out.
+   ///
+   /// The flash is snapped to full rather than ramped in over the fifth of a second the ambient
+   /// strikes take, which is what makes a scripted strike read as a crack rather than a swell.
+   /// \param volume volume to play the thunder sample at, or std::nullopt for the configured one.
+   void strike(const std::optional<float>& volume);
+
 private:
    /// \brief plays one randomly picked thunder sample, if any are configured.
-   void playThunder();
+   /// \param volume volume to play at, or std::nullopt for the configured sound volume.
+   void playThunder(const std::optional<float>& volume);
 
    enum class State
    {

--- a/src/game/level/levelscript.cpp
+++ b/src/game/level/levelscript.cpp
@@ -529,6 +529,7 @@ void LevelScript::flashMechanism(const std::string& search_pattern, float red, f
 
 void LevelScript::strikeThunderMechanism(
    const std::string& search_pattern,
+   const std::optional<std::string>& sample,
    const std::optional<float>& volume,
    const std::optional<std::string>& group
 )
@@ -545,7 +546,7 @@ void LevelScript::strikeThunderMechanism(
       auto* weather = dynamic_cast<Weather*>(mechanism.get());
       if (weather)
       {
-         weather->strikeThunder(volume);
+         weather->strikeThunder(sample, volume);
       }
    }
 }

--- a/src/game/level/levelscript.cpp
+++ b/src/game/level/levelscript.cpp
@@ -24,6 +24,7 @@
 #include "game/mechanisms/extra.h"
 #include "game/mechanisms/ringshaderlayer.h"
 #include "game/mechanisms/sensorrect.h"
+#include "game/mechanisms/weather.h"
 #include "game/player/playercontrols.h"
 #include "game/player/playerregistry.h"
 #include "game/player/weaponsystem.h"
@@ -177,6 +178,7 @@ void LevelScript::setup(const std::filesystem::path& path)
    lua_register(_lua_state, "setMechanismEnabled", LevelScriptCallbacks::setMechanismEnabled);
    lua_register(_lua_state, "setMechanismVisible", LevelScriptCallbacks::setMechanismVisible);
    lua_register(_lua_state, "flashMechanism", LevelScriptCallbacks::flashMechanism);
+   lua_register(_lua_state, "strikeThunderMechanism", LevelScriptCallbacks::strikeThunderMechanism);
    lua_register(_lua_state, "flashScreen", LevelScriptCallbacks::flashScreen);
    lua_register(_lua_state, "setAmbient", LevelScriptCallbacks::setAmbient);
    lua_register(_lua_state, "setZoomFactor", LevelScriptCallbacks::setZoomFactor);
@@ -521,6 +523,29 @@ void LevelScript::flashMechanism(const std::string& search_pattern, float red, f
       if (ring)
       {
          ring->flash(red, green, blue, duration_s);
+      }
+   }
+}
+
+void LevelScript::strikeThunderMechanism(
+   const std::string& search_pattern,
+   const std::optional<float>& volume,
+   const std::optional<std::string>& group
+)
+{
+   if (!_search_mechanism_callback)
+   {
+      Log::Error() << "search mechanism callback not initialized yet";
+      return;
+   }
+
+   const auto mechanisms = _search_mechanism_callback(search_pattern, group);
+   for (auto& mechanism : mechanisms)
+   {
+      auto* weather = dynamic_cast<Weather*>(mechanism.get());
+      if (weather)
+      {
+         weather->strikeThunder(volume);
       }
    }
 }

--- a/src/game/level/levelscript.h
+++ b/src/game/level/levelscript.h
@@ -77,6 +77,13 @@ public:
    /// \param duration_s fade-out duration in seconds.
    void flashMechanism(const std::string& search_pattern, float red, float green, float blue, float duration_s);
 
+   /// \brief fires one lightning strike on a thunderstorm right now.
+   /// \param search_pattern object id of the weather mechanism to strike.
+   /// \param volume volume to play the thunder sample at, or std::nullopt for the configured one.
+   /// \param group optional layer name to restrict the search to.
+   void
+   strikeThunderMechanism(const std::string& search_pattern, const std::optional<float>& volume, const std::optional<std::string>& group);
+
    /// \brief checks visibility of the first mechanism that matches the query.
    /// \param mechanism_id regex used to select mechanisms.
    /// \param group optional mechanism group filter.

--- a/src/game/level/levelscript.h
+++ b/src/game/level/levelscript.h
@@ -79,10 +79,15 @@ public:
 
    /// \brief fires one lightning strike on a thunderstorm right now.
    /// \param search_pattern object id of the weather mechanism to strike.
+   /// \param sample thunder sample to play, or std::nullopt to pick one at random.
    /// \param volume volume to play the thunder sample at, or std::nullopt for the configured one.
    /// \param group optional layer name to restrict the search to.
-   void
-   strikeThunderMechanism(const std::string& search_pattern, const std::optional<float>& volume, const std::optional<std::string>& group);
+   void strikeThunderMechanism(
+      const std::string& search_pattern,
+      const std::optional<std::string>& sample,
+      const std::optional<float>& volume,
+      const std::optional<std::string>& group
+   );
 
    /// \brief checks visibility of the first mechanism that matches the query.
    /// \param mechanism_id regex used to select mechanisms.

--- a/src/game/level/levelscriptcallbacks.cpp
+++ b/src/game/level/levelscriptcallbacks.cpp
@@ -206,26 +206,33 @@ int32_t flashMechanism(lua_State* state)
 int32_t strikeThunderMechanism(lua_State* state)
 {
    const auto argc = lua_gettop(state);
-   if (argc < 1 || argc > 3)
+   if (argc < 1 || argc > 4)
    {
       return 0;
    }
 
    const std::string search_pattern = lua_tostring(state, 1);
 
-   std::optional<float> volume;
-   if (argc >= 2)
+   // nil in the sample slot means "pick one at random", so a caller can give a volume without naming one
+   std::optional<std::string> sample;
+   if (argc >= 2 && !lua_isnoneornil(state, 2))
    {
-      volume = static_cast<float>(lua_tonumber(state, 2));
+      sample = lua_tostring(state, 2);
+   }
+
+   std::optional<float> volume;
+   if (argc >= 3 && !lua_isnoneornil(state, 3))
+   {
+      volume = static_cast<float>(lua_tonumber(state, 3));
    }
 
    std::optional<std::string> group;
-   if (argc == 3)
+   if (argc == 4)
    {
-      group = lua_tostring(state, 3);
+      group = lua_tostring(state, 4);
    }
 
-   LevelScript::getCurrent()->strikeThunderMechanism(search_pattern, volume, group);
+   LevelScript::getCurrent()->strikeThunderMechanism(search_pattern, sample, volume, group);
    return 0;
 }
 

--- a/src/game/level/levelscriptcallbacks.cpp
+++ b/src/game/level/levelscriptcallbacks.cpp
@@ -203,6 +203,32 @@ int32_t flashMechanism(lua_State* state)
    return 0;
 }
 
+int32_t strikeThunderMechanism(lua_State* state)
+{
+   const auto argc = lua_gettop(state);
+   if (argc < 1 || argc > 3)
+   {
+      return 0;
+   }
+
+   const std::string search_pattern = lua_tostring(state, 1);
+
+   std::optional<float> volume;
+   if (argc >= 2)
+   {
+      volume = static_cast<float>(lua_tonumber(state, 2));
+   }
+
+   std::optional<std::string> group;
+   if (argc == 3)
+   {
+      group = lua_tostring(state, 3);
+   }
+
+   LevelScript::getCurrent()->strikeThunderMechanism(search_pattern, volume, group);
+   return 0;
+}
+
 int32_t toggle(lua_State* state)
 {
    const auto argc = lua_gettop(state);

--- a/src/game/level/levelscriptcallbacks.h
+++ b/src/game/level/levelscriptcallbacks.h
@@ -21,6 +21,7 @@ int32_t isMechanismVisible(lua_State* state);
 int32_t setMechanismEnabled(lua_State* state);
 int32_t setMechanismVisible(lua_State* state);
 int32_t flashMechanism(lua_State* state);
+int32_t strikeThunderMechanism(lua_State* state);
 int32_t flashScreen(lua_State* state);
 int32_t toggle(lua_State* state);
 int32_t showDialogue(lua_State* state);

--- a/src/game/mechanisms/weather.cpp
+++ b/src/game/mechanisms/weather.cpp
@@ -317,7 +317,7 @@ static constexpr std::array weather_properties{
    PropertyInfo{.name = "limit_effect_to_room", .type = "bool", .default_value = false},
    PropertyInfo{.name = "effect_start_delay_s", .type = "float", .default_value = 0.0f},
    PropertyInfo{.name = "sound_volume", .type = "float", .default_value = 1.0f},
-   PropertyInfo{.name = "thunder_delay_s", .type = "float", .default_value = 0.5f},
+   PropertyInfo{.name = "thunder_delay_s", .type = "float", .default_value = 0.0f},
    PropertyInfo{.name = "z", .type = "int", .default_value = int32_t{20}},
 };
 static constexpr MechanismSchema weather_schema{

--- a/src/game/mechanisms/weather.cpp
+++ b/src/game/mechanisms/weather.cpp
@@ -165,7 +165,7 @@ std::optional<sf::FloatRect> Weather::getBoundingBoxPx()
    return _rect;
 }
 
-void Weather::strikeThunder(const std::optional<float>& volume)
+void Weather::strikeThunder(const std::optional<std::string>& sample, const std::optional<float>& volume)
 {
    auto thunderstorm = std::dynamic_pointer_cast<ThunderstormOverlay>(_overlay);
    if (!thunderstorm)
@@ -173,7 +173,7 @@ void Weather::strikeThunder(const std::optional<float>& volume)
       return;
    }
 
-   thunderstorm->strike(volume);
+   thunderstorm->strike(sample, volume);
 }
 
 std::shared_ptr<Weather> Weather::deserialize(GameNode* parent, const GameDeserializeData& data)

--- a/src/game/mechanisms/weather.cpp
+++ b/src/game/mechanisms/weather.cpp
@@ -165,6 +165,17 @@ std::optional<sf::FloatRect> Weather::getBoundingBoxPx()
    return _rect;
 }
 
+void Weather::strikeThunder(const std::optional<float>& volume)
+{
+   auto thunderstorm = std::dynamic_pointer_cast<ThunderstormOverlay>(_overlay);
+   if (!thunderstorm)
+   {
+      return;
+   }
+
+   thunderstorm->strike(volume);
+}
+
 std::shared_ptr<Weather> Weather::deserialize(GameNode* parent, const GameDeserializeData& data)
 {
    auto weather = std::make_shared<Weather>(parent);

--- a/src/game/mechanisms/weather.cpp
+++ b/src/game/mechanisms/weather.cpp
@@ -284,6 +284,8 @@ std::shared_ptr<Weather> Weather::deserialize(GameNode* parent, const GameDeseri
             settings._silence_time_s = silence_time_it->second->_value_float.value();
          }
 
+         settings._thunder_delay_s = ValueReader::readValue<float>("thunder_delay_s", map).value_or(settings._thunder_delay_s);
+
          const auto sounds = ValueReader::readValue<std::string>("sounds", map);
          if (sounds.has_value())
          {
@@ -315,6 +317,7 @@ static constexpr std::array weather_properties{
    PropertyInfo{.name = "limit_effect_to_room", .type = "bool", .default_value = false},
    PropertyInfo{.name = "effect_start_delay_s", .type = "float", .default_value = 0.0f},
    PropertyInfo{.name = "sound_volume", .type = "float", .default_value = 1.0f},
+   PropertyInfo{.name = "thunder_delay_s", .type = "float", .default_value = 0.5f},
    PropertyInfo{.name = "z", .type = "int", .default_value = int32_t{20}},
 };
 static constexpr MechanismSchema weather_schema{

--- a/src/game/mechanisms/weather.h
+++ b/src/game/mechanisms/weather.h
@@ -46,6 +46,14 @@ public:
    /// \return area that gates weather updates and drawing.
    std::optional<sf::FloatRect> getBoundingBoxPx() override;
 
+   /// \brief fires one lightning strike right now on a thunderstorm, for scripted moments.
+   ///
+   /// Does nothing on weather that is not a thunderstorm. The strike is only seen on an enabled
+   /// mechanism: draw and update both return early while it is disabled, so the flash would
+   /// neither be drawn nor decay.
+   /// \param volume volume to play the thunder sample at, or std::nullopt for the configured one.
+   void strikeThunder(const std::optional<float>& volume);
+
    /// \brief creates rain or thunderstorm weather from object name and properties.
    /// \param parent owning game node in the scene graph.
    /// \param data deserialization data with bounds and weather settings.

--- a/src/game/mechanisms/weather.h
+++ b/src/game/mechanisms/weather.h
@@ -51,8 +51,9 @@ public:
    /// Does nothing on weather that is not a thunderstorm. The strike is only seen on an enabled
    /// mechanism: draw and update both return early while it is disabled, so the flash would
    /// neither be drawn nor decay.
+   /// \param sample thunder sample to play, or std::nullopt to pick one at random.
    /// \param volume volume to play the thunder sample at, or std::nullopt for the configured one.
-   void strikeThunder(const std::optional<float>& volume);
+   void strikeThunder(const std::optional<std::string>& sample, const std::optional<float>& volume);
 
    /// \brief creates rain or thunderstorm weather from object name and properties.
    /// \param parent owning game node in the scene graph.


### PR DESCRIPTION
Taking the owl's eyes woke the thunderstorm only once the pickup message had been dismissed — and even then the overlay sat out a silence phase before its first flash:

```cpp
if (_state == State::Silence)
{
   _silence_time_elapsed_s += dt.asSeconds();
   ...
   if (_silence_time_elapsed_s > _settings._silence_time_s)
   {
      _state = State::Lightning;
      playThunder();
   }
}
```

`silence_time_s` defaults to 5.0s and the graveyard object doesn't set it, so the storm arrived five seconds after the player had already put the box away. Cause and effect were completely disconnected.

## `ThunderstormOverlay::strike()`

Enters the lightning phase there and then, and plays a thunder sample at a volume the caller picks. It snaps `_factor` to 1.0 instead of ramping it in at 5 per second the way the ambient strikes do — that's what makes a scripted strike read as a crack rather than a swell, and it means no separate "first strike" concept is needed.

Reached from Lua through the weather mechanism:

```
strikeThunderMechanism (lua)  ->  LevelScript  ->  Weather::strikeThunder  ->  ThunderstormOverlay::strike
```

`_overlay` stays private; `Weather::strikeThunder` does the cast and is a no-op on weather that isn't a thunderstorm.

**Why not `flashScreen`.** It already exists and would have needed no new binding, but it's a flat screen tint while the overlay modulates its quad with fbm noise. The scripted strike is immediately followed by the storm's own strikes, so putting the two back to back would read as two different effects.

## Level script

```lua
setStormActive(true)
strikeThunderMechanism("thunderstorm", 1.0, "weather")
_pickup_message_delay_s = _pickup_message_delay_default_s
```

Fired on the same frame the sockets go dark, at volume 1.0 while the ambient storm stays at the object's 0.8 — which is what the volume parameter is for.

The `rubies_acquired` message is **kept**. Every other item shows one and dropping it here would be inconsistent; it just waits 1.5s so the thunder lands first. It has `pause_game = false`, so the world keeps running underneath it either way. The delay is counted down in `update(dt)` — `luaUpdate` pushes `delta_time.asSeconds()`, so no timer binding was needed.

The old trigger on `rubies_acquired` `dismissed` is gone.

## Caveat, documented

A strike is only seen on an **enabled** thunderstorm — `Weather::draw` and `Weather::update` both return early while it's disabled, so the flash would neither be drawn nor decay. `strikeThunder` doesn't force-enable; the doc entry says to enable the storm first, and in `takeOwlEyes` the two calls sit next to each other.

## Not verified

Builds clean, `level.lua` parses and loads, formatting is clang-format clean. **I have not seen the strike in game** — the 1.5s delay in particular is a starting number, not a tuned one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
