### PR TITLE
draw the menu titles at the size the font was drawn for

### DIFF
--- a/data/locale/en.json
+++ b/data/locale/en.json
@@ -1,4 +1,8 @@
 {
+  "@font": {
+    "character_size": 13,
+    "path": "data/fonts/deceptum.ttf"
+  },
   "\"A sightless owl with a [color:#09e522FF] sword [/color] in her keep offers steel to the one who [br] ends her [color:#09e522FF]eyeless [/color] sleep.\"": "",
   "\"And in truth, all return to the end.\"": "",
   "\"Before all things, there is time.": "",

--- a/data/locale/it.json
+++ b/data/locale/it.json
@@ -1,4 +1,8 @@
 {
+  "@font": {
+    "character_size": 13,
+    "path": "data/fonts/deceptum.ttf"
+  },
   "Up": "Su",
   "Down": "Giù",
   "Left": "Sinistra",

--- a/data/locale/ja.json
+++ b/data/locale/ja.json
@@ -1,4 +1,8 @@
 {
+  "@font": {
+    "character_size": 12,
+    "path": "data/fonts/mona12.ttf"
+  },
   "@line_break": {
     "break_between_characters": [
       {

--- a/src/framework/tools/localization.cpp
+++ b/src/framework/tools/localization.cpp
@@ -158,6 +158,15 @@ std::string getFontPath()
    return "data/fonts/deceptum.ttf";
 }
 
+uint32_t getFontNativeCharacterSize()
+{
+   if (Localization::getInstance().getLocale() == "ja")
+   {
+      return 12;
+   }
+   return 13;
+}
+
 const sf::Font& getFont()
 {
    static sf::Font font = []

--- a/src/framework/tools/localization.cpp
+++ b/src/framework/tools/localization.cpp
@@ -33,6 +33,7 @@ void Localization::load(const std::string& locale)
    try
    {
       const auto json = nlohmann::json::parse(json_text);
+
       for (const auto& [key, value] : json.items())
       {
          // a locale file may also carry sections that are not translations, such as the line break
@@ -44,6 +45,14 @@ void Localization::load(const std::string& locale)
          }
 
          _translations[key] = value.get<std::string>();
+      }
+
+      // read after the table, so a locale that declares the section badly still gets its strings
+      const auto font_section = json.find("@font");
+      if (font_section != json.end())
+      {
+         _font_path = font_section->at("path").get<std::string>();
+         _font_character_size = font_section->at("character_size").get<uint32_t>();
       }
    }
    catch (const std::exception& exception)
@@ -58,6 +67,16 @@ void Localization::load(const std::string& locale)
 const std::string& Localization::getLocale() const
 {
    return _locale;
+}
+
+const std::string& Localization::getFontPath() const
+{
+   return _font_path;
+}
+
+uint32_t Localization::getFontNativeCharacterSize() const
+{
+   return _font_character_size;
 }
 
 std::string_view Localization::translate(std::string_view source_text) const
@@ -151,20 +170,12 @@ std::string tr(std::string_view source_text)
 
 std::string getFontPath()
 {
-   if (Localization::getInstance().getLocale() == "ja")
-   {
-      return "data/fonts/mona12.ttf";
-   }
-   return "data/fonts/deceptum.ttf";
+   return Localization::getInstance().getFontPath();
 }
 
 uint32_t getFontNativeCharacterSize()
 {
-   if (Localization::getInstance().getLocale() == "ja")
-   {
-      return 12;
-   }
-   return 13;
+   return Localization::getInstance().getFontNativeCharacterSize();
 }
 
 const sf::Font& getFont()

--- a/src/framework/tools/localization.h
+++ b/src/framework/tools/localization.h
@@ -37,6 +37,12 @@ public:
    /// \brief returns the active locale identifier.
    [[nodiscard]] const std::string& getLocale() const;
 
+   /// \brief returns the font file the active locale declares.
+   [[nodiscard]] const std::string& getFontPath() const;
+
+   /// \brief returns the character size the font of the active locale was drawn for.
+   [[nodiscard]] uint32_t getFontNativeCharacterSize() const;
+
    /// \brief looks up source_text in the active translation table.
    ///
    /// when no translation is found the source text is returned unchanged and
@@ -57,6 +63,8 @@ private:
    mutable std::unordered_set<std::string> _missing_keys;
    std::string _locale;
    std::string _locale_path;
+   std::string _font_path{"data/fonts/deceptum.ttf"};  //!< font file the active locale declares
+   uint32_t _font_character_size{13};                  //!< size that font was drawn at
 };
 
 /// \brief returns the translation of source_text in the active locale.
@@ -68,18 +76,17 @@ private:
 /// \return translated UTF-8 string, or source_text if no translation is available.
 [[nodiscard]] std::string tr(std::string_view source_text);
 
-/// \brief returns the font file path suitable for the active locale.
-///
-/// most locales use deceptum.ttf; japanese uses mona12.ttf.
-///
+/// \brief returns the font file path the active locale declares in its "@font" section.
 /// \return path to the font file, e.g. "data/fonts/deceptum.ttf".
 [[nodiscard]] std::string getFontPath();
 
 /// \brief returns the character size the font of the active locale was drawn for.
 ///
-/// both fonts are pixel fonts, and their outlines only land on the pixel grid at the size they were
+/// the fonts are pixel fonts, and their outlines only land on the pixel grid at the size they were
 /// drawn at and at whole multiples of it. at any other size freetype covers the edge pixels of a
-/// stem partially and the glyphs come out soft. deceptum is drawn for 13 pixels, mona12 for 12.
+/// stem partially and the glyphs come out soft. the size is declared next to the font file in the
+/// "@font" section of the locale, since it belongs to that font rather than to whoever draws with
+/// it.
 ///
 /// \return character size in pixels.
 [[nodiscard]] uint32_t getFontNativeCharacterSize();

--- a/src/framework/tools/localization.h
+++ b/src/framework/tools/localization.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -73,6 +74,15 @@ private:
 ///
 /// \return path to the font file, e.g. "data/fonts/deceptum.ttf".
 [[nodiscard]] std::string getFontPath();
+
+/// \brief returns the character size the font of the active locale was drawn for.
+///
+/// both fonts are pixel fonts, and their outlines only land on the pixel grid at the size they were
+/// drawn at and at whole multiples of it. at any other size freetype covers the edge pixels of a
+/// stem partially and the glyphs come out soft. deceptum is drawn for 13 pixels, mona12 for 12.
+///
+/// \return character size in pixels.
+[[nodiscard]] uint32_t getFontNativeCharacterSize();
 
 namespace sf
 {

--- a/src/menus/menuscreen.cpp
+++ b/src/menus/menuscreen.cpp
@@ -71,6 +71,7 @@ void MenuScreen::setTitle(const std::string& layer_name, const std::string& sour
 
    // a band that cannot hold the title grows, and the layer moves up by as much as it grew. that
    // leaves the ornament below the band on the pixel row it was drawn on
+   const auto title_character_size = getFontNativeCharacterSize();
    const auto band_px = std::max(word_band_height_px, MenuLabel::measureBoxHeight(title_character_size, title_scale));
    const auto grown_px = band_px - word_band_height_px;
 

--- a/src/menus/menuscreen.h
+++ b/src/menus/menuscreen.h
@@ -78,9 +78,8 @@ protected:
    /// \param word_band_height_px rows of the layer image the word occupies.
    void setTitle(const std::string& layer_name, const std::string& source_text, int32_t word_band_height_px);
 
-   //!< a screen title is the font's own 12px glyphs at twice the size, not 24px glyphs. see
-   //!< MenuLabel::measureWidth() on why
-   static constexpr uint32_t title_character_size = 12;
+   //!< a screen title is the glyphs of the size the font was drawn at, at twice that size, not
+   //!< glyphs of twice the size. see MenuLabel::measureWidth() on why
    static constexpr int32_t title_scale = 2;
 
    /// \brief draws a caption from the translation table and centers it where the artwork had it.


### PR DESCRIPTION
The screen titles looked anti-aliased.

## What was wrong

`deceptum.ttf` is a pixel font whose outlines only land on whole pixels at 13 px and multiples of
it; `mona12.ttf` does at 12. Everything in the menus asks for 12, so for the latin font freetype
covers the edge pixels of a stem partially. Measured over sizes 9 to 29, the share of fully opaque
ink pixels is:

| size | deceptum | mona12 |
| ---- | -------- | ------ |
| 12   | 14%      | 100%   |
| 13   | 100%     | 13%    |
| 24   | 53%      | 100%   |
| 26   | 100%     | 60%    |

At one to one those partial pixels sit around 91% alpha and nobody sees them. A title is the only
text that is magnified, so each of them became a two by two block.

## The change

The font file and the size it was drawn at are now declared by the locale, in an `@font` section of
`data/locale/<locale>.json` next to the line break rules that already live there:

```json
"@font": {
  "character_size": 13,
  "path": "data/fonts/deceptum.ttf"
}
```

`getFontPath()` and the new `getFontNativeCharacterSize()` read it, and `MenuScreen::setTitle()`
uses the size instead of a hardcoded 12. A new locale brings its own font with it rather than a
branch on the locale name in c++.

Checked on the running build by opening the options screen and grabbing the window: before, the
stems carry half lit pixels along their edges; after, every ink pixel is fully opaque and every
edge is a clean two by two block.

## Layout

Unchanged. The capital's ink height is 10 px at both 12 and 13, so the title band stays 20 px and
still fits under every screen's band (21, 34 and 41). The word itself is 8% wider and stays
centered. There is no on-grid size that keeps the old width: 24 renders genuinely soft, so 13 at
twice the size is the only crisp option near it.

The rest of the menu text is still 12 and off-grid too, but at one to one it is invisible and
moving it to 13 would reflow every screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)